### PR TITLE
Release v1.0.0: develop → main

### DIFF
--- a/.workflume/learnings.md
+++ b/.workflume/learnings.md
@@ -2,13 +2,14 @@
 
 **source:** #755
 **added:** 2026-05-04
+**files:** src/server/__tests__/search-grab-flow.e2e.test.ts, src/server/__tests__/sse-helpers.ts
 **tags:** testing, sse, fastify, e2e, test-harness
 
 ---
 
 Fastify's `app.inject()` cannot exercise SSE/streaming routes because Fastify hijacks the response on those handlers — the injection API never sees the streamed body. When migrating E2E tests from a non-streaming endpoint to an SSE replacement, the available workarounds are (a) call the underlying service method directly (preserves MSW/mocking assertions but bypasses the route handler) or (b) bind a real ephemeral port and parse the SSE event stream from a real HTTP client.
 
-Observed in `src/server/__tests__/e2e-helpers.ts` during the #755 migration: three tests originally hit `GET /api/search?q=...` via `app.inject()` and were ported to call `e2e.services.indexer.searchAll()` directly against `/api/search/stream`. The route-layer coverage was lost as a tradeoff. See the explanatory comment at `src/server/__tests__/search-stream.test.ts:417`.
+Observed in `src/server/__tests__/e2e-helpers.ts` during the #755 migration: three tests originally hit `GET /api/search?q=...` via `app.inject()` and were ported to call `e2e.services.indexer.searchAll()` directly against `/api/search/stream`. The route-layer coverage was lost as a tradeoff. See the explanatory comment in `src/server/__tests__/search-grab-flow.e2e.test.ts` (where `GET /api/search` is noted as retired in favor of the SSE surface, and the indexer service is exercised directly so the MSW capture still verifies the outgoing query params); `src/server/__tests__/sse-helpers.ts` documents why `app.inject()` hangs on `reply.hijack()` routes.
 
 If future work needs true end-to-end SSE coverage in this harness, add a `searchViaStream(e2e, query)` helper that spins up the app on a free port, opens a streaming HTTP request, and accumulates SSE `data:` frames into a result array. Until that helper exists, prefer the direct-service-call pattern for SSE route tests and document the bypass in the test.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ pnpm typecheck     # TypeScript checking
 
 ## Conventions & architecture
 
-Code style, the service/adapter/route layering, logging conventions, and the test layout live in **CONTRIBUTING.md**. The complete security model is in **SECURITY.md**. ESLint enforces the mechanical rules — `complexity ≤ 15`, `return await` in try/catch, `no-explicit-any`, `consistent-type-imports`, `narratorr/no-raw-error-logging`, and the client/server/core/shared/services/jobs layer-import boundaries — see `eslint.config.js`.
+Code style, the service/adapter/route layering, logging conventions, and the test layout live in **CONTRIBUTING.md**. The complete security model is in **SECURITY.md**. ESLint enforces the mechanical rules — `complexity ≤ 15`, `max-lines` (400/file), `max-lines-per-function` (150), `return await` in try/catch, `no-explicit-any`, `consistent-type-imports`, `narratorr/no-raw-error-logging`, `narratorr/no-tautological-expect` (on `*.test.ts(x)`), and the client/server/core/shared/services/jobs layer-import boundaries — see `eslint.config.js`.
 
 ## Debugging tools
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,12 @@ pnpm dev           # API on :3000, Vite on :5173
 ## Development Workflow
 
 1. Find or open an issue describing what you want to change.
-2. Branch off `main`: `git checkout -b feature/<short-slug>`.
+2. Branch off `develop`: `git checkout -b feature/<short-slug>`.
 3. Make your changes with tests for anything new or modified.
 4. Run the quality gates (see below).
-5. Open a PR against `main`.
+5. Open a PR against `develop`.
+
+PRs target `develop` (the integration branch); `main` is release-only.
 
 ## Quality Gates
 
@@ -104,6 +106,8 @@ See [e2e/README.md](e2e/README.md) for the Playwright harness, fakes, and fixtur
 - Logger type: `FastifyBaseLogger` from `fastify` (not `BaseLogger` from `pino`)
 - Non-submit `<button>` inside a `<form>` must have `type="button"` — the browser default is `type="submit"`, so an unmarked button submits the form on click
 - API client methods in `src/client/lib/api/` use domain-prefixed names (`getSystemStatus`, not `getStatus`) — the barrel export spreads them, so an unprefixed name silently overwrites another module's method
+
+ESLint also fails the build on: hollow/tautological test assertions (`narratorr/no-tautological-expect`, on `*.test.ts(x)`), files over 400 lines (`max-lines`), and functions over 150 lines (`max-lines-per-function`).
 
 ### Logging guidelines
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -69,7 +69,7 @@ Metadata from providers is noisy (see: genre normalization). The principle is: c
 
 ### Extensibility through adapters
 
-Indexers, download clients, metadata providers, notifiers, and import lists all follow the adapter pattern. Each type has an interface; implementations are pluggable. Adding a new indexer (Torznab), download client (Transmission), notifier (Discord), or import list (Audiobookshelf) means writing one adapter class that implements the interface. The rest of the system doesn't change.
+Indexers, download clients, metadata providers, notifiers, and import lists all follow the adapter pattern. Each type has an interface; implementations are pluggable. Adding a new indexer (Torznab), download client (Transmission), notifier (Discord), or import list (NYT / Hardcover) means writing one adapter class that implements the interface. The rest of the system doesn't change.
 
 This keeps the core thin and the integration surface wide.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Narratorr is the automation layer for your audiobook library: it searches your i
 - **Quality Gate** — Auto-import the first qualifying release for a wanted book and hold questionable ones for manual review. Imported books are never automatically replaced — re-importing a better version is a deliberate, manual choice.
 - **Library Management** — Configurable folder/file naming, audio enrichment from file tags, grid and list views with filtering and bulk actions.
 - **Discovery** — Personalized book suggestions based on your library: author affinity, series completion, genre, narrator, and diversity signals.
-- **Audio Processing** — Optional FFmpeg-based conversion, merging, ID3 tag embedding, and cover art embedding.
+- **Audio Processing** — Optional FFmpeg-based conversion, merging, metadata tag embedding, and cover art embedding.
 - **Notifications** — Discord, Slack, Telegram, Pushover, Gotify, Ntfy, email, and generic webhooks.
 - **Import Lists** — Sync wanted books from external sources.
 - **Security** — Forms or Basic auth with CSRF defenses, rate-limited login, AES-256-GCM credential encryption at rest, CSP with nonce-based script execution, SSRF protection on attacker-influenced fetches, library-root ancestry checks on filesystem mutations.
@@ -118,7 +118,7 @@ src/
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `3000` | Server port |
-| `NODE_ENV` | `development` | Environment (`production` enables security headers and restricts CORS) |
+| `NODE_ENV` | (unset) | Environment. Only `production` enables security headers and restricts CORS; any other value (including unset) runs in development mode |
 | `CONFIG_PATH` | `./config` | Config and database directory |
 | `DATABASE_URL` | `./config/narratorr.db` | SQLite database path (`file:` prefix optional) |
 | `URL_BASE` | `/` | Subpath for reverse-proxy deployments |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,7 +103,7 @@ In `basic`/`none` modes the browser already authenticates same-origin `EventSour
 
 Narratorr uses `@fastify/helmet` for HTTP security headers in production:
 
-- **Content-Security-Policy:** Strict CSP with nonce-based script execution (`script-src 'self'`, no `unsafe-inline` in script-src); `style-src` permits `'unsafe-inline'` (and explicitly no nonce — a Fastify `onSend` hook strips the `@fastify/helmet`-injected style nonce before the response is sent, because per CSP Level 2 a nonce's presence silently disables `unsafe-inline` in the same directive)
+- **Content-Security-Policy:** Strict CSP with nonce-based script execution (`script-src 'self'`, no `unsafe-inline` in script-src); `style-src` permits `'self'`, `'unsafe-inline'`, and `https://fonts.googleapis.com` (and explicitly no nonce — a Fastify `onSend` hook strips the `@fastify/helmet`-injected style nonce before the response is sent, because per CSP Level 2 a nonce's presence silently disables `unsafe-inline` in the same directive); `font-src` permits `'self'` and `https://fonts.gstatic.com` (Google Fonts); `img-src` permits `'self'`, `data:`, `https:`, and `blob:` (external cover art); `default-src`/`connect-src`/`base-uri`/`form-action`/`frame-ancestors` are `'self'`, with `object-src`/`script-src-attr` set to `'none'`
 - **X-Frame-Options:** `DENY` — prevents clickjacking
 - **Referrer-Policy:** `strict-origin-when-cross-origin`
 - **X-Content-Type-Options:** `nosniff` (helmet default)

--- a/src/core/utils/similarity.test.ts
+++ b/src/core/utils/similarity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { diceCoefficient, scoreResult, tokenizeNarrators, normalizeNarrator, narratorsFuzzyMatch, NARRATOR_MATCH_THRESHOLD } from './similarity.js';
+import { diceCoefficient, scoreResult, tokenizeNarrators, normalizeNarrator, narratorsFuzzyMatch, compareNarratorSignals, NARRATOR_MATCH_THRESHOLD } from './similarity.js';
 
 describe('diceCoefficient', () => {
   it('returns 1.0 for identical strings', () => {
@@ -224,5 +224,52 @@ describe('narratorsFuzzyMatch (#1650)', () => {
   it('honors a caller-supplied threshold override', () => {
     // Stevenson/Stephenson scores ≈ 0.706 — clears a relaxed 0.7 bar.
     expect(narratorsFuzzyMatch('Stevenson', ['Stephenson'], 0.7)).toBe(true);
+  });
+
+  it('treats the 0.8 threshold as INCLUSIVE — a score of exactly 0.8 matches (#1652)', () => {
+    // `abcdef` vs `abcdeg` share 4 of 5 bigrams → dice = 2*4/(5+5) = exactly 0.8.
+    // Locks the `>=` boundary: a `>=`→`>` regression would flip this to false.
+    expect(diceCoefficient('abcdef', 'abcdeg')).toBe(0.8);
+    expect(narratorsFuzzyMatch('abcdef', ['abcdeg'], 0.8)).toBe(true);
+  });
+
+  it('is order-insensitive — a Last, First flip still matches (#1652)', () => {
+    // `Stevenson, Juliet` vs `Juliet Stevenson`: the as-is dice ≈ 0.696 (below
+    // 0.8), but the token-sorted compare lines the words up → match.
+    expect(narratorsFuzzyMatch('Stevenson, Juliet', ['Juliet Stevenson'])).toBe(true);
+  });
+
+  it('does NOT force abbreviation/initial expansion (Mike/Michael stays a mismatch — #1652)', () => {
+    // Word-order is in scope; phonetic/abbreviation expansion is explicitly out.
+    expect(narratorsFuzzyMatch('Mike', ['Michael'])).toBe(false);
+  });
+});
+
+describe('compareNarratorSignals (3-state, #1650/#1652)', () => {
+  it('returns "no-signal" for punctuation-only narrators on both sides (lone hyphen vs period)', () => {
+    // The #1652 headline: `'-'` and `'.'` both normalize to empty, so there is no
+    // usable signal — NOT a mismatch. The file-side guard and the primitive agree.
+    expect(compareNarratorSignals('-', ['.'])).toBe('no-signal');
+  });
+
+  it('returns "no-signal" when the file narrator is absent or whitespace-only', () => {
+    expect(compareNarratorSignals(undefined, ['Michael York'])).toBe('no-signal');
+    expect(compareNarratorSignals('', ['Michael York'])).toBe('no-signal');
+    expect(compareNarratorSignals('   ', ['Michael York'])).toBe('no-signal');
+  });
+
+  it('returns "no-signal" when the edition has no usable narrators', () => {
+    expect(compareNarratorSignals('Adriel Brandt', undefined)).toBe('no-signal');
+    expect(compareNarratorSignals('Adriel Brandt', [])).toBe('no-signal');
+    expect(compareNarratorSignals('Adriel Brandt', ['   ', '.'])).toBe('no-signal');
+  });
+
+  it('returns "match" when a file token clears the threshold against any edition narrator', () => {
+    expect(compareNarratorSignals('Michael York', ['Michael York'])).toBe('match');
+    expect(compareNarratorSignals('Ethan Hawke', ['James Franco', 'Ethan Hawke'])).toBe('match');
+  });
+
+  it('returns "mismatch" when both sides carry signal but nothing clears the threshold', () => {
+    expect(compareNarratorSignals('Adriel Brandt', ['Michael York'])).toBe('mismatch');
   });
 });

--- a/src/core/utils/similarity.test.ts
+++ b/src/core/utils/similarity.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { diceCoefficient, scoreResult, tokenizeNarrators, normalizeNarrator } from './similarity.js';
+import { diceCoefficient, scoreResult, tokenizeNarrators, normalizeNarrator, narratorsFuzzyMatch, NARRATOR_MATCH_THRESHOLD } from './similarity.js';
 
 describe('diceCoefficient', () => {
   it('returns 1.0 for identical strings', () => {
@@ -174,5 +174,55 @@ describe('normalizeNarrator', () => {
     expect(normalizeNarrator('a,b')).toBe('a,b');
     expect(normalizeNarrator('a;b')).toBe('a;b');
     expect(normalizeNarrator('a&b')).toBe('a&b');
+  });
+});
+
+describe('narratorsFuzzyMatch (#1650)', () => {
+  it('exposes the 0.8 default threshold as the single source of truth', () => {
+    expect(NARRATOR_MATCH_THRESHOLD).toBe(0.8);
+  });
+
+  it('returns true for a spelling variant at or above threshold (dice ≈ 0.875)', () => {
+    expect(narratorsFuzzyMatch('Juliet Stevenson', ['Juliette Stevenson'])).toBe(true);
+  });
+
+  it('returns true when normalization collapses punctuation noise (Ray Porter / Ray. Porter)', () => {
+    expect(narratorsFuzzyMatch('Ray Porter', ['Ray. Porter'])).toBe(true);
+  });
+
+  it('returns false for a bare-surname variant below threshold (dice ≈ 0.706)', () => {
+    // Documents the design contract: no phonetic/alias layer — Stevenson/Stephenson
+    // scores below 0.8 and is (correctly) treated as a mismatch.
+    expect(narratorsFuzzyMatch('Stevenson', ['Stephenson'])).toBe(false);
+  });
+
+  it('returns false for distinct narrators (wrong-edition headline)', () => {
+    expect(narratorsFuzzyMatch('Adriel Brandt', ['Michael York'])).toBe(false);
+  });
+
+  it('set-overlap: any file token matching any edition narrator satisfies the match', () => {
+    expect(narratorsFuzzyMatch('Ethan Hawke', ['James Franco', 'Ethan Hawke'])).toBe(true);
+    expect(narratorsFuzzyMatch('Ethan Hawke', ['James Franco', 'Tatiana Maslany'])).toBe(false);
+  });
+
+  it('splits a multi-value file narrator string on delimiters', () => {
+    expect(narratorsFuzzyMatch('Ethan Hawke, James Franco', ['James Franco'])).toBe(true);
+  });
+
+  it('returns false when the file narrator has no signal', () => {
+    expect(narratorsFuzzyMatch(undefined, ['Michael York'])).toBe(false);
+    expect(narratorsFuzzyMatch('', ['Michael York'])).toBe(false);
+    expect(narratorsFuzzyMatch('   ', ['Michael York'])).toBe(false);
+  });
+
+  it('returns false when the edition has no narrators', () => {
+    expect(narratorsFuzzyMatch('Adriel Brandt', undefined)).toBe(false);
+    expect(narratorsFuzzyMatch('Adriel Brandt', [])).toBe(false);
+    expect(narratorsFuzzyMatch('Adriel Brandt', ['   '])).toBe(false);
+  });
+
+  it('honors a caller-supplied threshold override', () => {
+    // Stevenson/Stephenson scores ≈ 0.706 — clears a relaxed 0.7 bar.
+    expect(narratorsFuzzyMatch('Stevenson', ['Stephenson'], 0.7)).toBe(true);
   });
 });

--- a/src/core/utils/similarity.ts
+++ b/src/core/utils/similarity.ts
@@ -53,6 +53,49 @@ export function diceCoefficient(a: string, b: string): number {
 }
 
 /**
+ * Default dice threshold at or above which two narrator names are considered
+ * the same person. Single source of truth — both the search-ranking narrator
+ * tier and the library-import wrong-edition cap consume this (#1650).
+ */
+export const NARRATOR_MATCH_THRESHOLD = 0.8;
+
+/**
+ * Fuzzy narrator comparison: does the file's narrator tag name any of the
+ * matched edition's narrators? Shared primitive (#1650) — the fuzzy cross
+ * product (tokenize the file side → `normalizeNarrator` each token →
+ * `normalizeNarrator` each edition entry → max pairwise `diceCoefficient`)
+ * lives here so the search-ranking narrator tier and the match-job edition cap
+ * agree on one definition of "same narrator".
+ *
+ * Set-overlap semantics: a single pairwise hit at or above `threshold` is
+ * enough (multi-narrator / full-cast editions match when ANY file token lines
+ * up with ANY edition narrator). Returns `false` when either side carries no
+ * usable signal — callers that must distinguish "no signal" from "genuine
+ * mismatch" check signal presence themselves before consulting this.
+ *
+ * NOT modeled on `quality-gate.helpers.ts`, which is exact normalized set
+ * membership — a different contract.
+ */
+export function narratorsFuzzyMatch(
+  fileNarratorRaw: string | undefined,
+  editionNarrators: string[] | undefined,
+  threshold = NARRATOR_MATCH_THRESHOLD,
+): boolean {
+  if (!fileNarratorRaw) return false;
+  const fileTokens = tokenizeNarrators(fileNarratorRaw).map(normalizeNarrator).filter(Boolean);
+  if (fileTokens.length === 0) return false;
+  const editionTokens = (editionNarrators ?? []).map(normalizeNarrator).filter(Boolean);
+  if (editionTokens.length === 0) return false;
+  let best = 0;
+  for (const ft of fileTokens) {
+    for (const et of editionTokens) {
+      best = Math.max(best, diceCoefficient(ft, et));
+    }
+  }
+  return best >= threshold;
+}
+
+/**
  * Scores a search result against a search context (book title + author).
  * Returns 0-1 where 1 = perfect match.
  *

--- a/src/core/utils/similarity.ts
+++ b/src/core/utils/similarity.ts
@@ -59,40 +59,92 @@ export function diceCoefficient(a: string, b: string): number {
  */
 export const NARRATOR_MATCH_THRESHOLD = 0.8;
 
+/** Normalized, non-empty file-narrator tokens: split on delimiters → normalize → drop empties. */
+function fileNarratorTokens(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return tokenizeNarrators(raw).map(normalizeNarrator).filter(Boolean);
+}
+
+/** Normalized, non-empty edition-narrator tokens: normalize each entry → drop empties. */
+function editionNarratorTokens(narrators: string[] | undefined): string[] {
+  return (narrators ?? []).map(normalizeNarrator).filter(Boolean);
+}
+
+/** Sort a name's whitespace-separated words so word order can't sink the dice score. */
+function sortNameWords(s: string): string {
+  return s.split(' ').filter(Boolean).sort().join(' ');
+}
+
 /**
- * Fuzzy narrator comparison: does the file's narrator tag name any of the
- * matched edition's narrators? Shared primitive (#1650) — the fuzzy cross
- * product (tokenize the file side → `normalizeNarrator` each token →
- * `normalizeNarrator` each edition entry → max pairwise `diceCoefficient`)
- * lives here so the search-ranking narrator tier and the match-job edition cap
- * agree on one definition of "same narrator".
+ * Order-insensitive dice (#1652): the max of the as-is compare and the
+ * word-sorted compare. Lets `Stevenson, Juliet` match `Juliet Stevenson`
+ * (a `Last, First` flip) without a phonetic/alias layer — `Mike`/`Michael`
+ * still scores below threshold and stays a mismatch.
+ */
+function nameDice(a: string, b: string): number {
+  const direct = diceCoefficient(a, b);
+  const sorted = diceCoefficient(sortNameWords(a), sortNameWords(b));
+  return direct >= sorted ? direct : sorted;
+}
+
+/**
+ * Three-state narrator comparison (#1650, #1652). The single source of truth
+ * for BOTH "is there a usable narrator signal?" and "do the signals match?",
+ * so the search-ranking narrator tier (`narratorsFuzzyMatch`), the match-job
+ * edition cap (`narratorMismatchReason`), and any future consumer agree on one
+ * definition. This lives in core because core production code cannot import
+ * `src/server/**` (layer guard) — server helpers import this.
  *
- * Set-overlap semantics: a single pairwise hit at or above `threshold` is
- * enough (multi-narrator / full-cast editions match when ANY file token lines
- * up with ANY edition narrator). Returns `false` when either side carries no
- * usable signal — callers that must distinguish "no signal" from "genuine
- * mismatch" check signal presence themselves before consulting this.
+ * - `'no-signal'` — either side normalizes to no usable tokens (absent file
+ *   tag, empty edition list, or punctuation-only entries like `'-'`/`'.'` that
+ *   `normalizeNarrator` strips to empty). This is the fix for #1652: signal
+ *   presence is judged AFTER normalization on both sides, so the helper and the
+ *   primitive can no longer disagree about emptiness.
+ * - `'match'` — set-overlap: a single pairwise hit at or above `threshold` is
+ *   enough (multi-narrator / full-cast editions match when ANY file token lines
+ *   up with ANY edition narrator).
+ * - `'mismatch'` — both sides carry signal but nothing clears `threshold`.
  *
  * NOT modeled on `quality-gate.helpers.ts`, which is exact normalized set
  * membership — a different contract.
+ */
+export type NarratorComparison = 'match' | 'mismatch' | 'no-signal';
+
+export function compareNarratorSignals(
+  fileNarratorRaw: string | undefined,
+  editionNarrators: string[] | undefined,
+  threshold = NARRATOR_MATCH_THRESHOLD,
+): NarratorComparison {
+  const fileTokens = fileNarratorTokens(fileNarratorRaw);
+  const editionTokens = editionNarratorTokens(editionNarrators);
+  if (fileTokens.length === 0 || editionTokens.length === 0) return 'no-signal';
+
+  // A combined whole-name candidate recovers `Last, First` names that the
+  // delimiter split fragments into single words (the comma is also a multi-
+  // narrator delimiter, so we can't stop splitting it — we re-join instead).
+  const fileCombined = sortNameWords(fileTokens.join(' '));
+  let best = 0;
+  for (const et of editionTokens) {
+    best = Math.max(best, nameDice(fileCombined, et));
+    for (const ft of fileTokens) {
+      best = Math.max(best, nameDice(ft, et));
+    }
+  }
+  return best >= threshold ? 'match' : 'mismatch';
+}
+
+/**
+ * Fuzzy narrator comparison: does the file's narrator tag name any of the
+ * matched edition's narrators? Boolean façade over `compareNarratorSignals`
+ * (`'match'` only) — both "no signal" and "mismatch" return `false`; callers
+ * that must distinguish the two consult `compareNarratorSignals` directly.
  */
 export function narratorsFuzzyMatch(
   fileNarratorRaw: string | undefined,
   editionNarrators: string[] | undefined,
   threshold = NARRATOR_MATCH_THRESHOLD,
 ): boolean {
-  if (!fileNarratorRaw) return false;
-  const fileTokens = tokenizeNarrators(fileNarratorRaw).map(normalizeNarrator).filter(Boolean);
-  if (fileTokens.length === 0) return false;
-  const editionTokens = (editionNarrators ?? []).map(normalizeNarrator).filter(Boolean);
-  if (editionTokens.length === 0) return false;
-  let best = 0;
-  for (const ft of fileTokens) {
-    for (const et of editionTokens) {
-      best = Math.max(best, diceCoefficient(ft, et));
-    }
-  }
-  return best >= threshold;
+  return compareNarratorSignals(fileNarratorRaw, editionNarrators, threshold) === 'match';
 }
 
 /**

--- a/src/server/routes/import-preview.test.ts
+++ b/src/server/routes/import-preview.test.ts
@@ -115,7 +115,7 @@ describe('GET /api/import/preview/:token', () => {
     await writeFile(file, Buffer.alloc(64));
     const token = mintPreviewToken(file, workDir);
 
-    vi.setSystemTime(new Date('2026-01-01T01:00:00Z'));
+    vi.setSystemTime(new Date('2026-01-01T05:00:00Z')); // 5h later, past the 4-hour TTL
     const res = await app.inject({ method: 'GET', url: `/api/import/preview/${token}` });
     vi.useRealTimers();
 

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -127,6 +127,52 @@ describe('deriveTagQuery', () => {
     const scan = makeAudioScan({ tagTitle: 'X', tagAuthor: '(Various)' });
     expect(deriveTagQuery(scan)).toBeNull();
   });
+
+  // ── #1650 generic title-tag fallback ──────────────────────────────
+  describe('#1650 generic title-tag → album fallback', () => {
+    it('substitutes the album when a ", Book N" prefix differs from a usable album (headline)', () => {
+      // `Shattered Sea, Book 1` cleans to series-name prefix `Shattered Sea`;
+      // album `Half a King` is the real title → search on the album.
+      const scan = makeAudioScan({
+        tagTitle: 'Shattered Sea, Book 1',
+        tagAlbum: 'Half a King',
+        tagAuthor: 'Joe Abercrombie',
+        tagYear: '2014',
+      });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'Half a King', author: 'Joe Abercrombie', year: '2014' });
+    });
+
+    it('uses the album for a bare placeholder title when a usable album exists', () => {
+      const scan = makeAudioScan({ tagTitle: 'Book 1', tagAlbum: 'Half a King', tagAuthor: 'Joe Abercrombie' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'Half a King', author: 'Joe Abercrombie' });
+    });
+
+    it('returns null for a bare placeholder title with no usable album (falls through to Pass 2)', () => {
+      const scan = makeAudioScan({ tagTitle: 'Book 1', tagAuthor: 'Joe Abercrombie' });
+      expect(deriveTagQuery(scan)).toBeNull();
+    });
+
+    it('treats "<series-kw>, Book N" as a bare placeholder', () => {
+      const scan = makeAudioScan({ tagTitle: 'Series, Book 1', tagAlbum: 'Half a King', tagAuthor: 'Joe Abercrombie' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'Half a King', author: 'Joe Abercrombie' });
+    });
+
+    it('preserves a legitimate ", Book N" title when the cleaned album equals it', () => {
+      const scan = makeAudioScan({ tagTitle: 'The Hobbit, Book 1', tagAlbum: 'The Hobbit', tagAuthor: 'J.R.R. Tolkien' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'The Hobbit', author: 'J.R.R. Tolkien' });
+    });
+
+    it('preserves a legitimate ", Book N" title when there is no usable album', () => {
+      const scan = makeAudioScan({ tagTitle: 'The Hobbit, Book 1', tagAuthor: 'J.R.R. Tolkien' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'The Hobbit', author: 'J.R.R. Tolkien' });
+    });
+
+    it('does NOT substitute the album for a normal title (no series marker) even when album differs', () => {
+      // No `, Book N` marker → the album-difference rule never fires; the title stands.
+      const scan = makeAudioScan({ tagTitle: 'Half a King', tagAlbum: 'Shattered Sea', tagAuthor: 'Joe Abercrombie' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'Half a King', author: 'Joe Abercrombie' });
+    });
+  });
 });
 
 // ============================================================================

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
+import type { FastifyBaseLogger } from 'fastify';
 import type { AudioScanResult } from '../../core/utils/audio-scanner.js';
 import type { BookMetadata } from '../../core/metadata/index.js';
-import type { MatchCandidate } from './match-job.service.js';
+import type { MatchCandidate, MatchResult } from './match-job.service.js';
 import type * as FolderParsing from '../utils/folder-parsing.js';
 
 // Spy on cleanTagTitle so a single test can force the empty-cleaned-title path
@@ -16,14 +17,17 @@ vi.mock('../utils/folder-parsing.js', async (importActual) => {
 
 import { cleanTagTitle } from '../utils/folder-parsing.js';
 import {
+  applyNarratorCap,
   cleanTagAuthor,
   deriveTagQuery,
   isDurationVerified,
+  narratorMismatchReason,
   rankResultsCleaned,
   rankResults,
   resolveConfidenceFromDuration,
   parsePublishedYear,
   tagTitleScore,
+  type NarratorCapContext,
 } from './match-job.helpers.js';
 
 // -------- Factories --------
@@ -110,9 +114,10 @@ describe('deriveTagQuery', () => {
   });
 
   it('returns null when cleanTagTitle reduces title to empty', () => {
-    // Pins the cleanedTitle guard at match-job.helpers.ts:57 — if the guard is
-    // removed, deriveTagQuery would return { title: '', author: 'X' } and this
-    // test would fail. The mock forces the otherwise-unreachable branch.
+    // Pins the cleaned-title guard: resolveTagSearchTitle returns `cleanedTitle
+    // || null`, so deriveTagQuery's `if (!searchTitle) return null` fires. If the
+    // guard is removed, deriveTagQuery would return { title: '', author: 'X' }
+    // and this test would fail. The mock forces the otherwise-unreachable branch.
     vi.mocked(cleanTagTitle).mockReturnValueOnce('');
     const scan = makeAudioScan({ tagTitle: 'looks-non-empty', tagAuthor: 'X' });
     expect(deriveTagQuery(scan)).toBeNull();
@@ -170,6 +175,19 @@ describe('deriveTagQuery', () => {
     it('does NOT substitute the album for a normal title (no series marker) even when album differs', () => {
       // No `, Book N` marker → the album-difference rule never fires; the title stands.
       const scan = makeAudioScan({ tagTitle: 'Half a King', tagAlbum: 'Shattered Sea', tagAuthor: 'Joe Abercrombie' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'Half a King', author: 'Joe Abercrombie' });
+    });
+
+    it('does NOT substitute a bare-volume-marker album for a legitimate ", Book N" title (#1652 item 6)', () => {
+      // `The Hobbit, Book 1` has a series marker and the album `Book 5` differs,
+      // so the pre-guard rule would have picked the junk album. The new
+      // `!isPureVolumeMarker(rawAlbum)` guard rejects it → the title stands.
+      const scan = makeAudioScan({ tagTitle: 'The Hobbit, Book 1', tagAlbum: 'Book 5', tagAuthor: 'J.R.R. Tolkien' });
+      expect(deriveTagQuery(scan)).toEqual({ title: 'The Hobbit', author: 'J.R.R. Tolkien' });
+    });
+
+    it('still prefers a usable album over a pure-volume-marker title (#1652 item 6 — existing behavior preserved)', () => {
+      const scan = makeAudioScan({ tagTitle: 'Series, Book 1', tagAlbum: 'Half a King', tagAuthor: 'Joe Abercrombie' });
       expect(deriveTagQuery(scan)).toEqual({ title: 'Half a King', author: 'Joe Abercrombie' });
     });
   });
@@ -621,5 +639,119 @@ describe('parsePublishedYear', () => {
 
   it('returns undefined when no 4-digit run is present', () => {
     expect(parsePublishedYear('no year here')).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// narratorMismatchReason (#1650/#1652) — direct units
+// ============================================================================
+
+describe('narratorMismatchReason', () => {
+  it('returns null when the file narrator has no signal (absent / empty / whitespace)', () => {
+    expect(narratorMismatchReason(undefined, ['Jane Doe'])).toBeNull();
+    expect(narratorMismatchReason('', ['Jane Doe'])).toBeNull();
+    expect(narratorMismatchReason('   ', ['Jane Doe'])).toBeNull();
+  });
+
+  it('returns null when the edition has no usable narrators (undefined / empty / blank)', () => {
+    expect(narratorMismatchReason('Jane Doe', undefined)).toBeNull();
+    expect(narratorMismatchReason('Jane Doe', [])).toBeNull();
+    expect(narratorMismatchReason('Jane Doe', ['   '])).toBeNull();
+  });
+
+  it('returns null for punctuation-only narrators — the #1652 headline (no spurious cap)', () => {
+    // Lone hyphen file tag vs lone period edition: both normalize to empty, so
+    // this is "no signal", NOT a mismatch — the old looser guard capped it.
+    expect(narratorMismatchReason('-', ['.'])).toBeNull();
+  });
+
+  it('returns null for a spelling variant at or above the 0.8 threshold (no cap)', () => {
+    expect(narratorMismatchReason('Juliet Stevenson', ['Juliette Stevenson'])).toBeNull();
+  });
+
+  it('returns a reason string naming both sides on a genuine mismatch', () => {
+    const reason = narratorMismatchReason('Jane Doe', ['John Smith']);
+    expect(reason).toContain('Narrator mismatch');
+    expect(reason).toContain('Jane Doe');
+    expect(reason).toContain('John Smith');
+  });
+});
+
+// ============================================================================
+// applyNarratorCap (#1650/#1652) — direct units (with cap-log context)
+// ============================================================================
+
+describe('applyNarratorCap', () => {
+  function makeCtx(overrides: Partial<NarratorCapContext> = {}): { ctx: NarratorCapContext; log: { info: ReturnType<typeof vi.fn> } } {
+    const log = { info: vi.fn() };
+    const ctx: NarratorCapContext = {
+      log: log as unknown as FastifyBaseLogger,
+      matchSource: 'filename-single',
+      durationVerified: false,
+      ...overrides,
+    };
+    return { ctx, log };
+  }
+
+  function makeResult(overrides: Partial<MatchResult> = {}): MatchResult {
+    return {
+      path: '/audiobooks/Book',
+      confidence: 'high',
+      bestMatch: makeBook({ narrators: ['Michael York'] }),
+      alternatives: [],
+      ...overrides,
+    };
+  }
+
+  it('returns a null-bestMatch result untouched (no cap, no log)', () => {
+    const { ctx, log } = makeCtx();
+    const result = makeResult({ confidence: 'high', bestMatch: null });
+    expect(applyNarratorCap(result, makeAudioScan({ tagNarrator: 'Adriel Brandt' }), ctx)).toBe(result);
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('returns a non-high result untouched — no-op, never promotes (no log)', () => {
+    const { ctx, log } = makeCtx();
+    const result = makeResult({ confidence: 'medium', reason: 'Duration mismatch — ...' });
+    const out = applyNarratorCap(result, makeAudioScan({ tagNarrator: 'Adriel Brandt' }), ctx);
+    expect(out).toBe(result);
+    expect(out.confidence).toBe('medium');
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('caps high → medium with a reason on a genuine mismatch, and logs once with context', () => {
+    const { ctx, log } = makeCtx({ matchSource: 'exact', durationVerified: true });
+    const result = makeResult({ confidence: 'high', bestMatch: makeBook({ title: 'Brave New World', narrators: ['Michael York'], asin: 'B002V1BVK4' }) });
+    const out = applyNarratorCap(result, makeAudioScan({ tagNarrator: 'Adriel Brandt' }), ctx);
+
+    expect(out.confidence).toBe('medium');
+    expect(out.reason).toContain('Narrator mismatch');
+    expect(log.info).toHaveBeenCalledTimes(1);
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matchSource: 'exact',
+        durationVerified: true,
+        fileNarrator: 'Adriel Brandt',
+        editionNarrators: ['Michael York'],
+      }),
+      expect.stringContaining('Narrator wrong-edition cap fired'),
+    );
+  });
+
+  it('leaves a high match with a matching narrator untouched (no cap, no log)', () => {
+    const { ctx, log } = makeCtx();
+    const result = makeResult({ confidence: 'high', bestMatch: makeBook({ narrators: ['Michael York'] }) });
+    const out = applyNarratorCap(result, makeAudioScan({ tagNarrator: 'Michael York' }), ctx);
+    expect(out).toBe(result);
+    expect(out.confidence).toBe('high');
+    expect(log.info).not.toHaveBeenCalled();
+  });
+
+  it('leaves a high result untouched when there is no narrator signal (no cap, no log)', () => {
+    const { ctx, log } = makeCtx();
+    const result = makeResult({ confidence: 'high', bestMatch: makeBook({ narrators: ['Michael York'] }) });
+    const out = applyNarratorCap(result, makeAudioScan(), ctx); // no tagNarrator
+    expect(out).toBe(result);
+    expect(log.info).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/match-job.helpers.ts
+++ b/src/server/services/match-job.helpers.ts
@@ -1,9 +1,11 @@
 import { basename } from 'node:path';
+import type { FastifyBaseLogger } from 'fastify';
 import type { BookMetadata } from '../../core/metadata/index.js';
 import type { AudioScanResult } from '../../core/utils/audio-scanner.js';
-import { diceCoefficient, normalizeNarrator, narratorsFuzzyMatch, scoreResult, tokenizeNarrators } from '../../core/utils/similarity.js';
+import { compareNarratorSignals, diceCoefficient, normalizeNarrator, scoreResult } from '../../core/utils/similarity.js';
 import { cleanTagTitle, extractYear, hasTagSeriesMarker, isPureVolumeMarker } from '../utils/folder-parsing.js';
 import type { Confidence, MatchCandidate, MatchResult } from './match-job.service.js';
+import type { MatchSource } from './tag-search-planner.js';
 
 const DURATION_THRESHOLD_STRICT = 0.05;
 const DURATION_THRESHOLD_RELAXED = 0.15;
@@ -134,7 +136,11 @@ function normalizeForTitleCompare(s: string): string {
 function resolveTagSearchTitle(rawTitle: string, rawAlbum: string | undefined): string | null {
   const cleanedTitle = cleanTagTitle(rawTitle).trim();
   const cleanedAlbum = rawAlbum?.trim() ? cleanTagTitle(rawAlbum).trim() : '';
-  const usableAlbum = cleanedAlbum.length > 0;
+  // Shape-check the album the same way the title is checked (#1652): a bare
+  // volume marker (`Book 5`) is no more usable as a search title than a bare
+  // volume-marker title, so it must not survive `cleanTagTitle` and become the
+  // search query.
+  const usableAlbum = cleanedAlbum.length > 0 && !isPureVolumeMarker(rawAlbum!.trim());
 
   if (isPureVolumeMarker(rawTitle)) {
     return usableAlbum ? cleanedAlbum : null;
@@ -298,20 +304,34 @@ export function parsePublishedYear(date: string | undefined): number | undefined
  * the wrong edition; return a user-facing reason so the central cap can
  * downgrade `high → medium` (Review).
  *
- * Fuzzy, via the shared `narratorsFuzzyMatch` primitive — spelling/punctuation
- * variants at or above the `0.8` dice threshold are NOT a mismatch. Returns
- * `null` (no cap) whenever either side lacks a narrator signal: an absent file
- * tag or an edition with no `narrators` is "no signal", not a mismatch.
+ * Delegates the signal-presence AND match decision to the shared core
+ * `compareNarratorSignals` predicate (#1652) so the file side and the primitive
+ * can no longer disagree about emptiness: a punctuation-only narrator (`'-'`
+ * vs `'.'`) normalizes to no usable signal on both sides → `'no-signal'` → no
+ * cap, NOT a spurious mismatch. Spelling/punctuation variants at or above the
+ * `0.8` dice threshold are `'match'` (no cap); an absent file tag or an edition
+ * with no usable `narrators` is `'no-signal'` (no cap). Only a genuine
+ * `'mismatch'` returns a user-facing reason. Exported for direct unit tests.
  */
-function narratorMismatchReason(
+export function narratorMismatchReason(
   fileNarratorRaw: string | undefined,
   editionNarrators: string[] | undefined,
 ): string | null {
-  if (!fileNarratorRaw || tokenizeNarrators(fileNarratorRaw).length === 0) return null;
-  const editions = (editionNarrators ?? []).filter(n => n.trim().length > 0);
-  if (editions.length === 0) return null;
-  if (narratorsFuzzyMatch(fileNarratorRaw, editionNarrators)) return null;
-  return `Narrator mismatch — file: ${fileNarratorRaw.trim()} · matched edition: ${editions.join(', ')}`;
+  if (compareNarratorSignals(fileNarratorRaw, editionNarrators) !== 'mismatch') return null;
+  const editions = (editionNarrators ?? []).map(n => n.trim()).filter(n => n.length > 0);
+  return `Narrator mismatch — file: ${(fileNarratorRaw ?? '').trim()} · matched edition: ${editions.join(', ')}`;
+}
+
+/**
+ * Explicit context the cap needs to emit its observability log (#1652). The
+ * `MatchResult` alone carries no `matchSource`/`durationVerified` — those live
+ * branch-locally at the call site, so the caller threads them in here.
+ */
+export interface NarratorCapContext {
+  log: FastifyBaseLogger;
+  matchSource: MatchSource;
+  /** True when the scanned runtime independently corroborated the chosen edition (the `/import-uat` signal). */
+  durationVerified: boolean;
 }
 
 /**
@@ -322,10 +342,32 @@ function narratorMismatchReason(
  * an existing duration/attempt cap (a result already at `medium`/`none` is left
  * untouched). Fires even when duration verified the match — narrator is the
  * discriminator duration lacks, so it must not be bypassed by `isDurationVerified`.
+ *
+ * On an actual `high → medium` demotion it emits a single observability log
+ * (#1652) carrying the book identity, the file/edition narrators, the match
+ * source, and whether duration corroborated the edition — the instrument the
+ * next `/import-uat` run reads. The log fires ONLY on the transition, never on
+ * the no-op/non-high/no-signal paths above.
  */
-export function applyNarratorCap(result: MatchResult, audioResult: AudioScanResult | null): MatchResult {
+export function applyNarratorCap(
+  result: MatchResult,
+  audioResult: AudioScanResult | null,
+  ctx: NarratorCapContext,
+): MatchResult {
   if (result.confidence !== 'high' || !result.bestMatch) return result;
   const reason = narratorMismatchReason(audioResult?.tagNarrator, result.bestMatch.narrators);
   if (reason === null) return result;
+  ctx.log.info(
+    {
+      path: result.path,
+      bestTitle: result.bestMatch.title,
+      asin: result.bestMatch.asin,
+      fileNarrator: audioResult?.tagNarrator,
+      editionNarrators: result.bestMatch.narrators,
+      matchSource: ctx.matchSource,
+      durationVerified: ctx.durationVerified,
+    },
+    'Narrator wrong-edition cap fired — high → medium (Review)',
+  );
   return { ...result, confidence: 'medium', reason };
 }

--- a/src/server/services/match-job.helpers.ts
+++ b/src/server/services/match-job.helpers.ts
@@ -1,9 +1,9 @@
 import { basename } from 'node:path';
 import type { BookMetadata } from '../../core/metadata/index.js';
 import type { AudioScanResult } from '../../core/utils/audio-scanner.js';
-import { diceCoefficient, normalizeNarrator, scoreResult } from '../../core/utils/similarity.js';
-import { cleanTagTitle, extractYear } from '../utils/folder-parsing.js';
-import type { Confidence, MatchCandidate } from './match-job.service.js';
+import { diceCoefficient, normalizeNarrator, narratorsFuzzyMatch, scoreResult, tokenizeNarrators } from '../../core/utils/similarity.js';
+import { cleanTagTitle, extractYear, hasTagSeriesMarker, isPureVolumeMarker } from '../utils/folder-parsing.js';
+import type { Confidence, MatchCandidate, MatchResult } from './match-job.service.js';
 
 const DURATION_THRESHOLD_STRICT = 0.05;
 const DURATION_THRESHOLD_RELAXED = 0.15;
@@ -99,12 +99,53 @@ export function deriveTagQuery(audioResult: AudioScanResult | null): TagQuery | 
   const rawTitle = audioResult.tagTitle?.trim();
   const rawAuthor = audioResult.tagAuthor?.trim();
   if (!rawTitle || !rawAuthor) return null;
-  const cleanedTitle = cleanTagTitle(rawTitle).trim();
-  if (!cleanedTitle) return null;
   const cleanedAuthor = cleanTagAuthor(rawAuthor);
   if (!cleanedAuthor) return null;
+  const searchTitle = resolveTagSearchTitle(rawTitle, audioResult.tagAlbum);
+  if (!searchTitle) return null;
   const tagYear = audioResult.tagYear?.trim();
-  return { title: cleanedTitle, author: cleanedAuthor, ...(tagYear ? { year: tagYear } : {}) };
+  return { title: searchTitle, author: cleanedAuthor, ...(tagYear ? { year: tagYear } : {}) };
+}
+
+/** Normalize a title for the album-vs-prefix difference check: lowercase, trim, collapse internal whitespace. */
+function normalizeForTitleCompare(s: string): string {
+  return s.toLowerCase().trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * Resolve the tag-pass search title, redirecting generic/series-name title tags
+ * to the album when the real title lives there (#1650). Operates on the RAW
+ * `tagTitle` before `cleanTagTitle` strips the `, Book N` marker — the
+ * bare-vs-prefix distinction needs the original suffix. Uses only `tagTitle` +
+ * `tagAlbum` (no folder data, no signature change):
+ *
+ * - **Bare placeholder** (`Book 1`, `Series, Book 1`): no usable title in the
+ *   tag → use the cleaned album when present, else `null` (caller falls through
+ *   to Pass 2's filename-derived search).
+ * - **Series-prefix + differing album** (`Shattered Sea, Book 1` / album
+ *   `Half a King`): the `, Book N` marker means the cleaned prefix is a series
+ *   name, so prefer the cleaned album when it differs (normalized) from the
+ *   prefix.
+ * - **Legitimate `, Book N` title** (`The Hobbit, Book 1` with album
+ *   `The Hobbit` or no album): keep the cleaned title. The rule keys on the
+ *   album difference, not the title shape, because `The Hobbit, Book 1` and
+ *   `Shattered Sea, Book 1` are indistinguishable by grammar alone.
+ */
+function resolveTagSearchTitle(rawTitle: string, rawAlbum: string | undefined): string | null {
+  const cleanedTitle = cleanTagTitle(rawTitle).trim();
+  const cleanedAlbum = rawAlbum?.trim() ? cleanTagTitle(rawAlbum).trim() : '';
+  const usableAlbum = cleanedAlbum.length > 0;
+
+  if (isPureVolumeMarker(rawTitle)) {
+    return usableAlbum ? cleanedAlbum : null;
+  }
+
+  const albumDiffers = usableAlbum && normalizeForTitleCompare(cleanedAlbum) !== normalizeForTitleCompare(cleanedTitle);
+  if (hasTagSeriesMarker(rawTitle) && albumDiffers) {
+    return cleanedAlbum;
+  }
+
+  return cleanedTitle || null;
 }
 
 const TAG_TITLE_WEIGHT = 0.6;
@@ -247,4 +288,44 @@ export function parsePublishedYear(date: string | undefined): number | undefined
   if (!date) return undefined;
   const match = date.match(/\b(\d{4})\b/);
   return match ? parseInt(match[1]!, 10) : undefined;
+}
+
+/**
+ * Wrong-edition guard (#1650). Two *unabridged* readings of the same book are
+ * inherently almost the same length, so duration cannot distinguish editions —
+ * the narrator can. When the file's embedded narrator tag names a different
+ * person than the matched edition's narrators, the match is the right book but
+ * the wrong edition; return a user-facing reason so the central cap can
+ * downgrade `high → medium` (Review).
+ *
+ * Fuzzy, via the shared `narratorsFuzzyMatch` primitive — spelling/punctuation
+ * variants at or above the `0.8` dice threshold are NOT a mismatch. Returns
+ * `null` (no cap) whenever either side lacks a narrator signal: an absent file
+ * tag or an edition with no `narrators` is "no signal", not a mismatch.
+ */
+function narratorMismatchReason(
+  fileNarratorRaw: string | undefined,
+  editionNarrators: string[] | undefined,
+): string | null {
+  if (!fileNarratorRaw || tokenizeNarrators(fileNarratorRaw).length === 0) return null;
+  const editions = (editionNarrators ?? []).filter(n => n.trim().length > 0);
+  if (editions.length === 0) return null;
+  if (narratorsFuzzyMatch(fileNarratorRaw, editionNarrators)) return null;
+  return `Narrator mismatch — file: ${fileNarratorRaw.trim()} · matched edition: ${editions.join(', ')}`;
+}
+
+/**
+ * Central post-outcome narrator clamp (#1650). Applied to the *resolved*
+ * `{ confidence, reason }` of every high-confidence match outcome — both passes,
+ * including the tag ASIN kill-shot — so no high-confidence branch can slip past
+ * it. Only ever downgrades `high → medium`; never promotes, and never overrides
+ * an existing duration/attempt cap (a result already at `medium`/`none` is left
+ * untouched). Fires even when duration verified the match — narrator is the
+ * discriminator duration lacks, so it must not be bypassed by `isDurationVerified`.
+ */
+export function applyNarratorCap(result: MatchResult, audioResult: AudioScanResult | null): MatchResult {
+  if (result.confidence !== 'high' || !result.bestMatch) return result;
+  const reason = narratorMismatchReason(audioResult?.tagNarrator, result.bestMatch.narrators);
+  if (reason === null) return result;
+  return { ...result, confidence: 'medium', reason };
 }

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createMockLogger, inject } from '../__tests__/helpers.js';
-import { MatchJobService, capConfidence, type MatchCandidate } from './match-job.service.js';
+import { MatchJobService, capConfidence, type MatchCandidate, type MatchResult } from './match-job.service.js';
 import type { FastifyBaseLogger } from 'fastify';
 import type { MetadataService } from './metadata.service.js';
 import type { SettingsService } from './settings.service.js';
@@ -2673,10 +2673,14 @@ describe('MatchJobService', () => {
       };
 
       it('AC20 — Dark Forest: exact attempt zero results, album attempt wins with medium cap', async () => {
-        // Tag title is over-specified with `: The Three-Body Problem, Book 2` — exact
+        // Tag title is over-specified with `: The Three-Body Problem` — exact
         // search returns zero. Album-derived `The Dark Forest` finds the book.
+        // (No `, Book N` marker, so #1650's deriveTagQuery album-substitution
+        // does NOT preempt the planner — this still exercises the album-recovery
+        // attempt; the `, Book N` substitution path is covered by the
+        // deriveTagQuery secondary-fix tests in match-job.helpers.test.ts.)
         vi.mocked(scanAudioDirectory).mockResolvedValue(
-          makeRichScan('The Dark Forest: The Three-Body Problem, Book 2', 'Cixin Liu', {
+          makeRichScan('The Dark Forest: The Three-Body Problem', 'Cixin Liu', {
             tagAlbum: 'The Dark Forest (Unabridged)',
           }),
         );
@@ -3186,6 +3190,190 @@ describe('MatchJobService', () => {
           'Tag-search attempt fired',
         );
       });
+    });
+  });
+
+  // ── #1650 narrator wrong-edition cap ─────────────────────────────────
+  describe('#1650 narrator wrong-edition cap', () => {
+    // 443 min — the live Brave New World file duration.
+    function makeNarratorScan(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        codec: 'AAC',
+        bitrate: 128000,
+        sampleRate: 44100,
+        channels: 2,
+        bitrateMode: 'cbr' as const,
+        fileFormat: 'm4b',
+        totalSize: 100_000_000,
+        fileCount: 1,
+        hasCoverArt: false,
+        totalDuration: 443 * 60,
+        ...overrides,
+      };
+    }
+
+    const candidate: MatchCandidate = {
+      path: '/audiobooks/Brave New World',
+      title: 'Brave New World',
+      author: 'Aldous Huxley',
+    };
+
+    async function runSingle(): Promise<MatchResult> {
+      const id = service.createJob([candidate]);
+      await waitForJob(service, id);
+      return service.getJob(id)!.results[0]!;
+    }
+
+    it('caps a duration-verified tag-pass high → medium on narrator mismatch (headline, multi-alternative)', async () => {
+      // Two unabridged editions; duration (8.35% gap) verifies the marquee
+      // edition at the relaxed 15% band → high. Narrator is the discriminator
+      // duration lacks: file Adriel Brandt vs matched Michael York → cap to Review.
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Adriel Brandt' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 480, asin: 'B002V1BVK4' }),
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Some Reader'], duration: 500, asin: 'B0OTHEREDN' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.bestMatch?.title).toBe('Brave New World');
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Adriel Brandt');
+      expect(result.reason).toContain('Michael York');
+      expect(result.reason).toContain('Narrator mismatch');
+    });
+
+    it('does NOT cap when the file narrator is a spelling variant at or above 0.8 (Juliet/Juliette Stevenson)', async () => {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Sense and Sensibility', tagAuthor: 'Jane Austen', tagNarrator: 'Juliet Stevenson' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Sense and Sensibility', authors: [{ name: 'Jane Austen' }], narrators: ['Juliette Stevenson'], asin: 'B0SENSE001' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('does NOT cap on an exact narrator match (and does not promote)', async () => {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Michael York' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], asin: 'B002V1BVK4' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('multi-narrator edition: no cap when any file narrator overlaps the cast', async () => {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Slaughterhouse-Five', tagAuthor: 'Kurt Vonnegut', tagNarrator: 'Ethan Hawke' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Slaughterhouse-Five', authors: [{ name: 'Kurt Vonnegut' }], narrators: ['James Franco', 'Ethan Hawke'], asin: 'B0SLAUGH01' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('multi-narrator edition: caps when no file narrator overlaps the cast', async () => {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Slaughterhouse-Five', tagAuthor: 'Kurt Vonnegut', tagNarrator: 'Ethan Hawke' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Slaughterhouse-Five', authors: [{ name: 'Kurt Vonnegut' }], narrators: ['James Franco', 'Tatiana Maslany'], asin: 'B0SLAUGH02' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Narrator mismatch');
+    });
+
+    it('no file narrator → result untouched (no cap, no reason)', async () => {
+      for (const tagNarrator of [undefined, '', '   ']) {
+        vi.clearAllMocks();
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', ...(tagNarrator !== undefined && { tagNarrator }) }),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], asin: 'B002V1BVK4' }),
+        ]);
+
+        const result = await runSingle();
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+      }
+    });
+
+    it('no edition narrators → result untouched (undefined and [] both)', async () => {
+      for (const narrators of [undefined, [] as string[]]) {
+        vi.clearAllMocks();
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Adriel Brandt' }),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], ...(narrators !== undefined && { narrators }), asin: 'B002V1BVK4' }),
+        ]);
+
+        const result = await runSingle();
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+      }
+    });
+
+    it('never promotes: a duration-capped medium with a MATCHING narrator stays medium with its original reason', async () => {
+      // Top duration 600min vs 443min scan → 35% off → resolveConfidenceFromDuration
+      // returns medium with a duration reason. Matching narrator must NOT promote it.
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Michael York' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 600, asin: 'B002V1BVK4' }),
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 620, asin: 'B0OTHEREDN' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Duration mismatch');
+    });
+
+    it('Pass 2 (filename-derived): caps a single-result high → medium on narrator mismatch', async () => {
+      // No tagTitle/tagAuthor → Pass 1 falls through; Pass 2 runs on the folder
+      // name. The file still carries a narrator tag, so the cap applies there too.
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagNarrator: 'Adriel Brandt' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], asin: 'B002V1BVK4' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Narrator mismatch');
+    });
+
+    it('ASIN kill-shot branch: caps a high-confidence ASIN match → medium on narrator mismatch', async () => {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Adriel Brandt', tagAsin: 'B002V1BVK4' }),
+      );
+      // getBook resolves the ASIN kill-shot to the marquee edition (Michael York).
+      vi.mocked(metadataService.getBook).mockResolvedValue(
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], asin: 'B002V1BVK4' }),
+      );
+
+      const result = await runSingle();
+      expect(result.bestMatch?.title).toBe('Brave New World');
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Narrator mismatch');
+      // ASIN kill-shot returns before the planner — no search fired.
+      expect(metadataService.searchBooks).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -3375,5 +3375,123 @@ describe('MatchJobService', () => {
       // ASIN kill-shot returns before the planner — no search fired.
       expect(metadataService.searchBooks).not.toHaveBeenCalled();
     });
+
+    // ── #1652 hardening ────────────────────────────────────────────────
+    const CAP_LOG = 'Narrator wrong-edition cap fired';
+
+    it('#1652: does NOT cap on punctuation-only narrators (lone hyphen vs period — no signal)', async () => {
+      // The headline bug: file tag `-` and edition `.` both normalize to empty.
+      // The old looser file-side guard let this through as a spurious mismatch;
+      // now it is "no signal" and the high-confidence match is preserved.
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: '-' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['.'], asin: 'B002V1BVK4' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBeUndefined();
+      expect(log.info).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining(CAP_LOG));
+    });
+
+    it('#1652 (item 3a): a duration-capped medium with a MISMATCHING narrator keeps its duration reason (no-op, no cap log)', async () => {
+      // Top duration 600min vs 443min scan → 35% off → medium with a duration
+      // reason. The mismatching narrator must NOT override it (downgrade-only /
+      // no-op-on-non-high): confidence stays medium, the duration reason is kept,
+      // and the cap-firing log does NOT fire (no high→medium transition).
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Adriel Brandt' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 600, asin: 'B002V1BVK4' }),
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 620, asin: 'B0OTHEREDN' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Duration mismatch');
+      expect(result.reason).not.toContain('Narrator mismatch');
+      expect(log.info).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining(CAP_LOG));
+    });
+
+    it('#1652 (item 5): logs the cap once with matchSource + durationVerified on a tag-pass demotion (F6: exact/ASIN duration-matched → durationVerified true)', async () => {
+      // ASIN kill-shot (source 'asin-tag', maxConfidence 'high'). The scanned
+      // 443min runtime matches the edition's 443min → isDurationVerified === true,
+      // even though capBypassedByDuration is false (it is gated on medium attempts).
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Adriel Brandt', tagAsin: 'B002V1BVK4' }),
+      );
+      vi.mocked(metadataService.getBook).mockResolvedValue(
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 443, asin: 'B002V1BVK4' }),
+      );
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({
+          matchSource: 'asin-tag',
+          durationVerified: true,
+          fileNarrator: 'Adriel Brandt',
+          editionNarrators: ['Michael York'],
+        }),
+        expect.stringContaining(CAP_LOG),
+      );
+    });
+
+    it('#1652 (item 5): the filename-single branch logs matchSource "filename-single" with durationVerified false', async () => {
+      // No tagTitle/tagAuthor → Pass 1 falls through; Pass 2 single result is the
+      // filename-derived high. The filename-single branch runs no duration check.
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagNarrator: 'Adriel Brandt' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], asin: 'B002V1BVK4' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({ matchSource: 'filename-single', durationVerified: false }),
+        expect.stringContaining(CAP_LOG),
+      );
+    });
+
+    it('#1652 (item 5): the filename duration-resolved multi-result branch logs matchSource "filename-duration-resolved" with durationVerified true', async () => {
+      // No tagTitle/tagAuthor → Pass 1 falls through. Pass 2 returns MULTIPLE
+      // results; the top edition's 443min runtime matches the 443min scan, so
+      // resolveConfidenceFromDuration returns 'high' (duration-verified). The
+      // mismatching narrator then demotes high → medium, and the cap log must
+      // carry the multi-result filename source with durationVerified: true.
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagNarrator: 'Adriel Brandt' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], duration: 443, asin: 'B002V1BVK4' }),
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Some Reader'], duration: 500, asin: 'B0OTHEREDN' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('medium');
+      expect(result.reason).toContain('Narrator mismatch');
+      expect(log.info).toHaveBeenCalledWith(
+        expect.objectContaining({ matchSource: 'filename-duration-resolved', durationVerified: true }),
+        expect.stringContaining(CAP_LOG),
+      );
+    });
+
+    it('#1652 (item 5): a matching narrator does NOT fire the cap log', async () => {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(
+        makeNarratorScan({ tagTitle: 'Brave New World', tagAuthor: 'Aldous Huxley', tagNarrator: 'Michael York' }),
+      );
+      vi.mocked(metadataService.searchBooks).mockResolvedValue([
+        makeBookMetadata({ title: 'Brave New World', authors: [{ name: 'Aldous Huxley' }], narrators: ['Michael York'], asin: 'B002V1BVK4' }),
+      ]);
+
+      const result = await runSingle();
+      expect(result.confidence).toBe('high');
+      expect(log.info).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining(CAP_LOG));
+    });
   });
 });

--- a/src/server/services/match-job.service.ts
+++ b/src/server/services/match-job.service.ts
@@ -10,7 +10,7 @@ import { diceCoefficient, normalizeNarrator } from '../../core/utils/similarity.
 import { searchWithSwapRetryTrace } from '../utils/search-helpers.js';
 import { getErrorMessage } from '../utils/error-message.js';
 import { serializeError } from '../utils/serialize-error.js';
-import { deriveTagQuery, isDurationVerified, rankResults, rankResultsCleaned, resolveConfidenceFromDuration, tagTitleScore, type TagQuery } from './match-job.helpers.js';
+import { applyNarratorCap, deriveTagQuery, isDurationVerified, rankResults, rankResultsCleaned, resolveConfidenceFromDuration, tagTitleScore, type TagQuery } from './match-job.helpers.js';
 import { planTagSearchAttempts, type TagSearchAttempt, type TagSearchOutcome } from './tag-search-planner.js';
 
 
@@ -208,7 +208,7 @@ class MatchJob {
       // are populated. Bypasses searchWithSwapRetryTrace (no swap-on-zero) because
       // tag.title and tag.albumartist are structurally distinct fields.
       const tagResult = await this.tryTagDerivedMatch(book, audioResult, duration);
-      if (tagResult) return tagResult;
+      if (tagResult) return applyNarratorCap(tagResult, audioResult);
 
       // Pass 2 — filename-derived search via swap-retry wrapper (existing path).
       this.log.debug({ path: book.path, title: book.title, author: book.author, duration }, 'Searching metadata for book');
@@ -268,12 +268,12 @@ class MatchJob {
 
       if (scored.length === 1) {
         this.log.debug({ path: book.path, title: topScored.meta.title, score: topScored.score.toFixed(2) }, 'Single result — high confidence');
-        return {
+        return applyNarratorCap({
           path: book.path,
           confidence: 'high',
           bestMatch: topScored.meta,
           alternatives: [],
-        };
+        }, audioResult);
       }
 
       // Multiple results — use duration to determine confidence (not to override winner)
@@ -290,13 +290,13 @@ class MatchJob {
         },
         confidence === 'high' ? 'Duration-verified high confidence' : reason ?? 'Multiple results — medium confidence',
       );
-      return {
+      return applyNarratorCap({
         path: book.path,
         confidence,
         bestMatch: topScored.meta,
         alternatives: scored.slice(1).map(s => s.meta),
         ...(reason !== undefined && { reason }),
-      };
+      }, audioResult);
     } catch (error: unknown) {
       this.log.warn({ error: serializeError(error), path: book.path, title: book.title }, 'Match failed for book');
       return {

--- a/src/server/services/match-job.service.ts
+++ b/src/server/services/match-job.service.ts
@@ -10,7 +10,7 @@ import { diceCoefficient, normalizeNarrator } from '../../core/utils/similarity.
 import { searchWithSwapRetryTrace } from '../utils/search-helpers.js';
 import { getErrorMessage } from '../utils/error-message.js';
 import { serializeError } from '../utils/serialize-error.js';
-import { applyNarratorCap, deriveTagQuery, isDurationVerified, rankResults, rankResultsCleaned, resolveConfidenceFromDuration, tagTitleScore, type TagQuery } from './match-job.helpers.js';
+import { applyNarratorCap, deriveTagQuery, isDurationVerified, rankResults, rankResultsCleaned, resolveConfidenceFromDuration, tagTitleScore, type NarratorCapContext, type TagQuery } from './match-job.helpers.js';
 import { planTagSearchAttempts, type TagSearchAttempt, type TagSearchOutcome } from './tag-search-planner.js';
 
 
@@ -204,99 +204,109 @@ class MatchJob {
         this.log.debug({ error: serializeError(error), path: book.path }, 'Audio scan failed — proceeding without duration');
       }
 
+      // Every high-producing branch sets these and funnels through the single
+      // `applyNarratorCap` call at the resolved-match exit below (#1650/#1652);
+      // the non-high early returns ('none'/title-floor/catch) bypass the cap.
+      let resolved: MatchResult, capCtx: NarratorCapContext;
+
       // Pass 1 — tag-derived search (#984). Fires when both tagTitle and tagAuthor
       // are populated. Bypasses searchWithSwapRetryTrace (no swap-on-zero) because
       // tag.title and tag.albumartist are structurally distinct fields.
-      const tagResult = await this.tryTagDerivedMatch(book, audioResult, duration);
-      if (tagResult) return applyNarratorCap(tagResult, audioResult);
+      const tagMatch = await this.tryTagDerivedMatch(book, audioResult, duration);
+      if (tagMatch) {
+        ({ result: resolved, ctx: capCtx } = tagMatch);
+      } else {
+        // Pass 2 — filename-derived search via swap-retry wrapper (existing path).
+        this.log.debug({ path: book.path, title: book.title, author: book.author, duration }, 'Searching metadata for book');
+        const trace = await searchWithSwapRetryTrace({
+          searchFn: (q, opts) => this.metadataService.searchBooks(q, opts),
+          title: book.title,
+          author: book.author,
+          log: this.log,
+          options: { title: book.title, ...(book.author !== undefined && { author: book.author }) },
+        });
 
-      // Pass 2 — filename-derived search via swap-retry wrapper (existing path).
-      this.log.debug({ path: book.path, title: book.title, author: book.author, duration }, 'Searching metadata for book');
-      const trace = await searchWithSwapRetryTrace({
-        searchFn: (q, opts) => this.metadataService.searchBooks(q, opts),
-        title: book.title,
-        author: book.author,
-        log: this.log,
-        options: { title: book.title, ...(book.author !== undefined && { author: book.author }) },
-      });
+        if (trace.results.length === 0) {
+          this.log.debug({ path: book.path }, 'No search results returned');
+          return { path: book.path, confidence: 'none', bestMatch: null, alternatives: [] };
+        }
 
-      if (trace.results.length === 0) {
-        this.log.debug({ path: book.path }, 'No search results returned');
-        return { path: book.path, confidence: 'none', bestMatch: null, alternatives: [] };
+        this.log.debug({ path: book.path, resultCount: trace.results.length, swapRetry: trace.swapRetry }, 'Search returned results');
+
+        // When swap retry fired and author is present, use swapped context for ranking and similarity
+        const context: MatchCandidate = trace.swapRetry && book.author
+          ? { ...book, title: book.author, author: book.title }
+          : book;
+
+        // Fetch full detail for all results to get ASIN/duration
+        const detailed = await this.fetchDetails(trace.results);
+
+        // Score, re-rank, and apply year tiebreaker
+        const scored = rankResults(detailed, context);
+        const topScored = scored[0];
+        if (!topScored) {
+          // §6.1 — fetchDetails breaks on this.cancelled, so detailed (and thus
+          // scored) can be empty even when trace.results was non-empty. Return
+          // a clean 'none' result instead of crashing on topScored.meta.title.
+          this.log.debug(
+            { path: book.path, cancelled: this.cancelled, resultCount: trace.results.length },
+            'No scored results after ranking — cancelled mid-flight or all filtered',
+          );
+          return { path: book.path, confidence: 'none', bestMatch: null, alternatives: [] };
+        }
+
+        // Title similarity floor: below 50% → confidence 'none'
+        const titleSimilarity = context.title && topScored.meta.title
+          ? diceCoefficient(topScored.meta.title, context.title)
+          : 0;
+        if (titleSimilarity < TITLE_SIMILARITY_FLOOR) {
+          this.log.debug(
+            { path: book.path, titleSimilarity: titleSimilarity.toFixed(2), bestTitle: topScored.meta.title },
+            'Top result below title similarity floor — none confidence',
+          );
+          return {
+            path: book.path,
+            confidence: 'none',
+            bestMatch: topScored.meta,
+            alternatives: scored.slice(1).map(s => s.meta),
+          };
+        }
+
+        if (scored.length === 1) {
+          this.log.debug({ path: book.path, title: topScored.meta.title, score: topScored.score.toFixed(2) }, 'Single result — high confidence');
+          resolved = { path: book.path, confidence: 'high', bestMatch: topScored.meta, alternatives: [] };
+          // No duration check fires on the single-result filename branch.
+          capCtx = { log: this.log, matchSource: 'filename-single', durationVerified: false };
+        } else {
+          // Multiple results — use duration to determine confidence (not to override winner)
+          const { confidence, reason } = resolveConfidenceFromDuration(scored, duration);
+          this.log.debug(
+            {
+              path: book.path,
+              confidence,
+              resultCount: scored.length,
+              topScore: topScored.score.toFixed(2),
+              bestTitle: topScored.meta.title,
+              hasDuration: !!duration,
+              matchDuration: topScored.meta.duration,
+            },
+            confidence === 'high' ? 'Duration-verified high confidence' : reason ?? 'Multiple results — medium confidence',
+          );
+          resolved = {
+            path: book.path,
+            confidence,
+            bestMatch: topScored.meta,
+            alternatives: scored.slice(1).map(s => s.meta),
+            ...(reason !== undefined && { reason }),
+          };
+          // `resolveConfidenceFromDuration` returning 'high' IS the duration corroboration.
+          capCtx = { log: this.log, matchSource: 'filename-duration-resolved', durationVerified: confidence === 'high' };
+        }
       }
 
-      this.log.debug({ path: book.path, resultCount: trace.results.length, swapRetry: trace.swapRetry }, 'Search returned results');
-
-      // When swap retry fired and author is present, use swapped context for ranking and similarity
-      const context: MatchCandidate = trace.swapRetry && book.author
-        ? { ...book, title: book.author, author: book.title }
-        : book;
-
-      // Fetch full detail for all results to get ASIN/duration
-      const detailed = await this.fetchDetails(trace.results);
-
-      // Score, re-rank, and apply year tiebreaker
-      const scored = rankResults(detailed, context);
-      const topScored = scored[0];
-      if (!topScored) {
-        // §6.1 — fetchDetails breaks on this.cancelled, so detailed (and thus
-        // scored) can be empty even when trace.results was non-empty. Return
-        // a clean 'none' result instead of crashing on topScored.meta.title.
-        this.log.debug(
-          { path: book.path, cancelled: this.cancelled, resultCount: trace.results.length },
-          'No scored results after ranking — cancelled mid-flight or all filtered',
-        );
-        return { path: book.path, confidence: 'none', bestMatch: null, alternatives: [] };
-      }
-
-      // Title similarity floor: below 50% → confidence 'none'
-      const titleSimilarity = context.title && topScored.meta.title
-        ? diceCoefficient(topScored.meta.title, context.title)
-        : 0;
-      if (titleSimilarity < TITLE_SIMILARITY_FLOOR) {
-        this.log.debug(
-          { path: book.path, titleSimilarity: titleSimilarity.toFixed(2), bestTitle: topScored.meta.title },
-          'Top result below title similarity floor — none confidence',
-        );
-        return {
-          path: book.path,
-          confidence: 'none',
-          bestMatch: topScored.meta,
-          alternatives: scored.slice(1).map(s => s.meta),
-        };
-      }
-
-      if (scored.length === 1) {
-        this.log.debug({ path: book.path, title: topScored.meta.title, score: topScored.score.toFixed(2) }, 'Single result — high confidence');
-        return applyNarratorCap({
-          path: book.path,
-          confidence: 'high',
-          bestMatch: topScored.meta,
-          alternatives: [],
-        }, audioResult);
-      }
-
-      // Multiple results — use duration to determine confidence (not to override winner)
-      const { confidence, reason } = resolveConfidenceFromDuration(scored, duration);
-      this.log.debug(
-        {
-          path: book.path,
-          confidence,
-          resultCount: scored.length,
-          topScore: topScored.score.toFixed(2),
-          bestTitle: topScored.meta.title,
-          hasDuration: !!duration,
-          matchDuration: topScored.meta.duration,
-        },
-        confidence === 'high' ? 'Duration-verified high confidence' : reason ?? 'Multiple results — medium confidence',
-      );
-      return applyNarratorCap({
-        path: book.path,
-        confidence,
-        bestMatch: topScored.meta,
-        alternatives: scored.slice(1).map(s => s.meta),
-        ...(reason !== undefined && { reason }),
-      }, audioResult);
+      // Single cap chokepoint (#1650/#1652) — every high-producing branch above
+      // funnels here; non-high outcomes returned early and never reach it.
+      return applyNarratorCap(resolved, audioResult, capCtx);
     } catch (error: unknown) {
       this.log.warn({ error: serializeError(error), path: book.path, title: book.title }, 'Match failed for book');
       return {
@@ -313,34 +323,38 @@ class MatchJob {
   // (no tags, zero results across all attempts, floor fail, predicate fail,
   // unexpected throw); caller falls through to filename-derived. Bypasses
   // searchWithSwapRetryTrace — tag.title and tag.albumartist are structurally
-  // distinct, no swap-on-zero needed.
+  // distinct, no swap-on-zero needed. On success returns the resolved result
+  // plus the winning attempt's `source` and the genuine duration-corroboration
+  // flag, both threaded out to the single narrator-cap call (#1652).
   private async tryTagDerivedMatch(
     book: MatchCandidate,
     audioResult: AudioScanResult | null,
     duration: number | undefined,
-  ): Promise<MatchResult | null> {
+  ): Promise<{ result: MatchResult; ctx: NarratorCapContext } | null> {
     const tagQuery = deriveTagQuery(audioResult);
     if (!tagQuery || !audioResult) return null;
-
     this.log.debug({ path: book.path, tagTitle: tagQuery.title, tagAuthor: tagQuery.author }, 'Tag-derived metadata search');
-
     const outcome = await this.runTagSearch(book, audioResult, tagQuery);
     if (!outcome) return null;
 
     const { scored, attempt } = outcome;
     const top = scored[0]!;
 
-    // #1266 — the strip `medium` cap flags matches we couldn't corroborate; when the scanned
-    // runtime independently verifies the top candidate, bypass the cap and keep `high` (no reason).
-    const capBypassedByDuration = attempt.maxConfidence === 'medium' && isDurationVerified(top.meta, duration, top.score);
+    // #1652 (F6) — genuine runtime corroboration of the chosen edition for EVERY
+    // tag source (the `/import-uat` signal logged by the cap). Distinct from
+    // `capBypassedByDuration`, which is gated on `maxConfidence === 'medium'` and
+    // only governs the strip-attempt cap bypass — an exact/ASIN attempt
+    // (`maxConfidence: 'high'`) can be durationVerified while capBypassed is false.
+    const durationVerified = isDurationVerified(top.meta, duration, top.score);
+    // #1266 — when the scanned runtime verifies the top candidate, bypass the strip `medium` cap and keep `high`.
+    const capBypassedByDuration = attempt.maxConfidence === 'medium' && durationVerified;
     const cap = (raw: Confidence, reason: string | undefined): { confidence: Confidence; reason?: string } =>
       capBypassedByDuration ? { confidence: 'high' } : applyAttemptCap(raw, attempt.maxConfidence, reason);
 
-    if (scored.length === 1) {
-      return { path: book.path, ...cap('high', undefined), bestMatch: top.meta, alternatives: [] };
-    }
-    const { confidence, reason } = resolveConfidenceFromDuration(scored, duration);
-    return { path: book.path, ...cap(confidence, reason), bestMatch: top.meta, alternatives: scored.slice(1).map(s => s.meta) };
+    const single = scored.length === 1;
+    const { confidence, reason } = single ? { confidence: 'high' as Confidence } : resolveConfidenceFromDuration(scored, duration);
+    const result: MatchResult = { path: book.path, ...cap(confidence, reason), bestMatch: top.meta, alternatives: single ? [] : scored.slice(1).map(s => s.meta) };
+    return { result, ctx: { log: this.log, matchSource: attempt.source, durationVerified } };
   }
 
   /**

--- a/src/server/services/preview-token.test.ts
+++ b/src/server/services/preview-token.test.ts
@@ -77,8 +77,18 @@ describe('preview-token', () => {
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
     const token = mintPreviewToken('/p', '/r');
 
-    vi.setSystemTime(new Date('2026-01-01T01:00:00Z')); // 1 hour later, well past 30-min TTL
+    vi.setSystemTime(new Date('2026-01-01T05:00:00Z')); // 5 hours later, past the 4-hour TTL
     expect(verifyPreviewToken(token)).toBeNull();
+  });
+
+  it('stays valid within the 4-hour TTL window (past the old 30-min window)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    const token = mintPreviewToken('/p', '/r');
+
+    // 2 hours later: expired under the old 30-min TTL, still valid under the new 4-hour one.
+    vi.setSystemTime(new Date('2026-01-01T02:00:00Z'));
+    expect(verifyPreviewToken(token)).not.toBeNull();
   });
 
   it('returns null for wrong purpose', () => {

--- a/src/server/services/preview-token.ts
+++ b/src/server/services/preview-token.ts
@@ -11,7 +11,12 @@ const previewTokenPayloadSchema = z.object({
 
 export type PreviewTokenPayload = z.infer<typeof previewTokenPayloadSchema>;
 
-const TOKEN_TTL_MS = 30 * 60 * 1000;
+// 4 hours: long enough to outlast a large library-import review session. Sorting
+// hundreds of discoveries routinely ran past the old 30-minute window, after
+// which previewing a row 403s and the only recovery was a rescan that discards
+// in-progress review/selection state. The route is auth-gated and the token is a
+// per-file path *scope* (not the auth boundary), so a longer window is low-risk.
+const TOKEN_TTL_MS = 4 * 60 * 60 * 1000;
 
 /** Derive a purpose-specific signing key so preview tokens don't reuse the raw encryption key. */
 function getSigningKey(): Buffer {

--- a/src/server/services/quality-gate.helpers.ts
+++ b/src/server/services/quality-gate.helpers.ts
@@ -52,7 +52,13 @@ export function buildQualityAssessment(
   // Downloaded duration (null when 0 — no valid duration)
   const downloadedDuration = newDurationSeconds > 0 ? newDurationSeconds : null;
 
-  // Check narrator match (skip for first imports — no existing file to protect)
+  // Check narrator match (skip for first imports — no existing file to protect).
+  // NOTE (#1650/#1652): this is the EXACT normalized-set-membership narrator
+  // compare — `downloadTokens.some(n => existingSet.has(n))` below — and is
+  // intentionally NOT the fuzzy `narratorsFuzzyMatch` (`similarity.ts`, 0.8 dice)
+  // path the match-job edition cap uses. Different contract: an upgrade decision
+  // against the operator's OWN existing files wants exact identity, not fuzzy
+  // tolerance. Do not unify the two without revisiting the upgrade contract.
   let narratorMatch: boolean | null = null;
   let existingNarrator: string | null = null;
   let downloadNarrator: string | null = null;

--- a/src/server/services/search-ranking.ts
+++ b/src/server/services/search-ranking.ts
@@ -1,5 +1,5 @@
 import { calculateQuality } from '../../core/utils/index.js';
-import { diceCoefficient, tokenizeNarrators, normalizeNarrator } from '../../core/utils/similarity.js';
+import { narratorsFuzzyMatch } from '../../core/utils/similarity.js';
 import type { SearchResult } from '../../core/index.js';
 
 /** Optional narrator-priority config for auto-grab scoring. */
@@ -8,27 +8,15 @@ export interface NarratorPriority {
   threshold?: number;
 }
 
-const NARRATOR_MATCH_THRESHOLD = 0.8;
 const NARRATOR_QUALITY_FLOOR_MBHR = 30;
 
 /**
  * Check whether a search result's narrator fuzzy-matches any of the book's narrators.
- * Returns true if the best pairwise diceCoefficient >= threshold.
+ * Delegates to the shared `narratorsFuzzyMatch` primitive (#1650) so the fuzzy
+ * cross-product and the `0.8` default threshold live in exactly one place.
  */
 function isNarratorMatch(result: SearchResult, priority: NarratorPriority): boolean {
-  if (!result.narrator) return false;
-  const threshold = priority.threshold ?? NARRATOR_MATCH_THRESHOLD;
-  const resultTokens = tokenizeNarrators(result.narrator).map(normalizeNarrator).filter(Boolean);
-  if (resultTokens.length === 0) return false;
-  const bookNormalized = priority.bookNarrators.map(normalizeNarrator).filter(Boolean);
-  if (bookNormalized.length === 0) return false;
-  let best = 0;
-  for (const rt of resultTokens) {
-    for (const bn of bookNormalized) {
-      best = Math.max(best, diceCoefficient(rt, bn));
-    }
-  }
-  return best >= threshold;
+  return narratorsFuzzyMatch(result.narrator, priority.bookNarrators, priority.threshold);
 }
 
 /**

--- a/src/server/services/search-ranking.ts
+++ b/src/server/services/search-ranking.ts
@@ -5,6 +5,13 @@ import type { SearchResult } from '../../core/index.js';
 /** Optional narrator-priority config for auto-grab scoring. */
 export interface NarratorPriority {
   bookNarrators: string[];
+  /**
+   * Test-only seam (#1650/#1652): overrides the `0.8` dice threshold passed
+   * through to `narratorsFuzzyMatch`. `buildNarratorPriority` never assigns it
+   * in production, so the default always applies at runtime — it exists purely
+   * so `similarity.test.ts` can exercise the exact-boundary and relaxed-bar
+   * cases. Do NOT drop it as dead code.
+   */
   threshold?: number;
 }
 

--- a/src/server/services/tag-search-planner.ts
+++ b/src/server/services/tag-search-planner.ts
@@ -13,6 +13,13 @@ export type AttemptSource =
   | 'strip-leading-series'
   | 'strip-colon-suffix';
 
+/**
+ * Where a resolved match came from, for the narrator-cap observability log
+ * (#1652): a tag-pass `AttemptSource` (incl. the ASIN kill-shot's `'asin-tag'`)
+ * plus the two filename-pass outcomes. Colocated with `AttemptSource`.
+ */
+export type MatchSource = AttemptSource | 'filename-single' | 'filename-duration-resolved';
+
 export interface TagSearchAttempt {
   title: string;
   author: string;

--- a/src/server/utils/folder-parsing.test.ts
+++ b/src/server/utils/folder-parsing.test.ts
@@ -9,6 +9,8 @@ import {
   extractYear,
   extractASIN,
   normalizeFolderName,
+  isPureVolumeMarker,
+  hasTagSeriesMarker,
   CODEC_TEST_REGEX,
 } from './folder-parsing.js';
 import { isReleaseTagInner, isPureReleaseTagBracket } from './folder-parsing-patterns.js';
@@ -2469,6 +2471,36 @@ describe('folder-parsing (extracted from library-scan.service)', () => {
       expect(cleanTagTitle('The Sandman: Act I')).toBe('The Sandman: Act I');
       expect(cleanTagTitle('The Sandman: Act II')).toBe('The Sandman: Act II');
       expect(cleanTagTitle('The Sandman: Act III')).toBe('The Sandman: Act III');
+    });
+  });
+
+  describe('isPureVolumeMarker (#1650)', () => {
+    it('matches bare book/volume markers with no real title words', () => {
+      expect(isPureVolumeMarker('Book 1')).toBe(true);
+      expect(isPureVolumeMarker('Volume 2')).toBe(true);
+      expect(isPureVolumeMarker('Vol 3')).toBe(true);
+      expect(isPureVolumeMarker('Series, Book 1')).toBe(true);
+      expect(isPureVolumeMarker('  Book 1  ')).toBe(true);
+    });
+
+    it('does not match a real title carrying a marker', () => {
+      expect(isPureVolumeMarker('Shattered Sea, Book 1')).toBe(false);
+      expect(isPureVolumeMarker('The Hobbit, Book 1')).toBe(false);
+      expect(isPureVolumeMarker('Half a King')).toBe(false);
+    });
+  });
+
+  describe('hasTagSeriesMarker (#1650)', () => {
+    it('detects a trailing series/volume marker behind a real prefix', () => {
+      expect(hasTagSeriesMarker('Shattered Sea, Book 1')).toBe(true);
+      expect(hasTagSeriesMarker('The Final Empire Mistborn trilogy book 1')).toBe(true);
+      expect(hasTagSeriesMarker('Eric: Discworld, Book 9')).toBe(true);
+    });
+
+    it('returns false for titles with no trailing marker', () => {
+      expect(hasTagSeriesMarker('Half a King')).toBe(false);
+      expect(hasTagSeriesMarker('Book 1')).toBe(false); // no leading [\\s,]+ separator
+      expect(hasTagSeriesMarker('World War 3')).toBe(false);
     });
   });
 

--- a/src/server/utils/folder-parsing.ts
+++ b/src/server/utils/folder-parsing.ts
@@ -151,6 +151,29 @@ export function cleanTagTitle(s: string): string {
 }
 
 /**
+ * Whole-string pure volume/book marker — an optional series keyword followed by
+ * `Book`/`Vol`/`Volume` + number and nothing else (`Book 1`, `Volume 2`,
+ * `Series, Book 1`). Used by the tag pass (#1650) to detect a placeholder title
+ * tag that carries no real title — the real title lives in the album.
+ */
+const PURE_VOLUME_MARKER_REGEX = /^(?:saga|trilogy|series|cycle|chronicles)?[\s,]*(?:book|vol(?:ume)?)\s+\d+$/i;
+
+/** True when the whole tag title is only a `[<series-kw> ]Book/Vol N` marker, with no real title words. */
+export function isPureVolumeMarker(s: string): boolean {
+  return PURE_VOLUME_MARKER_REGEX.test(s.trim());
+}
+
+/**
+ * True when the tag title carries a trailing series/volume marker that
+ * `cleanTagTitle` would strip (`, Book N`, ` Book N`, `<series-kw> Book N`),
+ * leaving a real prefix in front of it. Distinguishes `Shattered Sea, Book 1`
+ * (a series-name prefix) from a bare `Title` (#1650).
+ */
+export function hasTagSeriesMarker(s: string): boolean {
+  return TAG_TITLE_SERIES_MARKER_REGEX.test(s);
+}
+
+/**
  * Strip bracketed release tags (`[M4B]`, `[64k]`, `[2021]`, `[GA]`) — but NOT when
  * doing so would leave a title-less remainder. When the whole title is wrapped in
  * brackets (`Author - [The Real Title]`, `[Dune]`), a global strip collapses the


### PR DESCRIPTION
## Release: develop → main — v1.0.0 candidate

Cuts the v1.0.0 release line. Carries the 4 commits landed on `develop` since the last release merge (#1649):

- **#1652** — Harden the #1650 narrator cap: shared core usable-signal predicate (fixes the punctuation-only spurious-cap edge), token-sorted narrator compare (order-insensitive `Last, First`), centralized cap chokepoint, boundary/edge tests, and a cap-firing observability log. Two data-gated questions (ASIN kill-shot, abbreviation tuning) deliberately deferred to a post-1.0 import-uat measurement.
- **#1650** — Catch wrong-edition library-import matches with a narrator check (→ Review); fix generic/series-name title-tag misroutes.
- **Doc-audit fixes** — README / CONTRIBUTING / CLAUDE / PRODUCT / SECURITY / learnings accuracy pass from the 2026-06-25 line-by-line audit (ID3→metadata wording, branch target, ESLint rules, CSP hosts, stale refs).
- **Preview-token TTL** 30m → 4h — outlasts a long library-import review session.

The `v1.0.0` tag is cut from `main` *after* this merges — that's what fires the multi-arch DockerHub/GHCR publish + GitHub Release via `.github/workflows/docker.yml`.
