### PR TITLE
Remove dead fuse.js dependency and two unused eslint-disable directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.1.0",
-    "fuse.js": "^7.3.0",
     "music-metadata": "^11.12.3",
     "nodemailer": "^8.0.7",
     "react": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,6 @@ importers:
       fastify-type-provider-zod:
         specifier: ^6.1.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.1)
-      fuse.js:
-        specifier: ^7.3.0
-        version: 7.3.0
       music-metadata:
         specifier: ^11.12.3
         version: 11.12.3
@@ -2195,10 +2192,6 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
-
-  fuse.js@7.3.0:
-    resolution: {integrity: sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==}
-    engines: {node: '>=10'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -5178,8 +5171,6 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
-
-  fuse.js@7.3.0: {}
 
   gensync@1.0.0-beta.2: {}
 

--- a/src/client/components/manual-import/ImportSummaryBar.tsx
+++ b/src/client/components/manual-import/ImportSummaryBar.tsx
@@ -46,7 +46,6 @@ type ImportSummaryBarProps = ImportSummaryBarBaseProps & (
   | { hideMode?: false; onModeChange: (mode: ImportMode) => void }
 );
 
-// eslint-disable-next-line complexity -- compound condition is the least-indirection way to express disabled state and pending label
 export function ImportSummaryBar({
   readyCount,
   reviewCount,

--- a/src/server/services/import-list.service.ts
+++ b/src/server/services/import-list.service.ts
@@ -361,7 +361,6 @@ function buildRawEnriched(item: ImportListItem): EnrichedItem {
   };
 }
 
-// eslint-disable-next-line complexity -- flat coalescing across item/match
 function buildMatchedEnriched(item: ImportListItem, match: BookMetadata): EnrichedItem {
   const primarySeries = match.seriesPrimary ?? match.series?.[0];
   return {


### PR DESCRIPTION
Drive-by cleanup surfaced by the 2026-06-09 pre-1.0 deep audit. Removes the dead fuse.js dependency (zero imports in src; last real use removed in #546) from package.json + lockfile, and two now-unused eslint-disable complexity directives (ImportSummaryBar.tsx, import-list.service.ts) whose functions are now under the limit. No behavior change; pnpm verify green.