### PR TITLE
#102 Fix tests failing on Windows — path separators and spawnSync

### DIFF
--- a/scripts/tsup-inject.test.ts
+++ b/scripts/tsup-inject.test.ts
@@ -13,7 +13,7 @@ describe('tsup GIT_COMMIT build-time injection', () => {
   const bundlePath = resolve('dist/server/index.js');
 
   it('inlines provided GIT_COMMIT value into emitted server bundle', () => {
-    const result = spawnSync('pnpm', ['build:server'], {
+    const result = spawnSync('pnpm', ['build:server'], { shell: true,
       env: { ...process.env, GIT_COMMIT: 'testsha1' },
       encoding: 'utf-8',
       timeout: 60_000,
@@ -28,7 +28,7 @@ describe('tsup GIT_COMMIT build-time injection', () => {
 
   it('inlines full 40-char GIT_COMMIT value into emitted server bundle', () => {
     const fullSha = 'abc1234def456789abc1234def456789abc12345';
-    const result = spawnSync('pnpm', ['build:server'], {
+    const result = spawnSync('pnpm', ['build:server'], { shell: true,
       env: { ...process.env, GIT_COMMIT: fullSha },
       encoding: 'utf-8',
       timeout: 60_000,
@@ -44,7 +44,7 @@ describe('tsup GIT_COMMIT build-time injection', () => {
     const env = { ...process.env };
     delete env.GIT_COMMIT;
 
-    const result = spawnSync('pnpm', ['build:server'], {
+    const result = spawnSync('pnpm', ['build:server'], { shell: true,
       env,
       encoding: 'utf-8',
       timeout: 60_000,

--- a/src/server/__tests__/import-flow.e2e.test.ts
+++ b/src/server/__tests__/import-flow.e2e.test.ts
@@ -142,7 +142,7 @@ describe('Import flow E2E', () => {
     const result = await e2e.services.import.importDownload(downloadId);
 
     // Import result
-    const expectedTarget = join(libraryDir, 'Brandon Sanderson', 'The Way of Kings');
+    const expectedTarget = join(libraryDir, 'Brandon Sanderson', 'The Way of Kings').split('\\').join('/');
     expect(result.downloadId).toBe(downloadId);
     expect(result.bookId).toBe(bookId);
     expect(result.targetPath).toBe(expectedTarget);

--- a/src/server/utils/import-helpers.ts
+++ b/src/server/utils/import-helpers.ts
@@ -54,7 +54,8 @@ export function buildTargetPath(
   };
 
   const rendered = renderTemplate(folderFormat, tokens);
-  return join(libraryPath, ...rendered.split('/'));
+  // Always use POSIX separators — paths are stored in DB and consumed inside Docker (Linux)
+  return join(libraryPath, ...rendered.split('/')).split('\\').join('/');
 }
 
 /** Recursively get total size of a path (file or directory). */


### PR DESCRIPTION
Refs #102

## Summary
- `buildTargetPath()` normalizes to POSIX separators (forward slashes) — paths are stored in DB and consumed inside Docker containers
- `tsup-inject.test.ts` uses `shell: true` for `spawnSync` — `pnpm` is a `.cmd` on Windows and needs a shell to execute
- E2E import test normalizes expected path to match

## Test plan
- [x] All 6258 tests pass on Windows (local)
- [ ] CI (Linux) remains green — this PR confirms no regressions