### PR TITLE
Release: develop → main (#1829 Detailed preset edition token)

### DIFF
--- a/src/client/pages/SettingsPage.test.tsx
+++ b/src/client/pages/SettingsPage.test.tsx
@@ -677,4 +677,24 @@ describe('SettingsPage - {edition} file preview row (#1819, real @core/utils)', 
     expect(screen.getAllByTestId('preview-file-edition')).toHaveLength(1);
     expect(screen.getAllByTestId('preview-multi-edition')).toHaveLength(1);
   });
+
+  // #1829 — the Detailed preset's fileFormat now carries { (?edition?)}, so choosing the
+  // preset (not just hand-typing the token) flips the row from the capability hint to a
+  // real rendered filename. SAMPLE_TOKENS has no trackNumber, so no ordinal renders.
+  it('selecting the Detailed preset flips the file edition row from the hint to a rendered filename (#1829)', async () => {
+    const user = userEvent.setup();
+    renderSettingsPage('/settings');
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'File Naming' })).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-file-edition').textContent).toMatch(/Add \{edition\}/);
+    });
+    await user.selectOptions(screen.getByLabelText('Preset'), 'detailed');
+    await waitFor(() => {
+      expect(screen.getByTestId('preview-file-edition').textContent).toBe(
+        'Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings (Full Cast).m4b',
+      );
+    });
+  });
 });

--- a/src/core/utils/naming-presets.test.ts
+++ b/src/core/utils/naming-presets.test.ts
@@ -20,7 +20,7 @@ describe('NAMING_PRESETS', () => {
     expect(preset).toBeDefined();
     expect(preset!.name).toBe('Detailed');
     expect(preset!.folderFormat).toBe('{author}/{series}/{seriesPosition:00? - }{title}');
-    expect(preset!.fileFormat).toBe('{author} - {series? - }{seriesPosition:00? - }{title} {- ?trackNumber:000}');
+    expect(preset!.fileFormat).toBe('{author} - {series? - }{seriesPosition:00? - }{title}{ (?edition?)}{ - ?trackNumber:000}');
   });
 
   it('contains Audiobookshelf preset with correct formats', () => {
@@ -101,16 +101,69 @@ describe('Plex preset with prefix conditional syntax', () => {
   });
 });
 
+describe('Detailed preset {edition} in fileFormat (#1829)', () => {
+  const DETAILED_FILE = NAMING_PRESETS.find(p => p.id === 'detailed')!.fileFormat;
+  const OLD_DETAILED_FILE = '{author} - {series? - }{seriesPosition:00? - }{title} {- ?trackNumber:000}';
+  const base = {
+    author: 'Brandon Sanderson', title: 'The Way of Kings',
+    series: 'The Stormlight Archive', seriesPosition: 1,
+  };
+
+  it('renders the edition parenthetical before the track ordinal (multi-file)', () => {
+    expect(renderFilename(DETAILED_FILE, { ...base, edition: 'Full Cast', trackNumber: 1, trackTotal: 12 }))
+      .toBe('Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings (Full Cast) - 001');
+  });
+
+  it('renders the edition parenthetical with no trailing artifacts (single file, no track tokens)', () => {
+    expect(renderFilename(DETAILED_FILE, { ...base, edition: 'Full Cast' }))
+      .toBe('Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings (Full Cast)');
+  });
+
+  // No-edition parity: BOTH template deltas ({ (?edition?)} and folding the track
+  // separator space into the conditional prefix) must be pure no-ops when no edition
+  // exists — byte-identical to the pre-#1829 template. The {series? - } and
+  // {seriesPosition:00? - } branches are where whitespace regressions hide.
+  const parityCases: [string, Record<string, string | number | undefined>][] = [
+    ['full metadata, multi-file', { ...base, trackNumber: 1, trackTotal: 12 }],
+    ['full metadata, single-file', { ...base }],
+    ['no series, multi-file', { author: base.author, title: base.title, trackNumber: 2, trackTotal: 3 }],
+    ['no seriesPosition, single-file', { author: base.author, title: base.title, series: base.series }],
+  ];
+  for (const [label, tokens] of parityCases) {
+    it(`renders byte-identical to the pre-edition template with no edition (${label})`, () => {
+      expect(renderFilename(DETAILED_FILE, tokens)).toBe(renderFilename(OLD_DETAILED_FILE, tokens));
+    });
+  }
+
+  it('treats an empty-string edition as absent (parity with the pre-edition template)', () => {
+    const tokens = { ...base, edition: '', trackNumber: 1, trackTotal: 12 };
+    expect(renderFilename(DETAILED_FILE, tokens)).toBe(renderFilename(OLD_DETAILED_FILE, tokens));
+  });
+
+  // F8: unlike the folder {edition} (verbatim), the file-side edition takes the
+  // separator transform like any other token — pin it so the behavior is explicit.
+  it('applies the separator transform to the file-side edition value (period separator)', () => {
+    expect(renderFilename(DETAILED_FILE, { ...base, edition: 'Full Cast', trackNumber: 1, trackTotal: 12 }, { separator: 'period' }))
+      .toBe('Brandon.Sanderson - The.Stormlight.Archive - 01 - The.Way.of.Kings (Full.Cast) - 001');
+  });
+});
+
 describe('detectPreset', () => {
   it('returns preset id when both fields match a defined preset', () => {
     expect(detectPreset('{author}/{title}', '{author} - {title}')).toBe('standard');
-    expect(detectPreset('{author}/{series}/{seriesPosition:00? - }{title}', '{author} - {series? - }{seriesPosition:00? - }{title} {- ?trackNumber:000}')).toBe('detailed');
+    expect(detectPreset('{author}/{series}/{seriesPosition:00? - }{title}', '{author} - {series? - }{seriesPosition:00? - }{title}{ (?edition?)}{ - ?trackNumber:000}')).toBe('detailed');
     expect(detectPreset('{author}/{series?/}{title}', '{title}')).toBe('audiobookshelf');
     expect(detectPreset('{authorLastFirst}/{titleSort}', '{authorLastFirst} - {titleSort}')).toBe('last-first');
   });
 
   it('returns "custom" when only folderFormat matches', () => {
     expect(detectPreset('{author}/{title}', '{title}')).toBe('custom');
+  });
+
+  // #1829 — saved templates from before the edition token was added to the Detailed
+  // fileFormat flip to Custom (cosmetic only; their rendering is unchanged, no migration).
+  it('detects the pre-edition Detailed fileFormat as "custom"', () => {
+    expect(detectPreset('{author}/{series}/{seriesPosition:00? - }{title}', '{author} - {series? - }{seriesPosition:00? - }{title} {- ?trackNumber:000}')).toBe('custom');
   });
 
   it('returns "custom" when only fileFormat matches', () => {

--- a/src/core/utils/naming-presets.ts
+++ b/src/core/utils/naming-presets.ts
@@ -16,7 +16,7 @@ export const NAMING_PRESETS: readonly NamingPreset[] = [
     id: 'detailed',
     name: 'Detailed',
     folderFormat: '{author}/{series}/{seriesPosition:00? - }{title}',
-    fileFormat: '{author} - {series? - }{seriesPosition:00? - }{title} {- ?trackNumber:000}',
+    fileFormat: '{author} - {series? - }{seriesPosition:00? - }{title}{ (?edition?)}{ - ?trackNumber:000}',
   },
   {
     id: 'audiobookshelf',

--- a/src/server/utils/paths.test.ts
+++ b/src/server/utils/paths.test.ts
@@ -566,6 +566,62 @@ describe('planFileRenames', () => {
     });
   });
 
+  describe('Detailed preset fileFormat with {edition} (#1829)', () => {
+    const DETAILED_FILE = '{author} - {series? - }{seriesPosition:00? - }{title}{ (?edition?)}{ - ?trackNumber:000}';
+    const OLD_DETAILED_FILE = '{author} - {series? - }{seriesPosition:00? - }{title} {- ?trackNumber:000}';
+    const seriesBook: RenameableBook = {
+      ...book,
+      title: 'The Way of Kings',
+      seriesName: 'The Stormlight Archive',
+      seriesPosition: 1,
+    };
+
+    it('multi-file with edition: parenthetical before the track ordinal', async () => {
+      await mockFiles(['a.mp3', 'b.mp3']);
+      const renames = await planFileRenames('/t', DETAILED_FILE, { ...seriesBook, editionLabel: 'Full Cast' }, 'Brandon Sanderson');
+      expect(renames.map(r => r.to)).toEqual([
+        'Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings (Full Cast) - 001.mp3',
+        'Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings (Full Cast) - 002.mp3',
+      ]);
+    });
+
+    it('single file with edition: no track ordinal, no trailing artifacts', async () => {
+      await mockFiles(['audiobook.mp3']);
+      const renames = await planFileRenames('/t', DETAILED_FILE, { ...seriesBook, editionLabel: 'Full Cast' }, 'Brandon Sanderson');
+      expect(renames).toEqual([
+        { from: 'audiobook.mp3', to: 'Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings (Full Cast).mp3' },
+      ]);
+    });
+
+    // No-edition parity: the new template must plan the exact same renames as the
+    // pre-#1829 template, across the conditional branches (no series / no position).
+    const parityBooks: [string, RenameableBook][] = [
+      ['full series metadata', seriesBook],
+      ['no series', { ...seriesBook, seriesName: null, seriesPosition: null }],
+      ['series without position', { ...seriesBook, seriesPosition: null }],
+    ];
+    for (const [label, parityBook] of parityBooks) {
+      it(`no edition (null): plans identical renames to the pre-edition template (${label})`, async () => {
+        await mockFiles(['a.mp3', 'b.mp3']);
+        const next = await planFileRenames('/t', DETAILED_FILE, { ...parityBook, editionLabel: null }, 'Brandon Sanderson');
+        await mockFiles(['a.mp3', 'b.mp3']);
+        const prev = await planFileRenames('/t', OLD_DETAILED_FILE, { ...parityBook, editionLabel: null }, 'Brandon Sanderson');
+        expect(next).toEqual(prev);
+      });
+    }
+
+    // planFileRenames passes editionLabel through un-normalized; the renderer treats
+    // '' as absent (EMPTY_TOKEN_SENTINEL), so an empty label must behave like null.
+    it('empty-string editionLabel behaves like null (parity with the pre-edition template)', async () => {
+      await mockFiles(['audiobook.mp3']);
+      const next = await planFileRenames('/t', DETAILED_FILE, { ...seriesBook, editionLabel: '' }, 'Brandon Sanderson');
+      await mockFiles(['audiobook.mp3']);
+      const prev = await planFileRenames('/t', OLD_DETAILED_FILE, { ...seriesBook, editionLabel: '' }, 'Brandon Sanderson');
+      expect(next).toEqual(prev);
+      expect(next[0]!.to).toBe('Brandon Sanderson - The Stormlight Archive - 01 - The Way of Kings.mp3');
+    });
+  });
+
   describe('ordering source', () => {
     it('does not import metadata/tag readers on the rename path (filenames only, no ID3)', async () => {
       const { readFile } = await import('node:fs/promises');


### PR DESCRIPTION
Single-commit catch-up: #1829 — add `{ (?edition?)}` to the Detailed naming preset's file format so two editions of the same book no longer render byte-identical filenames. Preset string + pinning tests only; folder format and renderer untouched. Old saved Detailed templates detect as Custom (cosmetic, no migration).