### PR TITLE
#1752 POSIX-fold findPathOwners lookup key so the collision fence matches on Windows

### DIFF
--- a/src/server/services/book-dedup.ts
+++ b/src/server/services/book-dedup.ts
@@ -220,9 +220,17 @@ export async function resolveDuplicate(db: Db, getById: GetByIdFn, candidate: Du
  * Return EVERY library row whose stored `path` equals the given normalized path
  * (#1711) — the cardinality input for the occupied-target collision fence.
  * `books.path` is indexed but NOT unique, so callers branch on 0 / 1 / 2+.
+ *
+ * `books.path` is stored in POSIX form (`buildTargetPath` emits forward slashes so
+ * the library DB is portable across the Linux runtime and Windows dev boxes). Callers
+ * pass `normalize(resolve(...))`, which is backslash-separated on Windows — so the
+ * exact-match `eq` below would MISS the row there (0 owners → a same-recording
+ * re-import wrongly disambiguates into a new `(edition)` folder instead of a staged
+ * swap). POSIX-fold the key so the comparison is POSIX-vs-POSIX on every platform (#1752).
  */
 export async function findPathOwners(db: Db, getById: GetByIdFn, normalizedPath: string): Promise<BookWithAuthor[]> {
-  const rows = await db.select({ id: books.id }).from(books).where(eq(books.path, normalizedPath));
+  const posixPath = normalizedPath.split('\\').join('/');
+  const rows = await db.select({ id: books.id }).from(books).where(eq(books.path, posixPath));
   const owners: BookWithAuthor[] = [];
   for (const r of rows) {
     const book = await getById(r.id);

--- a/src/server/services/import-orchestration.helpers.test.ts
+++ b/src/server/services/import-orchestration.helpers.test.ts
@@ -1814,11 +1814,12 @@ describe('copyToLibrary — cross-row collision fence (#1711)', () => {
 // AC: a NON-MOCKED findPathOwners must resolve a real `books` row through the fence call site.
 // All other fence suites inject findPathOwners as a mock, so the actual eq(books.path, …) query
 // is never exercised end-to-end. Here `bookService` is a REAL BookService over a real libSQL DB
-// (prior art: book.service.dedup.integration.test.ts). This is a POSIX/Linux happy-path test —
-// CI is Linux, where normalize(resolve(target)) is forward-slash and matches the stored POSIX
-// path. The Windows separator divergence at the call site is a separate `type/defect` (#1737),
-// NOT asserted here.
-describe('copyToLibrary — non-mocked findPathOwners through the fence (real DB, #1737)', () => {
+// (prior art: book.service.dedup.integration.test.ts). `findPathOwners` now POSIX-folds its key
+// (#1752), so this passes on BOTH Linux (CI) and Windows dev — where normalize(resolve(target))
+// is backslash-separated and previously missed the stored POSIX path (0 owners → wrong
+// disambiguation). The final `it` below pins that cross-platform fold with a literal-backslash
+// query, so it guards the fix on Linux CI too.
+describe('copyToLibrary — non-mocked findPathOwners through the fence (real DB, #1737/#1752)', () => {
   let baseDir: string;
   let libraryRoot: string;
   let source: string;
@@ -1888,5 +1889,20 @@ describe('copyToLibrary — non-mocked findPathOwners through the fence (real DB
     // The staged swap replaced the incumbent audio in the base folder — no disambiguated sibling.
     expect((await readdir(target)).sort()).toEqual(['new.mp3']);
     expect(await pathExists(join(libraryRoot, 'Author', 'Title (Stephen Fry)'))).toBe(false);
+  });
+
+  // #1752 regression, platform-INDEPENDENT: findPathOwners must match a POSIX-stored `books.path`
+  // even when queried with a Windows backslash separator (the shape normalize(resolve(...)) yields
+  // on Windows). Uses literal strings so it exercises the POSIX fold on Linux CI too — remove the
+  // fold in findPathOwners and this goes red regardless of host OS.
+  it('findPathOwners folds a backslash query key to POSIX so it still matches the stored path (#1752)', async () => {
+    const seeded = await bookService.create({ title: 'Title', authors: [{ name: 'Author' }], asin: 'B0FOLD', status: 'imported' });
+    await bookService.update(seeded.id, { path: '/library/Author/Title' });
+
+    const owners = await bookService.findPathOwners('\\library\\Author\\Title');
+    expect(owners.map(o => o.id)).toEqual([seeded.id]);
+
+    // A genuinely different POSIX path still misses (the fold doesn't over-match).
+    expect(await bookService.findPathOwners('\\library\\Author\\Other')).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem
`books.path` is stored in POSIX form (`buildTargetPath` emits forward slashes so the library DB is portable across the Linux runtime and Windows dev boxes). The occupied-target collision fence (`resolveOccupiedTarget` / `disambiguateTarget`) queried `findPathOwners(normalize(resolve(...)))`, which is **backslash-separated on Windows**. The exact `eq(books.path, key)` therefore missed the row (0 owners) on Windows, so a same-recording re-import wrongly disambiguated into a new `(edition)` folder instead of a staged swap.

In production (Docker/Linux) `normalize(resolve(...))` is already forward-slash so this never bit prod — it only failed on Windows dev, where the real-DB fence test (`#1737`) was effectively un-runnable green.

## Fix
POSIX-fold the query key inside `findPathOwners` (single home; the function that owns the `books.path` comparison), so the compare is POSIX-vs-POSIX on every platform.

## Tests
- Un-skips the real-DB fence test on Windows (now 74/74 in `import-orchestration.helpers.test.ts` locally on Windows; was 73/74).
- Adds a **platform-independent** regression test: a literal-backslash query against a POSIX-stored path must still match (and a genuinely different path must still miss) — guards the fold on Linux CI too.
- `lint`, `typecheck`, `build` green locally; affected suites green.

Closes #1752