### PR TITLE
Fix inverted unmatched-genres tracking by normalizing before the check

### DIFF
--- a/src/core/metadata/genres.test.ts
+++ b/src/core/metadata/genres.test.ts
@@ -157,8 +157,7 @@ describe('normalizeGenres', () => {
 
 describe('findUnmatchedGenres', () => {
   it('identifies genres not in any known list', () => {
-    const normalized = ['Fantasy', 'Cozy Mystery', 'Progression Fantasy'];
-    const unmatched = findUnmatchedGenres(normalized, normalized);
+    const unmatched = findUnmatchedGenres(['Fantasy', 'Cozy Mystery', 'Progression Fantasy']);
 
     // Fantasy is a known fiction child, so it's matched
     expect(unmatched).not.toContain('Fantasy');
@@ -168,11 +167,25 @@ describe('findUnmatchedGenres', () => {
   });
 
   it('returns empty for null input', () => {
-    expect(findUnmatchedGenres(null, null)).toEqual([]);
+    expect(findUnmatchedGenres(null)).toEqual([]);
   });
 
   it('returns empty when all genres are known', () => {
-    const result = findUnmatchedGenres(['Fantasy', 'Science Fiction'], ['Fantasy', 'Science Fiction']);
+    const result = findUnmatchedGenres(['Fantasy', 'Science Fiction']);
     expect(result).toEqual([]);
+  });
+
+  it('does not flag synonym keys or BISAC paths once normalized', () => {
+    // Raw provider genres the normalizer fully handles: a synonym key,
+    // a BISAC path, and a generic parent removed alongside its child.
+    const raw = ['Sci-Fi', 'Fiction / Fantasy / Epic', 'Fiction'];
+    const result = findUnmatchedGenres(normalizeGenres(raw));
+    expect(result).toEqual([]);
+  });
+
+  it('flags only the genuinely unknown genre from a mixed raw list', () => {
+    const raw = ['Sci-Fi', 'Weird Western'];
+    const result = findUnmatchedGenres(normalizeGenres(raw));
+    expect(result).toEqual(['Weird Western']);
   });
 });

--- a/src/core/metadata/genres.ts
+++ b/src/core/metadata/genres.ts
@@ -166,7 +166,6 @@ export function normalizeGenres(genres: string[] | undefined | null): string[] |
  * synonym map.
  */
 export function findUnmatchedGenres(
-  _raw: string[] | undefined | null,
   normalized: string[] | undefined | null,
 ): string[] {
   if (!normalized) return [];

--- a/src/server/services/book.service.test.ts
+++ b/src/server/services/book.service.test.ts
@@ -1445,6 +1445,19 @@ describe('BookService — transaction atomicity (#214)', () => {
       expect(insertChain.onConflictDoUpdate).toHaveBeenCalled();
     });
 
+    it('does NOT track genres the normalizer already handles', async () => {
+      db.update.mockReturnValue(mockDbChain([mockBook]));
+      setupGetById(db);
+
+      // 'Sci-Fi' is a synonym-map key — normalization maps it to
+      // 'Science Fiction', so nothing should reach the unmatched table.
+      await service.update(1, { genres: ['Sci-Fi'] });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(db.insert).not.toHaveBeenCalled();
+    });
+
     it('does NOT call trackUnmatchedGenres when genres are absent from update payload', async () => {
       db.update.mockReturnValue(mockDbChain([mockBook]));
       setupGetById(db);

--- a/src/server/services/book.service.ts
+++ b/src/server/services/book.service.ts
@@ -6,7 +6,7 @@ import { eq, and, sql, notExists } from 'drizzle-orm';
 import type { Db, DbOrTx } from '../../db/index.js';
 import type { FastifyBaseLogger } from 'fastify';
 import { books, authors, narrators, bookAuthors, bookNarrators, unmatchedGenres, importLists } from '../../db/schema.js';
-import { slugify, findUnmatchedGenres } from '../../core/index.js';
+import { slugify, findUnmatchedGenres, normalizeGenres } from '../../core/index.js';
 import { replaceSeriesLink, upsertSeriesLink, type ReplaceSeriesLinkArgs } from './book-series-link.js';
 import { findOrCreateAuthor, findOrCreateNarrator } from '../utils/find-or-create-person.js';
 import { type MetadataService } from './metadata.service.js';
@@ -462,7 +462,7 @@ export class BookService {
 
   /** Fire-and-forget: track genres not in the synonym/known lists for future analysis */
   private async trackUnmatchedGenres(genres: string[] | undefined): Promise<void> {
-    const unmatched = findUnmatchedGenres(genres, genres);
+    const unmatched = findUnmatchedGenres(normalizeGenres(genres));
     if (unmatched.length === 0) return;
 
     for (const genre of unmatched) {


### PR DESCRIPTION
## Problem

`trackUnmatchedGenres` (book.service.ts) called `findUnmatchedGenres(genres, genres)` — passing the **raw** provider genres where the function expects the **normalized** output of `normalizeGenres()`. The result was inverted telemetry: synonym keys ('sci-fi', 'ya'), BISAC paths, and compounds/parents the normalizer fully handles were logged as 'unmatched', while the table's actual purpose (surfacing genres the normalizer does NOT know, as candidates for `genres.ts`) was buried in noise. Live-instance data confirmed it: the #1 'unmatched' genre was generic category-tree noise.

## Fix

- Wire the call through the normalizer: `findUnmatchedGenres(normalizeGenres(genres))`
- Drop the dead `_raw` parameter from `findUnmatchedGenres` (it was never used — the function only ever filters the normalized list)
- Unit regression tests: synonym keys / BISAC paths / removed parents produce no unmatched entries; a mixed raw list flags only the genuinely unknown genre
- Service-level regression test: `update()` with a synonym-key genre performs no unmatched-genres insert

## Notes

Drive-by fix per Todd — dev-only tuning telemetry, table is write-only (no readers in code). Local `pnpm verify` test stage has 26 pre-existing Windows-path failures on develop (recent disc-group test PRs, unrelated); lint/typecheck/build green, both touched test files pass (128/128).