### PR TITLE
Release: develop → main (v0.9.2 candidate — narrator fix re-UAT)

### DIFF
--- a/src/core/utils/similarity.test.ts
+++ b/src/core/utils/similarity.test.ts
@@ -175,6 +175,71 @@ describe('normalizeNarrator', () => {
     expect(normalizeNarrator('a;b')).toBe('a;b');
     expect(normalizeNarrator('a&b')).toBe('a&b');
   });
+
+  describe('5A string-cleaning transforms (#1655)', () => {
+    it('strips a "Read by:" role prefix (with colon)', () => {
+      expect(normalizeNarrator('Read by: P. J. Ochlan')).toBe('pj ochlan');
+    });
+
+    it('strips a "Read By" role prefix (no colon)', () => {
+      expect(normalizeNarrator('Read By Sissy Spacek')).toBe('sissy spacek');
+    });
+
+    it('strips a "Narrated by" role prefix', () => {
+      expect(normalizeNarrator('Narrated by Paul Boehmer')).toBe('paul boehmer');
+    });
+
+    it('drops a parenthetical descriptor', () => {
+      expect(normalizeNarrator('James Marsters (Spike from Buffy The Vampire Slayer)')).toBe('james marsters');
+    });
+
+    it('folds diacritics (NFD + combining-mark strip)', () => {
+      expect(normalizeNarrator('Thérèse Plummer')).toBe('therese plummer');
+    });
+
+    it('canonicalizes initials: spaced "R. C." and unspaced "R.C." converge', () => {
+      expect(normalizeNarrator('R. C. Bray')).toBe('rc bray');
+      expect(normalizeNarrator('R.C. Bray')).toBe('rc bray');
+      expect(normalizeNarrator('R. C. Bray')).toBe(normalizeNarrator('R.C. Bray'));
+    });
+
+    it('collapses a 3-initial run without touching the surname', () => {
+      // J.R.R. Tolkien — both spaced and unspaced forms reduce identically.
+      expect(normalizeNarrator('J. R. R. Tolkien')).toBe('jrr tolkien');
+      expect(normalizeNarrator('J.R.R. Tolkien')).toBe('jrr tolkien');
+    });
+
+    it('does NOT collapse a real two-word name into initials (Jo Anna)', () => {
+      expect(normalizeNarrator('Jo Anna')).toBe('jo anna');
+    });
+  });
+
+  describe('5A bare-prefix guard — never empties a token (#1655)', () => {
+    // Role-prefix strip is non-destructive: a prefix-only value normalizes to
+    // itself (non-empty), proving the placeholder/no-signal call is NOT in the
+    // global string primitive — it lives at the comparison layer (5B).
+    it('leaves a bare "Narrator" intact', () => {
+      expect(normalizeNarrator('Narrator')).toBe('narrator');
+    });
+
+    it('leaves a bare "Voice" intact', () => {
+      expect(normalizeNarrator('Voice')).toBe('voice');
+    });
+
+    it('leaves a bare "Read by" intact (prefix with no following name)', () => {
+      expect(normalizeNarrator('Read by')).toBe('read by');
+    });
+
+    it('leaves the "Author" placeholder as a non-empty token', () => {
+      expect(normalizeNarrator('Author')).toBe('author');
+    });
+
+    it('does NOT partial-match a prefix inside a longer word (word boundary)', () => {
+      // `voice` must not strip from `Voiceover`, nor `narrator` from `Narrators`.
+      expect(normalizeNarrator('Voiceover Artist')).toBe('voiceover artist');
+      expect(normalizeNarrator('Narrators Guild')).toBe('narrators guild');
+    });
+  });
 });
 
 describe('narratorsFuzzyMatch (#1650)', () => {
@@ -243,6 +308,36 @@ describe('narratorsFuzzyMatch (#1650)', () => {
     // Word-order is in scope; phonetic/abbreviation expansion is explicitly out.
     expect(narratorsFuzzyMatch('Mike', ['Michael'])).toBe(false);
   });
+
+  describe('5A noise resolves the 6 non-placeholder false positives (#1655)', () => {
+    // The UAT false-positive fixture: same person on both sides, sunk previously
+    // by tag noise the normalizer now folds. Each must fuzzy-MATCH (no cap).
+    it('initials spacing — "R. C. Bray" ↔ "R.C. Bray"', () => {
+      expect(narratorsFuzzyMatch('R. C. Bray', ['R.C. Bray'])).toBe(true);
+    });
+
+    it('role prefix with colon — "Read by: P. J. Ochlan" ↔ "P. J. Ochlan"', () => {
+      expect(narratorsFuzzyMatch('Read by: P. J. Ochlan', ['P. J. Ochlan'])).toBe(true);
+    });
+
+    it('role prefix no colon — "Read By Sissy Spacek" ↔ "Sissy Spacek"', () => {
+      expect(narratorsFuzzyMatch('Read By Sissy Spacek', ['Sissy Spacek'])).toBe(true);
+    });
+
+    it('role prefix "Narrated by" — "Narrated by Paul Boehmer" ↔ "Paul Boehmer"', () => {
+      expect(narratorsFuzzyMatch('Narrated by Paul Boehmer', ['Paul Boehmer'])).toBe(true);
+    });
+
+    it('parenthetical descriptor — "James Marsters (Spike…)" ↔ "James Marsters"', () => {
+      expect(
+        narratorsFuzzyMatch('James Marsters (Spike from Buffy The Vampire Slayer)', ['James Marsters']),
+      ).toBe(true);
+    });
+
+    it('diacritics — "Therese Plummer" ↔ "Thérèse Plummer"', () => {
+      expect(narratorsFuzzyMatch('Therese Plummer', ['Thérèse Plummer'])).toBe(true);
+    });
+  });
 });
 
 describe('compareNarratorSignals (3-state, #1650/#1652)', () => {
@@ -271,5 +366,52 @@ describe('compareNarratorSignals (3-state, #1650/#1652)', () => {
 
   it('returns "mismatch" when both sides carry signal but nothing clears the threshold', () => {
     expect(compareNarratorSignals('Adriel Brandt', ['Michael York'])).toBe('mismatch');
+  });
+
+  describe('5B placeholder denylist → "no-signal", NOT "mismatch" (#1655)', () => {
+    // Junk file tags carry no usable signal even though they normalize to a
+    // non-empty string. The two UAT placeholder fixtures plus the full denylist
+    // set must collapse to no-signal (no cap) — asserted at THIS layer, never
+    // via narratorsFuzzyMatch (which can't distinguish no-signal from mismatch).
+    it('"Multiple Readers" against a real full-cast edition is no-signal (Hyperion fixture)', () => {
+      expect(
+        compareNarratorSignals('Multiple Readers', [
+          'Marc Vietor',
+          'Allyson Johnson',
+          'Kevin Pariseau',
+          'Jay Snyder',
+          'Victor Bevine',
+        ]),
+      ).toBe('no-signal');
+    });
+
+    it('"Author" against a real narrator is no-signal (1776 fixture)', () => {
+      expect(compareNarratorSignals('Author', ['David McCullough'])).toBe('no-signal');
+    });
+
+    it('the full denylist set (incl. literal "narrator") is no-signal against a real edition', () => {
+      const denylist = [
+        'Author',
+        'Multiple Readers',
+        'Various',
+        'Various Narrators',
+        'Full Cast',
+        'Unknown',
+        'Uncredited',
+        'Narrator',
+      ];
+      for (const placeholder of denylist) {
+        expect(compareNarratorSignals(placeholder, ['David McCullough'])).toBe('no-signal');
+      }
+    });
+
+    it('drops only the placeholder token from a mixed file tag, keeping the real name', () => {
+      // `Various, Ray Porter` — `various` is dropped, `Ray Porter` still matches.
+      expect(compareNarratorSignals('Various, Ray Porter', ['Ray Porter'])).toBe('match');
+    });
+
+    it('placeholder on the EDITION side is also dropped → no-signal', () => {
+      expect(compareNarratorSignals('Ray Porter', ['Full Cast'])).toBe('no-signal');
+    });
   });
 });

--- a/src/core/utils/similarity.test.ts
+++ b/src/core/utils/similarity.test.ts
@@ -415,3 +415,64 @@ describe('compareNarratorSignals (3-state, #1650/#1652)', () => {
     });
   });
 });
+
+describe('over-reach guard — pins current behavior, NOT hardening (#1657)', () => {
+  // The 5A/5B blocks prove noise → clean. These pin that the same transforms did
+  // NOT start matching different people OR drop real names. Every assertion below
+  // is the CURRENT, verified output — a future tightening must change these on
+  // purpose, test-visibly. Behavior-changing hardening is deferred (see #1657
+  // Out of Scope).
+
+  describe('different-middle-initial — accepted collapseInitials over-match', () => {
+    // Same first-initial + same surname + 1-char-different middle initial. The
+    // word-sorted leg of nameDice clears 0.8 once collapseInitials joins the run,
+    // so these read as 'match'. This is the accepted trade-off documented on
+    // collapseInitials — pin it as a match (NOT a mismatch), so removing it later
+    // is a conscious decision.
+    it('R. C. Bray vs R. K. Bray is a match (over-match accepted)', () => {
+      expect(compareNarratorSignals('R. C. Bray', ['R. K. Bray'])).toBe('match');
+    });
+
+    it('P. J. Ochlan vs P. T. Ochlan is a match (over-match accepted)', () => {
+      expect(compareNarratorSignals('P. J. Ochlan', ['P. T. Ochlan'])).toBe('match');
+    });
+  });
+
+  describe('real name containing a denied placeholder token is KEPT', () => {
+    // The 5B denylist is exact-set membership, not substring — `Authorson`
+    // contains `author` but is real signal, never dropped.
+    it('normalizeNarrator keeps "Authorson"', () => {
+      expect(normalizeNarrator('Authorson')).toBe('authorson');
+    });
+
+    it('"Authorson" is treated as real signal and matches itself', () => {
+      expect(compareNarratorSignals('Authorson', ['Authorson'])).toBe('match');
+    });
+  });
+
+  describe('role-word-first-name — current 5A behavior (vanishingly rare)', () => {
+    // A real first name that happens to be a bare role word is consumed by the
+    // role-prefix strip. Pinned as current behavior; requiring a `by`/`:` suffix
+    // is deferred (#1657 Out of Scope).
+    it('normalizeNarrator("Voice Carter") → "carter"', () => {
+      expect(normalizeNarrator('Voice Carter')).toBe('carter');
+    });
+
+    it('normalizeNarrator("Narrator Jones") → "jones"', () => {
+      expect(normalizeNarrator('Narrator Jones')).toBe('jones');
+    });
+  });
+
+  describe('parenthetical disambiguator — current global-strip behavior', () => {
+    // normalizeNarrator strips ALL parentheticals (global /\([^)]*\)/g), trailing
+    // OR embedded. Switching to a trailing-only strip is deferred (#1657 Out of
+    // Scope) — pin the current global behavior.
+    it('strips a trailing disambiguator', () => {
+      expect(normalizeNarrator('James Marsters (Spike from Buffy)')).toBe('james marsters');
+    });
+
+    it('strips an embedded parenthetical alias too', () => {
+      expect(normalizeNarrator('Robert (Bob) Smith')).toBe('robert smith');
+    });
+  });
+});

--- a/src/core/utils/similarity.ts
+++ b/src/core/utils/similarity.ts
@@ -39,6 +39,17 @@ function foldDiacritics(s: string): string {
  * and unspaced initials converge (`r c bray` → `rc bray`). Only single-letter
  * runs join — real two-word names (`jo anna`) are untouched. Runs after
  * punctuation strip, when `R.C.`/`R. C.` have already lost their periods.
+ *
+ * ACCEPTED TRADE-OFF (#1657, do NOT "fix"): collapsing the initial run is
+ * load-bearing — it's what lets `R. C. Bray` match `R.C. Bray` across the
+ * corpus. The cost is that two genuinely different same-surname narrators whose
+ * only difference is a middle initial (`R. C. Bray` vs `R. K. Bray`,
+ * `P. J. Ochlan` vs `P. T. Ochlan`) cross the 0.8 threshold via the word-sorted
+ * leg of `nameDice` and read as `'match'`. This collision is rare (same
+ * first-initial + same surname + 1-char-different middle, two narrators of the
+ * SAME edition) and is pinned by the over-reach guard tests in
+ * `similarity.test.ts`. Removing or weakening this re-breaks the corpus; any
+ * future tightening must be a conscious, test-visible decision.
  */
 function collapseInitials(s: string): string {
   return s.replace(/\b([a-z])\s+(?=[a-z]\b)/g, '$1');
@@ -120,8 +131,17 @@ export const NARRATOR_MATCH_THRESHOLD = 0.8;
  * which is in scope. The literal `narrator` token is the seam between the two
  * layers — 5A's role-prefix strip leaves a bare `Narrator` as the string
  * `'narrator'` (direct callers unchanged), and 5B drops that token here.
+ *
+ * SINGLE HOME for the narrator-placeholder vocabulary (#1657). The metadata
+ * reject-word strip (`PSEUDO_NARRATORS` in `src/server/services/metadata.service.ts`)
+ * is a deliberately NARROWER decision (a 3-value subset) that answers a
+ * different question — "strip this fake narrator from the reject-word search
+ * surface?" rather than "does this token carry usable fuzzy-match signal?". That
+ * subset relationship is pinned by a named consistency test so the two paths
+ * can never silently diverge. Exported so the test can reference this set; do
+ * not fork a second copy of the full vocabulary.
  */
-const NARRATOR_PLACEHOLDERS = new Set([
+export const NARRATOR_PLACEHOLDERS = new Set([
   'author',
   'multiple readers',
   'various',

--- a/src/core/utils/similarity.ts
+++ b/src/core/utils/similarity.ts
@@ -8,18 +8,67 @@ export function tokenizeNarrators(raw: string): string[] {
 }
 
 /**
+ * Leading role-prefix matcher (#1655): `Read by`, `Read By`, `Narrated by`,
+ * `Narrator`, `Performed by`, `Voiced by`, `Voice`, with an optional trailing
+ * `:` and surrounding whitespace. Case-insensitive. Longer alternatives precede
+ * their prefixes (`narrated by` before `narrator`, `voiced by` before `voice`)
+ * so the alternation never short-matches.
+ */
+const ROLE_PREFIX_RE = /^(?:read by|narrated by|narrator|performed by|voiced by|voice)\b\s*:?\s*/i;
+
+/**
+ * Strip a leading role prefix, but ONLY when a non-empty name remains after it
+ * (#1655, 5A item 1 — non-destructive). `Narrated by Paul Boehmer` → name,
+ * but a bare prefix-only token (`Narrator`, `Voice`, `Read by`) is left intact
+ * so `normalizeNarrator` never collapses a placeholder to empty. The "this is a
+ * placeholder, treat as no signal" call belongs to the comparison layer (5B),
+ * not to this global string primitive.
+ */
+function stripRolePrefix(s: string): string {
+  const stripped = s.replace(ROLE_PREFIX_RE, '');
+  return stripped.trim().length > 0 ? stripped : s;
+}
+
+/** Fold diacritics (#1655, 5A item 3): NFD-decompose then drop combining marks (`Thérèse` → `Therese`). */
+function foldDiacritics(s: string): string {
+  return s.normalize('NFD').replace(/[\u0300-\u036f]/gu, '');
+}
+
+/**
+ * Collapse runs of adjacent single-letter tokens (#1655, 5A item 4) so spaced
+ * and unspaced initials converge (`r c bray` → `rc bray`). Only single-letter
+ * runs join — real two-word names (`jo anna`) are untouched. Runs after
+ * punctuation strip, when `R.C.`/`R. C.` have already lost their periods.
+ */
+function collapseInitials(s: string): string {
+  return s.replace(/\b([a-z])\s+(?=[a-z]\b)/g, '$1');
+}
+
+/**
  * Normalize a single narrator name token for comparison.
- * 1. Trim and lowercase
- * 2. Strip punctuation (periods, quotes, hyphens, etc.) — NOT commas/semicolons/ampersands (delimiters)
- * 3. Collapse whitespace
+ *
+ * Order is load-bearing — do NOT reshuffle (#1655):
+ *  1. Parenthetical strip + role-prefix strip run on the raw-ish string, before
+ *     punctuation strip would fragment the prefix/parens.
+ *  2. lowercase → punctuation strip (periods, quotes, hyphens; NOT
+ *     commas/semicolons/ampersands, which are delimiters) → collapse whitespace.
+ *  3. Diacritic fold + initials canonicalization run AFTER punctuation strip
+ *     (the initials collapse needs the periods gone so `R.C.`/`R. C.` converge).
+ *
+ * These are pure string-cleaning transforms shared by every consumer
+ * (library-import cap, tag-author dice, quality-gate set-membership). They never
+ * empty a token — the placeholder/no-signal semantic lives in the comparison
+ * layer's token builders (5B), not here.
  */
 export function normalizeNarrator(name: string): string {
-  return name
-    .trim()
+  const deparened = name.replace(/\([^)]*\)/g, ' ').trim();
+  const deprefixed = stripRolePrefix(deparened);
+  const punctStripped = deprefixed
     .toLowerCase()
     .replace(/[.!?'"-]/g, '')
     .replace(/\s+/g, ' ')
     .trim();
+  return collapseInitials(foldDiacritics(punctStripped));
 }
 
 /**
@@ -59,15 +108,44 @@ export function diceCoefficient(a: string, b: string): number {
  */
 export const NARRATOR_MATCH_THRESHOLD = 0.8;
 
-/** Normalized, non-empty file-narrator tokens: split on delimiters → normalize → drop empties. */
-function fileNarratorTokens(raw: string | undefined): string[] {
-  if (!raw) return [];
-  return tokenizeNarrators(raw).map(normalizeNarrator).filter(Boolean);
+/**
+ * Placeholder narrator tokens (#1655, 5B): values that carry NO usable narrator
+ * signal even though they normalize to a non-empty string. Literal, already in
+ * `normalizeNarrator` output form. This denylist lives at the comparison layer
+ * ONLY — dropping these from the signal token set collapses to the existing
+ * empty-tokens → `'no-signal'` path, extending the #1652 "no signal ≠ mismatch"
+ * principle from *empty* tags to *junk* tags. It is intentionally NOT in
+ * `normalizeNarrator`: doing so would zero a legitimate `Author` author-dice in
+ * tag-author scoring and silently change quality-gate set membership, neither of
+ * which is in scope. The literal `narrator` token is the seam between the two
+ * layers — 5A's role-prefix strip leaves a bare `Narrator` as the string
+ * `'narrator'` (direct callers unchanged), and 5B drops that token here.
+ */
+const NARRATOR_PLACEHOLDERS = new Set([
+  'author',
+  'multiple readers',
+  'various',
+  'various narrators',
+  'full cast',
+  'unknown',
+  'uncredited',
+  'narrator',
+]);
+
+/** A normalized token carries usable narrator signal when it is non-empty and not a placeholder. */
+function isSignalToken(normalized: string): boolean {
+  return normalized.length > 0 && !NARRATOR_PLACEHOLDERS.has(normalized);
 }
 
-/** Normalized, non-empty edition-narrator tokens: normalize each entry → drop empties. */
+/** Usable file-narrator signal tokens: split on delimiters → normalize → drop empties and placeholders. */
+function fileNarratorTokens(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return tokenizeNarrators(raw).map(normalizeNarrator).filter(isSignalToken);
+}
+
+/** Usable edition-narrator signal tokens: normalize each entry → drop empties and placeholders. */
 function editionNarratorTokens(narrators: string[] | undefined): string[] {
-  return (narrators ?? []).map(normalizeNarrator).filter(Boolean);
+  return (narrators ?? []).map(normalizeNarrator).filter(isSignalToken);
 }
 
 /** Sort a name's whitespace-separated words so word order can't sink the dice score. */
@@ -95,11 +173,13 @@ function nameDice(a: string, b: string): number {
  * definition. This lives in core because core production code cannot import
  * `src/server/**` (layer guard) — server helpers import this.
  *
- * - `'no-signal'` — either side normalizes to no usable tokens (absent file
- *   tag, empty edition list, or punctuation-only entries like `'-'`/`'.'` that
- *   `normalizeNarrator` strips to empty). This is the fix for #1652: signal
- *   presence is judged AFTER normalization on both sides, so the helper and the
- *   primitive can no longer disagree about emptiness.
+ * - `'no-signal'` — either side normalizes to no usable tokens: an absent file
+ *   tag, an empty edition list, punctuation-only entries like `'-'`/`'.'` that
+ *   `normalizeNarrator` strips to empty (#1652), or placeholder tokens like
+ *   `Multiple Readers`/`Author`/`narrator` that the token builders drop as junk
+ *   (#1655, 5B). This is the fix for #1652: signal presence is judged AFTER
+ *   normalization on both sides, so the helper and the primitive can no longer
+ *   disagree about emptiness.
  * - `'match'` — set-overlap: a single pairwise hit at or above `threshold` is
  *   enough (multi-narrator / full-cast editions match when ANY file token lines
  *   up with ANY edition narrator).

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -286,6 +286,23 @@ describe('rankResultsCleaned', () => {
     const ranked = rankResultsCleaned([actI, actIII, actII], { title: 'The Sandman: Act II', author: 'Neil Gaiman' });
     expect(ranked[0]!.meta.title).toBe('The Sandman: Act II');
   });
+
+  // #1655 F1 — the 5B placeholder denylist lives at the comparison layer, NOT in
+  // normalizeNarrator. So tag-author scoring (a DIRECT normalizeNarrator caller)
+  // is unaffected: a placeholder-looking author value is NOT zeroed.
+  it('does NOT zero a placeholder-looking author value ("Author") — 5B is comparison-only', () => {
+    const book = makeBook({ title: 'Some Memoir', authors: [{ name: 'Author' }] });
+    const ranked = rankResultsCleaned([book], { title: 'Some Memoir', author: 'Author' });
+    // If the denylist had leaked into normalizeNarrator, the author dice would be
+    // 0 (empty vs empty) and the score would drop to the title-only weight.
+    expect(ranked[0]!.score).toBeCloseTo(1.0, 5);
+  });
+
+  it('#1655 5A: a "Read by …" / diacritic author normalizes without regression in tag-author scoring', () => {
+    const book = makeBook({ title: 'Memoir', authors: [{ name: 'Thérèse Plummer' }] });
+    const ranked = rankResultsCleaned([book], { title: 'Memoir', author: 'Therese Plummer' });
+    expect(ranked[0]!.score).toBeCloseTo(1.0, 5);
+  });
 });
 
 // ============================================================================
@@ -674,6 +691,32 @@ describe('narratorMismatchReason', () => {
     expect(reason).toContain('Narrator mismatch');
     expect(reason).toContain('Jane Doe');
     expect(reason).toContain('John Smith');
+  });
+
+  // The complete #1655 UAT false-positive fixture: each was a high-confidence
+  // library-import match wrongly capped to Review by tag noise. After hardening,
+  // every one must return null (no reason emitted → no cap → stays high).
+  describe('#1655 UAT false-positive fixture — all 8 resolve null (no cap)', () => {
+    const fixture: Array<[book: string, tag: string, edition: string[]]> = [
+      ['Zero Hour', 'R. C. Bray', ['R.C. Bray']],
+      ["Death's End", 'Read by: P. J. Ochlan', ['P. J. Ochlan']],
+      ['To Kill a Mockingbird', 'Read By Sissy Spacek', ['Sissy Spacek']],
+      ["The Farseer: Assassin's Apprentice", 'Narrated by Paul Boehmer', ['Paul Boehmer']],
+      ['Storm Front', 'James Marsters (Spike from Buffy The Vampire Slayer)', ['James Marsters']],
+      ['Shelter Mountain', 'Therese Plummer', ['Thérèse Plummer']],
+      ['Hyperion', 'Multiple Readers', ['Marc Vietor', 'Allyson Johnson', 'Kevin Pariseau', 'Jay Snyder', 'Victor Bevine']],
+      ['1776', 'Author', ['David McCullough']],
+    ];
+    it.each(fixture)('%s — tag "%s" no longer caps', (_book, tag, edition) => {
+      expect(narratorMismatchReason(tag, edition)).toBeNull();
+    });
+  });
+
+  it('control: a genuinely different real narrator still returns a reason (real catch preserved)', () => {
+    const reason = narratorMismatchReason('Scott Brick', ['R.C. Bray']);
+    expect(reason).toContain('Narrator mismatch');
+    expect(reason).toContain('Scott Brick');
+    expect(reason).toContain('R.C. Bray');
   });
 });
 

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -3270,6 +3270,54 @@ describe('MatchJobService', () => {
       expect(result.reason).toBeUndefined();
     });
 
+    // #1655: the complete UAT false-positive fixture, end-to-end. Each was a
+    // high-confidence library-import match wrongly demoted to Review by tag
+    // noise the normalizer now folds (6 string-noise cases) or by placeholder
+    // junk the comparison layer now drops as no-signal (2 placeholder cases).
+    describe('#1655 UAT false-positive fixture resolves high (no cap)', () => {
+      const fixture = [
+        { title: 'Zero Hour', author: 'Joshua Dalzelle', tag: 'R. C. Bray', edition: ['R.C. Bray'] },
+        { title: "Death's End", author: 'Cixin Liu', tag: 'Read by: P. J. Ochlan', edition: ['P. J. Ochlan'] },
+        { title: 'To Kill a Mockingbird', author: 'Harper Lee', tag: 'Read By Sissy Spacek', edition: ['Sissy Spacek'] },
+        { title: "Assassin's Apprentice", author: 'Robin Hobb', tag: 'Narrated by Paul Boehmer', edition: ['Paul Boehmer'] },
+        { title: 'Storm Front', author: 'Jim Butcher', tag: 'James Marsters (Spike from Buffy The Vampire Slayer)', edition: ['James Marsters'] },
+        { title: 'Shelter Mountain', author: 'Robyn Carr', tag: 'Therese Plummer', edition: ['Thérèse Plummer'] },
+        { title: 'Hyperion', author: 'Dan Simmons', tag: 'Multiple Readers', edition: ['Marc Vietor', 'Allyson Johnson', 'Kevin Pariseau', 'Jay Snyder', 'Victor Bevine'] },
+        { title: '1776', author: 'David McCullough', tag: 'Author', edition: ['David McCullough'] },
+      ];
+
+      it.each(fixture)('$title — tag "$tag" stays high (no cap)', async ({ title, author, tag, edition }) => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeNarratorScan({ tagTitle: title, tagAuthor: author, tagNarrator: tag }),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title, authors: [{ name: author }], narrators: edition, asin: 'B0FIXTURE1' }),
+        ]);
+
+        const id = service.createJob([{ path: `/audiobooks/${title}`, title, author }]);
+        await waitForJob(service, id);
+        const result = service.getJob(id)!.results[0]!;
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+      });
+
+      it('control: a genuinely different real narrator still caps high → medium', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeNarratorScan({ tagTitle: 'Zero Hour', tagAuthor: 'Joshua Dalzelle', tagNarrator: 'Scott Brick' }),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title: 'Zero Hour', authors: [{ name: 'Joshua Dalzelle' }], narrators: ['R.C. Bray'], asin: 'B0FIXTURE2' }),
+        ]);
+
+        const id = service.createJob([{ path: '/audiobooks/Zero Hour', title: 'Zero Hour', author: 'Joshua Dalzelle' }]);
+        await waitForJob(service, id);
+        const result = service.getJob(id)!.results[0]!;
+        expect(result.confidence).toBe('medium');
+        expect(result.reason).toContain('Narrator mismatch');
+        expect(result.reason).toContain('Scott Brick');
+      });
+    });
+
     it('multi-narrator edition: no cap when any file narrator overlaps the cast', async () => {
       vi.mocked(scanAudioDirectory).mockResolvedValue(
         makeNarratorScan({ tagTitle: 'Slaughterhouse-Five', tagAuthor: 'Kurt Vonnegut', tagNarrator: 'Ethan Hawke' }),

--- a/src/server/services/metadata.service.test.ts
+++ b/src/server/services/metadata.service.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { RateLimitError, TransientError, METADATA_SEARCH_PROVIDER_FACTORIES } from '../../core/index.js';
+import { RateLimitError, TransientError, METADATA_SEARCH_PROVIDER_FACTORIES, NARRATOR_PLACEHOLDERS } from '../../core/index.js';
 import { createMockLogger, inject } from '../__tests__/helpers.js';
 import type { FastifyBaseLogger } from 'fastify';
-import { MetadataService, isRejectedByWords } from './metadata.service.js';
+import { MetadataService, isRejectedByWords, PSEUDO_NARRATORS } from './metadata.service.js';
 import type { BookMetadata } from '../../core/index.js';
 
 const mockFactories = vi.mocked(METADATA_SEARCH_PROVIDER_FACTORIES);
@@ -2370,5 +2370,27 @@ describe('MetadataService.resolveBook', () => {
       service.resolveBook({ title: 'Words of Radiance', author: 'Brandon Sanderson' }),
     ).rejects.toBeInstanceOf(RateLimitError);
     expect(mockAudibleProvider.searchBooks).not.toHaveBeenCalled();
+  });
+});
+
+describe('narrator-placeholder vocabulary subset consistency (#1657)', () => {
+  // PSEUDO_NARRATORS (the reject-word strip in this service) and
+  // NARRATOR_PLACEHOLDERS (the fuzzy-match no-signal vocabulary, the single home
+  // in src/core/utils/similarity.ts) are two DISTINCT decisions that overlap.
+  // The reject-word strip is intentionally NARROWER — a strict subset. Pinning
+  // that subset relationship here means adding a junk value to the shared core
+  // vocabulary can never make the two paths silently disagree; widening
+  // PSEUDO_NARRATORS to the full set (a runtime change, out of scope for #1657)
+  // would still satisfy the subset, but the explicit current-value assertion
+  // below guards that the reject-word set stays its current 3 values.
+
+  it('PSEUDO_NARRATORS ⊆ NARRATOR_PLACEHOLDERS (every reject-word marker is a known placeholder)', () => {
+    for (const marker of PSEUDO_NARRATORS) {
+      expect(NARRATOR_PLACEHOLDERS.has(marker)).toBe(true);
+    }
+  });
+
+  it('PSEUDO_NARRATORS stays its current narrow 3-value reject-word set (behavior unchanged)', () => {
+    expect([...PSEUDO_NARRATORS].sort()).toEqual(['full cast', 'unknown', 'various']);
   });
 });

--- a/src/server/services/metadata.service.ts
+++ b/src/server/services/metadata.service.ts
@@ -47,7 +47,22 @@ export interface MetadataServiceConfig {
   audibleRegion?: string;
 }
 
-const PSEUDO_NARRATORS = new Set(['full cast', 'various', 'unknown']);
+/**
+ * Pseudo-narrator markers stripped from the reject-word search surface before
+ * `matchesWord` (#1032). Answers "should this fake narrator be removed from the
+ * reject-word surface?" — a DIFFERENT question from the fuzzy-match no-signal
+ * decision in `NARRATOR_PLACEHOLDERS` (`src/core/utils/similarity.ts`), the
+ * single home for the full narrator-placeholder vocabulary (#1657).
+ *
+ * This set is intentionally NARROWER (a strict subset): widening it to the full
+ * 8-value vocabulary would change `isRejectedByWords` at runtime — e.g.
+ * stripping `Author`/`Multiple Readers`/`uncredited`/`narrator` from the
+ * reject-word surface — which is out of scope. The subset relationship
+ * (`PSEUDO_NARRATORS ⊆ NARRATOR_PLACEHOLDERS`) is pinned by a named consistency
+ * test in `metadata.service.test.ts`, so adding a junk value to the shared
+ * vocabulary can never make the two paths silently disagree.
+ */
+export const PSEUDO_NARRATORS = new Set(['full cast', 'various', 'unknown']);
 
 function isPseudoNarrator(name: string): boolean {
   return PSEUDO_NARRATORS.has(name.trim().toLowerCase().replace(/\s+/g, ' '));

--- a/src/server/services/quality-gate.helpers.test.ts
+++ b/src/server/services/quality-gate.helpers.test.ts
@@ -107,6 +107,35 @@ describe('buildQualityAssessment — existing audio metadata fields', () => {
   });
 });
 
+describe('buildQualityAssessment — narrator_mismatch (#1655 5A/5B surface checks)', () => {
+  // Quality-gate uses EXACT normalized set membership (not the fuzzy cap path),
+  // and is a DIRECT normalizeNarrator caller. 5A's string-cleaning reaches it
+  // (intended: fewer spurious holds); 5B's placeholder denylist does NOT.
+
+  it('5A: same person modulo role-prefix noise no longer holds (Read by: P. J. Ochlan ↔ P. J. Ochlan)', () => {
+    const book = { ...baseBook, narrators: [{ name: 'P. J. Ochlan' }] };
+    const scan = { ...baseScan, tagNarrator: 'Read by: P. J. Ochlan' };
+    const result = buildQualityAssessment(scan, book);
+    expect(result.holdReasons).not.toContain('narrator_mismatch');
+  });
+
+  it('control: a genuinely different existing narrator still holds', () => {
+    // baseBook narrator is John Smith.
+    const scan = { ...baseScan, tagNarrator: 'Jane Doe' };
+    const result = buildQualityAssessment(scan, baseBook);
+    expect(result.holdReasons).toContain('narrator_mismatch');
+  });
+
+  it('5B placeholder is NOT applied here: "Author" tag vs a real existing narrator still holds (unchanged)', () => {
+    // The 5B denylist lives at the comparison layer only. At quality-gate,
+    // `Author` normalizes to the non-empty token `author` and is compared
+    // exactly — exactly as before 5B existed.
+    const scan = { ...baseScan, tagNarrator: 'Author' };
+    const result = buildQualityAssessment(scan, baseBook);
+    expect(result.holdReasons).toContain('narrator_mismatch');
+  });
+});
+
 describe('buildQualityAssessment — resolveBookQualityInputs caching', () => {
   it('calls resolveBookQualityInputs exactly once when book has path (upgrade scenario)', () => {
     const spy = vi.spyOn(qualityModule, 'resolveBookQualityInputs');

--- a/src/server/services/search-pipeline.test.ts
+++ b/src/server/services/search-pipeline.test.ts
@@ -2428,6 +2428,20 @@ describe('filterAndRankResults — narrator priority', () => {
       expect(results[0]!.title).toBe('B');
     });
 
+    it('#1655 5B: a placeholder book narrator ("Full Cast") creates NO narrator-priority boost', () => {
+      // Search ranking shares the comparison path with the import cap, so the 5B
+      // placeholder denylist applies here too — `Full Cast` carries no signal,
+      // so the placeholder "match" loses to a higher-quality non-match.
+      const placeholderMatch = makeResult({ narrator: 'Full Cast', size: sizeForMbhr(79), matchScore: 0.9, title: 'Placeholder' });
+      const goodNoMatch = makeResult({ narrator: 'Someone Else', size: sizeForMbhr(200), matchScore: 0.9, title: 'NoMatch' });
+      const { results } = filterAndRankResults(
+        [placeholderMatch, goodNoMatch],
+        BOOK_DURATION,
+        { grabFloor: 0, minSeeders: 1, protocolPreference: 'none', languages: [], narratorPriority: { bookNarrators: ['Full Cast'] } },
+      );
+      expect(results[0]!.title).toBe('NoMatch');
+    });
+
     it('unknown quality narrator-match beats known Good quality non-match', () => {
       // No size = unknown quality, should still be eligible for narrator boost
       const unknownMatch = makeResult({ narrator: 'Kevin R. Free', size: undefined, matchScore: 0.9, title: 'Match' });


### PR DESCRIPTION
## Release: develop → main — narrator-fix re-UAT candidate

Carries the two commits landed on `develop` since the last release merge (#1654):

- **#1655** — Harden narrator-mismatch normalization: kills the 8 UAT false positives (role-prefix variants, parentheticals, diacritics, initials spacing, placeholder tags like `Author` / `Multiple Readers`) while **preserving real wrong-edition catches**. All 8 are locked as a regression fixture; the cap stays net-positive.
- **#1657** — Polish: pin the `collapseInitials` trade-off with boundary tests, resolve the `NARRATOR_PLACEHOLDERS` ↔ `PSEUDO_NARRATORS` DRY-3 via a named consistency test (subset invariant), add over-reach guard tests. Behavior-neutral.

`v0.9.2` is tagged from `main` after this merges → the re-UAT image for the narrator fix.
