### PR TITLE
Release: develop → main (#1831 chunked import + #1833 hardening)

### DIFF
--- a/src/client/hooks/useMatchJob.test.ts
+++ b/src/client/hooks/useMatchJob.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useMatchJob } from './useMatchJob';
-import type { MatchJobStatus } from '@/lib/api';
+import { useMatchJob, packMatchCandidates } from './useMatchJob';
+import type { MatchCandidate, MatchJobStatus } from '@/lib/api';
 
 const mockStartMatchJob = vi.fn();
 const mockGetMatchJob = vi.fn();
@@ -261,6 +261,90 @@ describe('useMatchJob', () => {
     });
 
     expect(result.current.error).toBeNull();
+  });
+
+  // #1831 — byte-budgeted match chunking + sequential chunk-job queue
+  describe('chunked match submission (#1831)', () => {
+    /** A candidate whose padded title pushes each one above the byte budget → 1 per chunk. */
+    const bigCandidate = (path: string): MatchCandidate => ({ path, title: 'x'.repeat(300 * 1024) });
+
+    it('packMatchCandidates splits by byte budget, preserving order', () => {
+      const chunks = packMatchCandidates([bigCandidate('/a'), bigCandidate('/b'), bigCandidate('/c')]);
+      expect(chunks).toHaveLength(3);
+      expect(chunks.flat().map(c => c.path)).toEqual(['/a', '/b', '/c']);
+    });
+
+    it('packs small candidates into a single chunk', () => {
+      const chunks = packMatchCandidates([{ path: '/a', title: 'A' }, { path: '/b', title: 'B' }]);
+      expect(chunks).toHaveLength(1);
+    });
+
+    it('runs chunk jobs sequentially — the next chunk starts only after the previous completes', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+      mockGetMatchJob.mockImplementation((id: string) => Promise.resolve({
+        id,
+        status: 'completed',
+        total: 1,
+        matched: 1,
+        results: [{ path: id === 'job-1' ? '/a' : '/b', confidence: 'high', bestMatch: null, alternatives: [] }],
+      } satisfies MatchJobStatus));
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => {
+        await result.current.startMatching([bigCandidate('/a'), bigCandidate('/b')]);
+      });
+
+      // Only the first chunk's job has started.
+      expect(mockStartMatchJob).toHaveBeenCalledTimes(1);
+
+      // One poll completes chunk 1 → chunk 2's job launches.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(mockStartMatchJob).toHaveBeenCalledTimes(2);
+
+      // Next poll completes chunk 2.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(result.current.isMatching).toBe(false);
+
+      // Append-only accumulation across chunks + queue-wide aggregate progress.
+      expect(result.current.results.map(r => r.path)).toEqual(['/a', '/b']);
+      expect(result.current.progress).toEqual({ matched: 2, total: 2 });
+    });
+
+    it('accumulates results append-only — chunk 1 results survive while chunk 2 is still matching', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+      mockGetMatchJob
+        .mockResolvedValueOnce({ id: 'job-1', status: 'completed', total: 1, matched: 1, results: [{ path: '/a', confidence: 'high', bestMatch: null, alternatives: [] }] })
+        .mockResolvedValueOnce({ id: 'job-2', status: 'matching', total: 1, matched: 0, results: [] });
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => {
+        await result.current.startMatching([bigCandidate('/a'), bigCandidate('/b')]);
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); }); // chunk 1 completes, chunk 2 starts
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); }); // chunk 2 first poll (still matching)
+
+      // Chunk 1's frozen result is still present; total spans the whole queue.
+      expect(result.current.results.map(r => r.path)).toEqual(['/a']);
+      expect(result.current.progress.total).toBe(2);
+    });
+
+    it('cancel mid-queue abandons pending chunks', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+      mockGetMatchJob.mockResolvedValue({ id: 'job-1', status: 'matching', total: 1, matched: 0, results: [] });
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => {
+        await result.current.startMatching([bigCandidate('/a'), bigCandidate('/b')]);
+      });
+
+      act(() => { result.current.cancel(); });
+      expect(mockCancelMatchJob).toHaveBeenCalledWith('job-1');
+      expect(result.current.isMatching).toBe(false);
+
+      // The queued second chunk never starts.
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+      expect(mockStartMatchJob).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('resets results when starting a new job', async () => {

--- a/src/client/hooks/useMatchJob.test.ts
+++ b/src/client/hooks/useMatchJob.test.ts
@@ -328,6 +328,76 @@ describe('useMatchJob', () => {
       expect(result.current.progress.total).toBe(2);
     });
 
+    it('packMatchCandidates budgets UTF-8 bytes, not characters', () => {
+      // 80k 3-byte chars ≈ 240 KiB serialized per candidate → two exceed the 400 KiB budget
+      // → 2 chunks. Char-count accounting (~160k) would pack them together.
+      const mk = (p: string): MatchCandidate => ({ path: p, title: 'あ'.repeat(80 * 1024) });
+      expect(packMatchCandidates([mk('/a'), mk('/b')])).toHaveLength(2);
+    });
+
+    it('startMatching([]) is a no-op: no API call, idle state', async () => {
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => { await result.current.startMatching([]); });
+      expect(mockStartMatchJob).not.toHaveBeenCalled();
+      expect(result.current.isMatching).toBe(false);
+      expect(result.current.progress).toEqual({ matched: 0, total: 0 });
+    });
+
+    // Chunk N>1 failure paths flow through the startChunkRef indirection — structurally
+    // distinct from the first-chunk path, so a stale-closure or ref-wiring bug would only
+    // manifest on the second chunk, exactly where these look.
+    it('chunk N>1 start failure surfaces the error, stops the queue, and preserves chunk 1 results', async () => {
+      mockStartMatchJob
+        .mockResolvedValueOnce({ jobId: 'job-1' })
+        .mockRejectedValueOnce(new Error('provider down'));
+      mockGetMatchJob.mockResolvedValueOnce({
+        id: 'job-1', status: 'completed', total: 1, matched: 1,
+        results: [{ path: '/a', confidence: 'high', bestMatch: null, alternatives: [] }],
+      } satisfies MatchJobStatus);
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => {
+        await result.current.startMatching([bigCandidate('/a'), bigCandidate('/b')]);
+      });
+      // Chunk 1 completes → chunk 2's start rejects.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+
+      expect(result.current.error).toBe('provider down');
+      expect(result.current.isMatching).toBe(false);
+      // Chunk 1's frozen results survive the failure.
+      expect(result.current.results.map(r => r.path)).toEqual(['/a']);
+      // No further starts after the failure.
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+      expect(mockStartMatchJob).toHaveBeenCalledTimes(2);
+    });
+
+    it('chunk N>1 poll failure stops polling, surfaces the error, and preserves chunk 1 results', async () => {
+      mockStartMatchJob
+        .mockResolvedValueOnce({ jobId: 'job-1' })
+        .mockResolvedValueOnce({ jobId: 'job-2' });
+      mockGetMatchJob
+        .mockResolvedValueOnce({
+          id: 'job-1', status: 'completed', total: 1, matched: 1,
+          results: [{ path: '/a', confidence: 'high', bestMatch: null, alternatives: [] }],
+        } satisfies MatchJobStatus)
+        .mockRejectedValueOnce(new Error('job expired'));
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => {
+        await result.current.startMatching([bigCandidate('/a'), bigCandidate('/b')]);
+      });
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); }); // chunk 1 completes, chunk 2 starts
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); }); // chunk 2's first poll rejects
+
+      expect(result.current.error).toBe('job expired');
+      expect(result.current.isMatching).toBe(false);
+      expect(result.current.results.map(r => r.path)).toEqual(['/a']);
+      // Polling has stopped.
+      mockGetMatchJob.mockClear();
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(mockGetMatchJob).not.toHaveBeenCalled();
+    });
+
     it('cancel mid-queue abandons pending chunks', async () => {
       mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
       mockGetMatchJob.mockResolvedValue({ id: 'job-1', status: 'matching', total: 1, matched: 0, results: [] });

--- a/src/client/hooks/useMatchJob.test.ts
+++ b/src/client/hooks/useMatchJob.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useMatchJob, packMatchCandidates } from './useMatchJob';
+import { useMatchJob, packMatchCandidates, MATCH_CHUNK_BYTE_BUDGET } from './useMatchJob';
 import type { MatchCandidate, MatchJobStatus } from '@/lib/api';
 
 const mockStartMatchJob = vi.fn();
@@ -414,6 +414,161 @@ describe('useMatchJob', () => {
       // The queued second chunk never starts.
       await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
       expect(mockStartMatchJob).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #1833 — response-identity guard, cancelled-status semantics, envelope byte accounting
+  describe('poll identity + cancelled semantics (#1833)', () => {
+    // These tests use persistent + one-shot mock implementations (pending promises we resolve
+    // by hand). The file-level `clearAllMocks` does NOT drain the mockImplementationOnce queue
+    // or reset a persistent mockImplementation, so reset the two job mocks fully on both edges
+    // to keep this block hermetic and prevent queue pollution leaking in or out.
+    beforeEach(() => {
+      mockStartMatchJob.mockReset();
+      mockGetMatchJob.mockReset();
+    });
+    afterEach(() => {
+      mockStartMatchJob.mockReset();
+      mockGetMatchJob.mockReset();
+    });
+
+    /** A candidate padded above the byte budget → 1 per chunk (predictable 2-chunk queues). */
+    const bigCandidate = (path: string): MatchCandidate => ({ path, title: 'x'.repeat(300 * 1024) });
+
+    it('overlapping completed polls for one job advance the queue exactly once', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' });
+      // getMatchJob returns pending promises we resolve by hand, so two polls can be in flight.
+      const resolvers: Array<() => void> = [];
+      mockGetMatchJob.mockImplementation((id: string) => new Promise<MatchJobStatus>((resolve) => {
+        resolvers.push(() => resolve({
+          id, status: 'completed', total: 1, matched: 1,
+          results: [{ path: '/a', confidence: 'high', bestMatch: null, alternatives: [] }],
+        }));
+      }));
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => { await result.current.startMatching([{ path: '/a', title: 'A' }]); });
+
+      // Two interval ticks fire two overlapping getMatchJob calls before either resolves.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(mockGetMatchJob).toHaveBeenCalledTimes(2);
+
+      // Both resolve completed; only the first advances — the second is ignored by the id guard.
+      await act(async () => { resolvers[0]!(); resolvers[1]!(); });
+
+      expect(result.current.results.map(r => r.path)).toEqual(['/a']);
+      expect(result.current.progress).toEqual({ matched: 1, total: 1 });
+      expect(result.current.isMatching).toBe(false);
+    });
+
+    it('a stale completed poll from a superseded run (Retry Match) mutates nothing in the new queue', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+      let resolveOld: (() => void) | undefined;
+      mockGetMatchJob
+        .mockImplementationOnce((id: string) => new Promise<MatchJobStatus>((resolve) => {
+          resolveOld = () => resolve({
+            id, status: 'completed', total: 1, matched: 1,
+            results: [{ path: '/old', confidence: 'high', bestMatch: null, alternatives: [] }],
+          });
+        }))
+        .mockImplementation(() => new Promise<MatchJobStatus>(() => {})); // job-2 poll never resolves
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => { await result.current.startMatching([{ path: '/a', title: 'A' }]); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); }); // job-1 poll in-flight
+
+      // Retry Match supersedes with a fresh queue (job-2).
+      await act(async () => { await result.current.startMatching([{ path: '/b', title: 'B' }]); });
+
+      // The stale job-1 poll resolves — its result must not leak into the new run.
+      await act(async () => { resolveOld?.(); });
+
+      expect(result.current.results).toEqual([]);
+      expect(result.current.error).toBeNull();
+      expect(result.current.isMatching).toBe(true);
+    });
+
+    it('a stale poll rejection from a superseded run leaves the new run untouched', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+      let rejectOld: (() => void) | undefined;
+      mockGetMatchJob
+        .mockImplementationOnce(() => new Promise<MatchJobStatus>((_, reject) => { rejectOld = () => reject(new Error('job-1 expired')); }))
+        .mockImplementation(() => new Promise<MatchJobStatus>(() => {}));
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => { await result.current.startMatching([{ path: '/a', title: 'A' }]); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); }); // job-1 poll in-flight
+      await act(async () => { await result.current.startMatching([{ path: '/b', title: 'B' }]); }); // supersede → job-2
+
+      await act(async () => { rejectOld?.(); });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.isMatching).toBe(true);
+
+      // The new run's polling is still live.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+      expect(mockGetMatchJob).toHaveBeenCalledWith('job-2');
+    });
+
+    it('a stale start rejection from a superseded run does not error or stop the new run', async () => {
+      let rejectStartOld: (() => void) | undefined;
+      mockStartMatchJob
+        .mockImplementationOnce(() => new Promise<{ jobId: string }>((_, reject) => { rejectStartOld = () => reject(new Error('job-1 start failed')); }))
+        .mockResolvedValueOnce({ jobId: 'job-2' });
+      mockGetMatchJob.mockImplementation(() => new Promise<MatchJobStatus>(() => {}));
+
+      const { result } = renderHook(() => useMatchJob());
+      // Run A's startChunk awaits a pending startMatchJob — do NOT await startMatching (it hangs).
+      act(() => { void result.current.startMatching([{ path: '/a', title: 'A' }]); });
+      // Supersede with run B before A's start settles.
+      await act(async () => { await result.current.startMatching([{ path: '/b', title: 'B' }]); });
+
+      // Run A's start now rejects — it belongs to a cancelled queue and must be swallowed.
+      await act(async () => { rejectStartOld?.(); });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.isMatching).toBe(true);
+    });
+
+    it('a server cancelled status terminates the queue — no next chunk, partial results kept', async () => {
+      mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+      mockGetMatchJob.mockResolvedValueOnce({
+        id: 'job-1', status: 'cancelled', total: 1, matched: 1,
+        results: [{ path: '/a', confidence: 'high', bestMatch: null, alternatives: [] }],
+      } satisfies MatchJobStatus);
+
+      const { result } = renderHook(() => useMatchJob());
+      await act(async () => { await result.current.startMatching([bigCandidate('/a'), bigCandidate('/b')]); });
+      // Chunk 1's poll returns cancelled.
+      await act(async () => { await vi.advanceTimersByTimeAsync(2000); });
+
+      expect(result.current.isMatching).toBe(false);
+      // Chunk 2's job never launches, and partial results from chunk 1 are retained.
+      expect(mockStartMatchJob).toHaveBeenCalledTimes(1);
+      expect(result.current.results.map(r => r.path)).toEqual(['/a']);
+
+      // No further starts after more ticks.
+      await act(async () => { await vi.advanceTimersByTimeAsync(4000); });
+      expect(mockStartMatchJob).toHaveBeenCalledTimes(1);
+    });
+
+    it('every emitted match chunk body — { books } with envelope — stays within the byte budget', () => {
+      // Two candidates each serializing to exactly half the byte budget. Summing the bare
+      // candidate array (pre-#1833) packs both into one chunk at exactly the budget — but the
+      // real { books } wire body (array brackets + a comma + the envelope) then spills one
+      // request past the limit. Envelope-aware accounting splits them instead.
+      const half = MATCH_CHUNK_BYTE_BUDGET / 2;
+      const mk = (path: string): MatchCandidate => {
+        const overhead = new TextEncoder().encode(JSON.stringify({ path, title: '' })).length;
+        return { path, title: 'x'.repeat(half - overhead) };
+      };
+      const chunks = packMatchCandidates([mk('/p0'), mk('/p1')]);
+      expect(chunks).toHaveLength(2);
+      for (const chunk of chunks) {
+        const body = new TextEncoder().encode(JSON.stringify({ books: chunk })).length;
+        expect(body).toBeLessThanOrEqual(MATCH_CHUNK_BYTE_BUDGET);
+      }
     });
   });
 

--- a/src/client/hooks/useMatchJob.ts
+++ b/src/client/hooks/useMatchJob.ts
@@ -12,22 +12,37 @@ const POLL_INTERVAL = 2000;
  * they share only array splitting) covers all three call sites by construction: the
  * library initial scan, library Retry Match, and manual scan.
  */
-const MATCH_CHUNK_BYTE_BUDGET = 400 * 1024; // 400 KiB — well under 1 MiB
+export const MATCH_CHUNK_BYTE_BUDGET = 400 * 1024; // 400 KiB — well under 1 MiB
 const MATCH_CHUNK_MAX_ITEMS = 1000; // secondary count bound
+
+/** Reused across every candidate serialization instead of ~5k per-pack allocations (#1833). */
+const encoder = new TextEncoder();
+/**
+ * Byte cost of the `{ books: [...] }` request envelope for an EMPTY array —
+ * `{"books":[]}` = 12 bytes. Reserved up front so the budget bounds what actually
+ * crosses the wire, not the bare candidate array (#1833). Each item after the first
+ * in a chunk additionally costs a `,` separator, accounted for below.
+ */
+const MATCH_ENVELOPE_BYTES = encoder.encode(JSON.stringify({ books: [] })).length;
 
 export function packMatchCandidates(candidates: MatchCandidate[]): MatchCandidate[][] {
   const chunks: MatchCandidate[][] = [];
   let current: MatchCandidate[] = [];
-  let bytes = 0;
+  // Track the serialized size of the whole `{ books: current }` body, not just the
+  // summed candidate bytes — the wire body is `JSON.stringify({ books: chunk })` (#1833).
+  let bodyBytes = MATCH_ENVELOPE_BYTES;
   for (const candidate of candidates) {
-    const size = new TextEncoder().encode(JSON.stringify(candidate)).length;
-    if (current.length > 0 && (bytes + size > MATCH_CHUNK_BYTE_BUDGET || current.length >= MATCH_CHUNK_MAX_ITEMS)) {
+    const size = encoder.encode(JSON.stringify(candidate)).length;
+    // Adding to a non-empty chunk also costs a separating comma.
+    const wouldExceed = bodyBytes + size + 1 > MATCH_CHUNK_BYTE_BUDGET;
+    if (current.length > 0 && (wouldExceed || current.length >= MATCH_CHUNK_MAX_ITEMS)) {
       chunks.push(current);
       current = [];
-      bytes = 0;
+      bodyBytes = MATCH_ENVELOPE_BYTES;
     }
+    // First item in a chunk pays no comma; subsequent items pay one.
+    bodyBytes += current.length > 0 ? size + 1 : size;
     current.push(candidate);
-    bytes += size;
   }
   if (current.length > 0) chunks.push(current);
   return chunks;
@@ -87,13 +102,31 @@ export function useMatchJob(): UseMatchJobReturn {
   const handlePollStatus = useCallback((status: MatchJobStatus) => {
     const q = queueRef.current;
     if (!q || q.cancelled) return;
+    // Response-identity guard (#1833): ignore any poll whose job is no longer the active
+    // one. Two triggers this closes — (a) an overlapping poll that resolves after we already
+    // advanced past this job (the 2 s interval firing while a slow getMatchJob is pending),
+    // and (b) a stale poll resolving after Retry Match swapped in a fresh queue (which reads
+    // `queueRef` fresh, so `q.cancelled` alone would not catch it). Without this the frozen
+    // prefix duplicates and a whole chunk is silently skipped.
+    if (status.id !== jobIdRef.current) return;
 
     // Append-only view: frozen completed-chunks prefix + this chunk's partial results,
     // preserving the monotonic slice contract both consumers depend on.
     setResults([...q.completed, ...status.results]);
     setProgress({ matched: q.completed.length + status.matched, total: q.total });
 
-    if (status.status === 'completed' || status.status === 'cancelled') {
+    // A server-reported cancellation (#1833) — e.g. cancelJob() from a second tab — terminates
+    // the WHOLE queue. It must NOT advance like completion: launching the next chunk against an
+    // intentionally-stopped run would resurrect a cancelled job. Partial results are retained.
+    if (status.status === 'cancelled') {
+      stopPolling();
+      q.cancelled = true;
+      jobIdRef.current = null;
+      setIsMatching(false);
+      return;
+    }
+
+    if (status.status === 'completed') {
       stopPolling();
       jobIdRef.current = null;
       // Freeze this chunk's results into the prefix and advance to the next chunk.
@@ -104,11 +137,17 @@ export function useMatchJob(): UseMatchJobReturn {
   }, [stopPolling]);
 
   const pollTick = useCallback(async () => {
-    if (!jobIdRef.current) return;
+    // Capture the polled job id before the await so a rejection can be attributed to the run
+    // it belongs to (#1833) — jobIdRef may have moved on by the time the promise settles.
+    const jobId = jobIdRef.current;
+    if (!jobId) return;
     try {
-      const status = await api.getMatchJob(jobIdRef.current);
+      const status = await api.getMatchJob(jobId);
       handlePollStatus(status);
     } catch (error: unknown) {
+      // A rejection from a superseded run (Retry Match / cancel already moved on) must not
+      // stop the NEW run's polling or surface a spurious error that disables Register (#1833).
+      if (jobId !== jobIdRef.current) return;
       // The active chunk's job may have expired — stop and surface the error.
       stopPolling();
       setIsMatching(false);
@@ -133,6 +172,10 @@ export function useMatchJob(): UseMatchJobReturn {
       jobIdRef.current = jobId;
       intervalRef.current = setInterval(() => pollTickRef.current(), POLL_INTERVAL);
     } catch (error: unknown) {
+      // A stale rejection from a superseded run (this queue was cancelled/replaced while the
+      // start was in flight) must not stop polling or error the NEW run (#1833). The captured
+      // `q` is this run's queue; `cancel()` marks it before swapping in the replacement.
+      if (q.cancelled) return;
       stopPolling();
       setIsMatching(false);
       setError(getErrorMessage(error));

--- a/src/client/hooks/useMatchJob.ts
+++ b/src/client/hooks/useMatchJob.ts
@@ -4,6 +4,44 @@ import { getErrorMessage } from '@/lib/error-message.js';
 
 const POLL_INTERVAL = 2000;
 
+/**
+ * Byte-budgeted chunking for match-start candidates (#1831). Candidates are
+ * `{ path, title, author }` (~250 B, no metadata blob) so a large scan crosses the
+ * 1 MiB body limit near ~4,000 books — enough for a big library to 413 at match-start
+ * before confirm is ever reached. Chunking here (rather than in the confirm chunker —
+ * they share only array splitting) covers all three call sites by construction: the
+ * library initial scan, library Retry Match, and manual scan.
+ */
+const MATCH_CHUNK_BYTE_BUDGET = 400 * 1024; // 400 KiB — well under 1 MiB
+const MATCH_CHUNK_MAX_ITEMS = 1000; // secondary count bound
+
+export function packMatchCandidates(candidates: MatchCandidate[]): MatchCandidate[][] {
+  const chunks: MatchCandidate[][] = [];
+  let current: MatchCandidate[] = [];
+  let bytes = 0;
+  for (const candidate of candidates) {
+    const size = new TextEncoder().encode(JSON.stringify(candidate)).length;
+    if (current.length > 0 && (bytes + size > MATCH_CHUNK_BYTE_BUDGET || current.length >= MATCH_CHUNK_MAX_ITEMS)) {
+      chunks.push(current);
+      current = [];
+      bytes = 0;
+    }
+    current.push(candidate);
+    bytes += size;
+  }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
+
+interface QueueState {
+  chunks: MatchCandidate[][];
+  index: number;
+  /** Frozen results from completed chunks — the append-only prefix. */
+  completed: MatchResult[];
+  total: number;
+  cancelled: boolean;
+}
+
 interface UseMatchJobReturn {
   results: MatchResult[];
   progress: { matched: number; total: number };
@@ -20,6 +58,7 @@ export function useMatchJob(): UseMatchJobReturn {
   const [error, setError] = useState<string | null>(null);
   const jobIdRef = useRef<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const queueRef = useRef<QueueState | null>(null);
 
   const stopPolling = useCallback(() => {
     if (intervalRef.current) {
@@ -30,6 +69,9 @@ export function useMatchJob(): UseMatchJobReturn {
 
   const cancel = useCallback(() => {
     stopPolling();
+    // Drain the pending queue: the active-chunk poll/advance both bail on `cancelled`,
+    // so no queued chunk starts once this is set.
+    if (queueRef.current) queueRef.current.cancelled = true;
     if (jobIdRef.current) {
       api.cancelMatchJob(jobIdRef.current).catch(() => {});
       jobIdRef.current = null;
@@ -37,52 +79,95 @@ export function useMatchJob(): UseMatchJobReturn {
     setIsMatching(false);
   }, [stopPolling]);
 
-  const handlePollResult = useCallback((status: MatchJobStatus) => {
-    setResults(status.results);
-    setProgress({ matched: status.matched, total: status.total });
+  // The setInterval poll and the chunk-advance are mutually recursive (a completed chunk
+  // launches the next). Route both through refs so neither captures a stale closure.
+  const pollTickRef = useRef<() => void>(() => {});
+  const startChunkRef = useRef<() => void>(() => {});
+
+  const handlePollStatus = useCallback((status: MatchJobStatus) => {
+    const q = queueRef.current;
+    if (!q || q.cancelled) return;
+
+    // Append-only view: frozen completed-chunks prefix + this chunk's partial results,
+    // preserving the monotonic slice contract both consumers depend on.
+    setResults([...q.completed, ...status.results]);
+    setProgress({ matched: q.completed.length + status.matched, total: q.total });
 
     if (status.status === 'completed' || status.status === 'cancelled') {
       stopPolling();
-      setIsMatching(false);
       jobIdRef.current = null;
+      // Freeze this chunk's results into the prefix and advance to the next chunk.
+      q.completed = [...q.completed, ...status.results];
+      q.index += 1;
+      startChunkRef.current();
     }
   }, [stopPolling]);
 
-  const startMatching = useCallback(async (candidates: MatchCandidate[]) => {
-    // Cancel any existing job
-    cancel();
-
-    setResults([]);
-    setProgress({ matched: 0, total: candidates.length });
-    setIsMatching(true);
-    setError(null);
-
+  const pollTick = useCallback(async () => {
+    if (!jobIdRef.current) return;
     try {
-      const { jobId } = await api.startMatchJob(candidates);
-      jobIdRef.current = jobId;
-
-      intervalRef.current = setInterval(async () => {
-        if (!jobIdRef.current) return;
-        try {
-          const status = await api.getMatchJob(jobIdRef.current);
-          handlePollResult(status);
-        } catch (error: unknown) {
-          // Job may have expired — stop polling
-          stopPolling();
-          setIsMatching(false);
-          setError(getErrorMessage(error));
-        }
-      }, POLL_INTERVAL);
+      const status = await api.getMatchJob(jobIdRef.current);
+      handlePollStatus(status);
     } catch (error: unknown) {
+      // The active chunk's job may have expired — stop and surface the error.
+      stopPolling();
       setIsMatching(false);
       setError(getErrorMessage(error));
     }
-  }, [cancel, handlePollResult, stopPolling]);
+  }, [handlePollStatus, stopPolling]);
 
-  // Cleanup on unmount
+  const startChunk = useCallback(async () => {
+    const q = queueRef.current;
+    if (!q || q.cancelled) return;
+    if (q.index >= q.chunks.length) {
+      // Queue drained — every chunk completed.
+      setIsMatching(false);
+      return;
+    }
+    try {
+      const { jobId } = await api.startMatchJob(q.chunks[q.index]!);
+      if (q.cancelled) {
+        api.cancelMatchJob(jobId).catch(() => {});
+        return;
+      }
+      jobIdRef.current = jobId;
+      intervalRef.current = setInterval(() => pollTickRef.current(), POLL_INTERVAL);
+    } catch (error: unknown) {
+      stopPolling();
+      setIsMatching(false);
+      setError(getErrorMessage(error));
+    }
+  }, [stopPolling]);
+
+  // Keep the engine refs pointing at the latest callbacks each render.
+  useEffect(() => {
+    pollTickRef.current = () => { void pollTick(); };
+    startChunkRef.current = () => { void startChunk(); };
+  });
+
+  const startMatching = useCallback(async (candidates: MatchCandidate[]) => {
+    // Cancel any existing run and reset for the new queue.
+    cancel();
+
+    const chunks = packMatchCandidates(candidates);
+    queueRef.current = { chunks, index: 0, completed: [], total: candidates.length, cancelled: false };
+    setResults([]);
+    setProgress({ matched: 0, total: candidates.length });
+    setError(null);
+
+    if (chunks.length === 0) {
+      setIsMatching(false);
+      return;
+    }
+    setIsMatching(true);
+    await startChunk();
+  }, [cancel, startChunk]);
+
+  // Cleanup on unmount — abandon the queue and cancel the in-flight chunk.
   useEffect(() => {
     return () => {
       stopPolling();
+      if (queueRef.current) queueRef.current.cancelled = true;
       if (jobIdRef.current) {
         api.cancelMatchJob(jobIdRef.current).catch(() => {});
       }

--- a/src/client/lib/confirm-chunk-runner.test.ts
+++ b/src/client/lib/confirm-chunk-runner.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runChunkedConfirm } from './confirm-chunk-runner.js';
+import { serializedItemBytes, MAX_SINGLE_ITEM_BYTES } from './confirm-chunks.js';
+import type { ImportConfirmItem, ImportMode, ImportResult } from '@/lib/api';
+
+/** Signature of the runner's `confirm` param — used to type each mock. */
+type ConfirmFn = (items: ImportConfirmItem[], mode: ImportMode | undefined) => Promise<ImportResult>;
+
+/** Each item is padded above the chunk byte budget, so 1 item ⇒ 1 chunk (predictable boundaries). */
+function bigItem(path: string, bytes = 500 * 1024): ImportConfirmItem {
+  const base: ImportConfirmItem = { path, title: 'T', metadata: { blob: '' } as never };
+  const pad = Math.max(0, bytes - serializedItemBytes(base));
+  return { path, title: 'T', metadata: { blob: 'x'.repeat(pad) } as never };
+}
+
+const ok = (n: number): ImportResult => ({ accepted: n, heldReview: [], skipped: [], failed: [] });
+
+describe('runChunkedConfirm (#1831)', () => {
+  it('resolves with a concatenated aggregate over all chunks on full success', async () => {
+    const items = [bigItem('/a'), bigItem('/b'), bigItem('/c')];
+    const confirm = vi.fn<ConfirmFn>(async (chunk) => ({
+      accepted: chunk.length,
+      heldReview: [{ path: chunk[0]!.path, title: 'H', reason: 'recording-review-required' as const }],
+      skipped: [],
+      failed: [],
+    }));
+
+    const res = await runChunkedConfirm({ items, mode: undefined, confirm });
+
+    expect(confirm).toHaveBeenCalledTimes(3);
+    expect(res.aggregateResult.accepted).toBe(3);
+    expect(res.aggregateResult.heldReview.map(h => h.path)).toEqual(['/a', '/b', '/c']);
+    expect(res.submittedItems.map(i => i.path)).toEqual(['/a', '/b', '/c']);
+    expect(res.unsubmitted).toEqual({ count: 0, inFlight: 0, remainder: 0, reason: null });
+    expect(res.tooLarge.count).toBe(0);
+  });
+
+  it('threads mode to every chunk and reports progress across the run', async () => {
+    const items = [bigItem('/a'), bigItem('/b')];
+    const confirm = vi.fn<ConfirmFn>(async (chunk) => ok(chunk.length));
+    const onProgress = vi.fn();
+
+    await runChunkedConfirm({ items, mode: 'move', confirm, onProgress });
+
+    expect(confirm).toHaveBeenNthCalledWith(1, expect.any(Array), 'move');
+    expect(confirm).toHaveBeenNthCalledWith(2, expect.any(Array), 'move');
+    // Final progress reports both items submitted of the total, across 2 chunks.
+    expect(onProgress).toHaveBeenLastCalledWith({ current: 2, total: 2, chunks: 2 });
+  });
+
+  it('mid-sequence failure returns submittedItems + the in-flight/remainder split', async () => {
+    const items = [bigItem('/a'), bigItem('/b'), bigItem('/c'), bigItem('/d'), bigItem('/e')];
+    let call = 0;
+    const confirm = vi.fn<ConfirmFn>(async (chunk) => {
+      call += 1;
+      if (call === 3) throw new Error('connection reset');
+      return ok(chunk.length);
+    });
+
+    const res = await runChunkedConfirm({ items, mode: undefined, confirm });
+
+    // Chunks 1–2 applied; chunk 3 in-flight; chunks 4–5 never sent.
+    expect(res.aggregateResult.accepted).toBe(2);
+    expect(res.submittedItems.map(i => i.path)).toEqual(['/a', '/b']);
+    expect(res.unsubmitted).toEqual({ count: 3, inFlight: 1, remainder: 2, reason: 'connection reset' });
+    expect(res.tooLarge.count).toBe(0);
+  });
+
+  it('rejects on a first-chunk failure with nothing submitted and no tooLarge rows', async () => {
+    const items = [bigItem('/a'), bigItem('/b')];
+    const confirm = vi.fn<ConfirmFn>(async () => { throw new Error('boom'); });
+
+    await expect(runChunkedConfirm({ items, mode: undefined, confirm })).rejects.toThrow('boom');
+  });
+
+  it('resolves (does not reject) when a self-oversize item is present even with a first-chunk failure', async () => {
+    const items = [bigItem('/huge', MAX_SINGLE_ITEM_BYTES + 50 * 1024), bigItem('/a')];
+    const confirm = vi.fn<ConfirmFn>(async () => { throw new Error('boom'); });
+
+    const res = await runChunkedConfirm({ items, mode: undefined, confirm });
+
+    expect(res.tooLarge.count).toBe(1);
+    expect(res.submittedItems).toHaveLength(0);
+    expect(res.unsubmitted.count).toBe(1); // the one non-oversize chunk was in-flight when it failed
+  });
+
+  it('resolves with only tooLarge when every item is self-oversize (never calls confirm)', async () => {
+    const items = [bigItem('/huge', MAX_SINGLE_ITEM_BYTES + 50 * 1024)];
+    const confirm = vi.fn<ConfirmFn>(async () => ok(1));
+
+    const res = await runChunkedConfirm({ items, mode: undefined, confirm });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(res.tooLarge.count).toBe(1);
+    expect(res.submittedItems).toHaveLength(0);
+    expect(res.unsubmitted.count).toBe(0);
+  });
+});
+

--- a/src/client/lib/confirm-chunk-runner.test.ts
+++ b/src/client/lib/confirm-chunk-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { runChunkedConfirm } from './confirm-chunk-runner.js';
 import { serializedItemBytes, MAX_SINGLE_ITEM_BYTES } from './confirm-chunks.js';
+import { ApiError } from '@/lib/api';
 import type { ImportConfirmItem, ImportMode, ImportResult } from '@/lib/api';
 
 /** Signature of the runner's `confirm` param — used to type each mock. */
@@ -31,7 +32,7 @@ describe('runChunkedConfirm (#1831)', () => {
     expect(res.aggregateResult.accepted).toBe(3);
     expect(res.aggregateResult.heldReview.map(h => h.path)).toEqual(['/a', '/b', '/c']);
     expect(res.submittedItems.map(i => i.path)).toEqual(['/a', '/b', '/c']);
-    expect(res.unsubmitted).toEqual({ count: 0, inFlight: 0, remainder: 0, reason: null });
+    expect(res.unsubmitted).toEqual({ count: 0, inFlight: 0, remainder: 0, reason: null, reasonKind: null });
     expect(res.tooLarge.count).toBe(0);
   });
 
@@ -44,8 +45,25 @@ describe('runChunkedConfirm (#1831)', () => {
 
     expect(confirm).toHaveBeenNthCalledWith(1, expect.any(Array), 'move');
     expect(confirm).toHaveBeenNthCalledWith(2, expect.any(Array), 'move');
+    // Intermediate progress reports items-ATTEMPTED, never "0 of N" while POSTing (#1833):
+    // chunk 1 in-flight → 1 of 2; chunk 2 in-flight → 2 of 2.
+    expect(onProgress).toHaveBeenNthCalledWith(1, { current: 1, total: 2, chunks: 2 });
+    expect(onProgress).toHaveBeenNthCalledWith(2, { current: 2, total: 2, chunks: 2 });
     // Final progress reports both items submitted of the total, across 2 chunks.
     expect(onProgress).toHaveBeenLastCalledWith({ current: 2, total: 2, chunks: 2 });
+  });
+
+  it('first chunk progress is never "0 of N" while POSTing (#1833)', async () => {
+    const items = [bigItem('/a'), bigItem('/b')];
+    const onProgress = vi.fn();
+    // A deferred confirm keeps chunk 1 in-flight; assert the progress emitted before the POST.
+    const confirm = vi.fn<ConfirmFn>(() => new Promise<ImportResult>(() => {}));
+
+    void runChunkedConfirm({ items, mode: undefined, confirm, onProgress });
+    await Promise.resolve();
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, { current: 1, total: 2, chunks: 2 });
+    expect(onProgress).not.toHaveBeenCalledWith({ current: 0, total: 2, chunks: 2 });
   });
 
   it('mid-sequence failure returns submittedItems + the in-flight/remainder split', async () => {
@@ -62,8 +80,40 @@ describe('runChunkedConfirm (#1831)', () => {
     // Chunks 1–2 applied; chunk 3 in-flight; chunks 4–5 never sent.
     expect(res.aggregateResult.accepted).toBe(2);
     expect(res.submittedItems.map(i => i.path)).toEqual(['/a', '/b']);
-    expect(res.unsubmitted).toEqual({ count: 3, inFlight: 1, remainder: 2, reason: 'connection reset' });
+    expect(res.unsubmitted).toEqual({ count: 3, inFlight: 1, remainder: 2, reason: 'connection reset', reasonKind: 'transport' });
     expect(res.tooLarge.count).toBe(0);
+  });
+
+  it('a mid-run 413 marks the in-flight chunk too-large; a network reset marks it transport (#1833)', async () => {
+    const items = [bigItem('/a'), bigItem('/b'), bigItem('/c')];
+
+    const tooLargeConfirm = vi.fn<ConfirmFn>(async (chunk) => {
+      if (chunk[0]!.path === '/b') throw new ApiError(413, { error: 'Payload Too Large' });
+      return ok(chunk.length);
+    });
+    const tooLargeRes = await runChunkedConfirm({ items, mode: undefined, confirm: tooLargeConfirm });
+    expect(tooLargeRes.unsubmitted.reasonKind).toBe('too-large');
+    expect(tooLargeRes.unsubmitted.inFlight).toBe(1);
+
+    const transportConfirm = vi.fn<ConfirmFn>(async (chunk) => {
+      if (chunk[0]!.path === '/b') throw new ApiError(500, { error: 'Internal Server Error' });
+      return ok(chunk.length);
+    });
+    const transportRes = await runChunkedConfirm({ items, mode: undefined, confirm: transportConfirm });
+    expect(transportRes.unsubmitted.reasonKind).toBe('transport');
+
+    const resetConfirm = vi.fn<ConfirmFn>(async (chunk) => {
+      if (chunk[0]!.path === '/b') throw new Error('connection reset');
+      return ok(chunk.length);
+    });
+    const resetRes = await runChunkedConfirm({ items, mode: undefined, confirm: resetConfirm });
+    expect(resetRes.unsubmitted.reasonKind).toBe('transport');
+  });
+
+  it('rejects an empty-items run without calling confirm — never a phantom clean import (#1833)', async () => {
+    const confirm = vi.fn<ConfirmFn>(async () => ok(0));
+    await expect(runChunkedConfirm({ items: [], mode: undefined, confirm })).rejects.toThrow(/no books/i);
+    expect(confirm).not.toHaveBeenCalled();
   });
 
   it('rejects on a first-chunk failure with nothing submitted and no tooLarge rows', async () => {

--- a/src/client/lib/confirm-chunk-runner.ts
+++ b/src/client/lib/confirm-chunk-runner.ts
@@ -1,0 +1,96 @@
+import type { ImportConfirmItem, ImportMode, ImportResult } from '@/lib/api';
+import { getErrorMessage } from '@/lib/error-message.js';
+import { packConfirmChunks } from './confirm-chunks.js';
+
+/**
+ * Sequential chunk runner for the confirm POST (#1831). Packs the selected items
+ * (see {@link packConfirmChunks}), diverts self-oversize rows to `tooLarge`, and
+ * POSTs each chunk one at a time to the unchanged confirm endpoint — the server is
+ * already chunk-safe (per-item, DB-backed dedup; a resubmitted accepted item
+ * re-classifies as skipped).
+ *
+ * Contract (the part where the naive version breaks #1822): this RESOLVES (never
+ * rejects) once ≥1 chunk has succeeded OR any row was diverted to `tooLarge`,
+ * returning the aggregate plus the *actually-submitted* items so the caller can
+ * compute accepted/held/deselection over `submittedItems` — NOT the full selection,
+ * which would misclassify the never-sent remainder as accepted and silently
+ * deselect it. Only a first-chunk failure with nothing submitted and no `tooLarge`
+ * rows rejects, into the caller's existing `onError` path unchanged.
+ */
+export interface ChunkedConfirmResult {
+  /** Per-chunk `accepted`/`heldReview`/`skipped`/`failed` concatenated across submitted chunks. */
+  aggregateResult: ImportResult;
+  /** Items from chunks that received a response — the basis for accepted/deselection semantics. */
+  submittedItems: ImportConfirmItem[];
+  /**
+   * Items that did not land. `inFlight` is the failing chunk (attempted, unconfirmed —
+   * resubmit-safe); `remainder` is the never-sent chunks after it; `count` is their sum.
+   * `reason` carries the transport error message (null on a fully-submitted run). The
+   * in-flight/remainder split lets the toast name both, which the base `{ count, reason }`
+   * shape cannot express.
+   */
+  unsubmitted: { count: number; inFlight: number; remainder: number; reason: string | null };
+  /** Rows diverted pre-flight because their own serialized size exceeds the transport ceiling. */
+  tooLarge: { count: number };
+}
+
+export interface RunChunkedConfirmParams {
+  items: ImportConfirmItem[];
+  /** Threaded to every chunk so manual-import's per-attempt mode snapshot (#1732) is preserved. */
+  mode: ImportMode | undefined;
+  confirm: (items: ImportConfirmItem[], mode: ImportMode | undefined) => Promise<ImportResult>;
+  /**
+   * Progress across the sequential run — drives the "Registering X of Y…" label.
+   * `chunks` is the number of requests the run splits into; the UI only surfaces the
+   * label for a genuinely multi-chunk run (a single-chunk import keeps "Importing…").
+   */
+  onProgress?: (progress: { current: number; total: number; chunks: number }) => void;
+}
+
+const emptyResult = (): ImportResult => ({ accepted: 0, heldReview: [], skipped: [], failed: [] });
+
+export async function runChunkedConfirm(params: RunChunkedConfirmParams): Promise<ChunkedConfirmResult> {
+  const { items, mode, confirm, onProgress } = params;
+  const { chunks, tooLarge } = packConfirmChunks(items);
+
+  const aggregate = emptyResult();
+  const submittedItems: ImportConfirmItem[] = [];
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const chunkCount = chunks.length;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]!;
+    onProgress?.({ current: submittedItems.length, total, chunks: chunkCount });
+
+    let result: ImportResult;
+    try {
+      result = await confirm(chunk, mode);
+    } catch (error: unknown) {
+      // First-chunk failure with nothing to report → reject into the existing onError path.
+      if (submittedItems.length === 0 && tooLarge.length === 0) throw error;
+      // Otherwise resolve with the partial outcome, splitting the failing (in-flight) chunk
+      // from the never-sent remainder so the toast can name both.
+      const remainder = chunks.slice(i + 1).reduce((n, c) => n + c.length, 0);
+      return {
+        aggregateResult: aggregate,
+        submittedItems,
+        unsubmitted: { count: chunk.length + remainder, inFlight: chunk.length, remainder, reason: getErrorMessage(error) },
+        tooLarge: { count: tooLarge.length },
+      };
+    }
+
+    submittedItems.push(...chunk);
+    aggregate.accepted += result.accepted;
+    aggregate.heldReview.push(...result.heldReview);
+    aggregate.skipped.push(...result.skipped);
+    aggregate.failed.push(...result.failed);
+  }
+
+  onProgress?.({ current: submittedItems.length, total, chunks: chunkCount });
+  return {
+    aggregateResult: aggregate,
+    submittedItems,
+    unsubmitted: { count: 0, inFlight: 0, remainder: 0, reason: null },
+    tooLarge: { count: tooLarge.length },
+  };
+}

--- a/src/client/lib/confirm-chunk-runner.ts
+++ b/src/client/lib/confirm-chunk-runner.ts
@@ -1,6 +1,17 @@
+import { ApiError } from '@/lib/api';
 import type { ImportConfirmItem, ImportMode, ImportResult } from '@/lib/api';
 import { getErrorMessage } from '@/lib/error-message.js';
 import { packConfirmChunks } from './confirm-chunks.js';
+
+/**
+ * Why a mid-run chunk did not land (#1833). `'transport'` is a network-level failure
+ * (connection reset) — the chunk was attempted, its fate is unknown, and resubmitting is
+ * safe (the server re-classifies an already-accepted item as skipped). `'too-large'` is a
+ * deterministic 413 (Fastify body limit or, more often, a proxy hop with a sub-900 KiB
+ * `client_max_body_size`) — it will fail identically on every retry, so the toast must NOT
+ * claim resubmitting is safe. `null` on a fully-submitted run.
+ */
+export type UnsubmittedReasonKind = 'transport' | 'too-large' | null;
 
 /**
  * Sequential chunk runner for the confirm POST (#1831). Packs the selected items
@@ -25,11 +36,13 @@ export interface ChunkedConfirmResult {
   /**
    * Items that did not land. `inFlight` is the failing chunk (attempted, unconfirmed —
    * resubmit-safe); `remainder` is the never-sent chunks after it; `count` is their sum.
-   * `reason` carries the transport error message (null on a fully-submitted run). The
-   * in-flight/remainder split lets the toast name both, which the base `{ count, reason }`
-   * shape cannot express.
+   * `reason` carries the transport error message (null on a fully-submitted run);
+   * `reasonKind` discriminates a deterministic 413 (`'too-large'`) from a retryable
+   * transport failure (`'transport'`) so the toast can drop the false "resubmitting is
+   * safe" claim for the too-large case (#1833). The in-flight/remainder split lets the
+   * toast name both, which the base `{ count, reason }` shape cannot express.
    */
-  unsubmitted: { count: number; inFlight: number; remainder: number; reason: string | null };
+  unsubmitted: { count: number; inFlight: number; remainder: number; reason: string | null; reasonKind: UnsubmittedReasonKind };
   /** Rows diverted pre-flight because their own serialized size exceeds the transport ceiling. */
   tooLarge: { count: number };
 }
@@ -51,6 +64,11 @@ const emptyResult = (): ImportResult => ({ accepted: 0, heldReview: [], skipped:
 
 export async function runChunkedConfirm(params: RunChunkedConfirmParams): Promise<ChunkedConfirmResult> {
   const { items, mode, confirm, onProgress } = params;
+  // An empty selection has nothing to POST. The old single-request path 400ed server-side;
+  // resolving as a clean empty result here would fire a phantom green toast + navigate away
+  // with no server call (#1833). Reject so the caller's onError path handles it — the UI
+  // gates the Import button on a non-empty selection, so this is a defensive guard.
+  if (items.length === 0) throw new Error('No books selected to import.');
   const { chunks, tooLarge } = packConfirmChunks(items);
 
   const aggregate = emptyResult();
@@ -60,7 +78,9 @@ export async function runChunkedConfirm(params: RunChunkedConfirmParams): Promis
 
   for (let i = 0; i < chunks.length; i++) {
     const chunk = chunks[i]!;
-    onProgress?.({ current: submittedItems.length, total, chunks: chunkCount });
+    // Report items-ATTEMPTED (previously-submitted + this in-flight chunk) so the first chunk
+    // renders "Registering N of M" while POSTing, never a stalled "0 of M" (#1833).
+    onProgress?.({ current: submittedItems.length + chunk.length, total, chunks: chunkCount });
 
     let result: ImportResult;
     try {
@@ -69,12 +89,15 @@ export async function runChunkedConfirm(params: RunChunkedConfirmParams): Promis
       // First-chunk failure with nothing to report → reject into the existing onError path.
       if (submittedItems.length === 0 && tooLarge.length === 0) throw error;
       // Otherwise resolve with the partial outcome, splitting the failing (in-flight) chunk
-      // from the never-sent remainder so the toast can name both.
+      // from the never-sent remainder so the toast can name both. Preserve error identity: a
+      // 413 is deterministic (too-large), a network reset is retryable (transport) — the toast
+      // wording branches on this (#1833).
       const remainder = chunks.slice(i + 1).reduce((n, c) => n + c.length, 0);
+      const reasonKind: UnsubmittedReasonKind = error instanceof ApiError && error.status === 413 ? 'too-large' : 'transport';
       return {
         aggregateResult: aggregate,
         submittedItems,
-        unsubmitted: { count: chunk.length + remainder, inFlight: chunk.length, remainder, reason: getErrorMessage(error) },
+        unsubmitted: { count: chunk.length + remainder, inFlight: chunk.length, remainder, reason: getErrorMessage(error), reasonKind },
         tooLarge: { count: tooLarge.length },
       };
     }
@@ -90,7 +113,7 @@ export async function runChunkedConfirm(params: RunChunkedConfirmParams): Promis
   return {
     aggregateResult: aggregate,
     submittedItems,
-    unsubmitted: { count: 0, inFlight: 0, remainder: 0, reason: null },
+    unsubmitted: { count: 0, inFlight: 0, remainder: 0, reason: null, reasonKind: null },
     tooLarge: { count: tooLarge.length },
   };
 }

--- a/src/client/lib/confirm-chunks.test.ts
+++ b/src/client/lib/confirm-chunks.test.ts
@@ -75,4 +75,45 @@ describe('packConfirmChunks (#1831)', () => {
     expect(chunks).toHaveLength(0);
     expect(tooLarge).toHaveLength(1);
   });
+
+  // Byte-vs-character accounting: every fixture above is ASCII (chars == bytes), so a
+  // TextEncoder → .length regression would pass the whole suite while undercounting
+  // multi-byte metadata up to 4× and breaching the 1 MiB floor. 'あ' is 1 JS char / 3 UTF-8 bytes.
+  it('diverts a multi-byte item whose UTF-8 bytes exceed the ceiling even though its char count does not', () => {
+    // 310k chars ≈ 930 KiB serialized > 900 KiB ceiling; a char-count accounting would pass it.
+    const item = { path: '/utf8', title: 'T', metadata: { blob: 'あ'.repeat(310 * 1024) } as never };
+    expect(serializedItemBytes(item)).toBeGreaterThan(MAX_SINGLE_ITEM_BYTES);
+    const { chunks, tooLarge } = packConfirmChunks([item]);
+    expect(tooLarge).toHaveLength(1);
+    expect(chunks).toHaveLength(0);
+  });
+
+  it('splits multi-byte items by UTF-8 byte budget even when combined char count is under it', () => {
+    // Two items each ~240 KiB serialized (80k 3-byte chars) → 480 KiB > 400 KiB budget → 2 chunks.
+    // Char-count accounting (~160k total) would pack them together.
+    const mk = (p: string) => ({ path: p, title: 'T', metadata: { blob: 'あ'.repeat(80 * 1024) } as never });
+    const { chunks } = packConfirmChunks([mk('/a'), mk('/b')]);
+    expect(chunks).toHaveLength(2);
+  });
+
+  // Exactly-at-threshold boundaries: a flipped > vs >= would silently ship.
+  it('ships an item at exactly MAX_SINGLE_ITEM_BYTES; one byte over diverts (ceiling is inclusive)', () => {
+    const exact = itemOfSize('/exact', MAX_SINGLE_ITEM_BYTES);
+    expect(serializedItemBytes(exact)).toBe(MAX_SINGLE_ITEM_BYTES);
+    const atCeiling = packConfirmChunks([exact]);
+    expect(atCeiling.tooLarge).toHaveLength(0);
+    expect(atCeiling.chunks).toEqual([[exact]]);
+
+    const over = itemOfSize('/over', MAX_SINGLE_ITEM_BYTES + 1);
+    const overCeiling = packConfirmChunks([over]);
+    expect(overCeiling.tooLarge).toHaveLength(1);
+    expect(overCeiling.chunks).toHaveLength(0);
+  });
+
+  it('packs items summing to exactly CHUNK_BYTE_BUDGET into one chunk; one byte more splits', () => {
+    const half = itemOfSize('/h1', CHUNK_BYTE_BUDGET / 2);
+    expect(serializedItemBytes(half)).toBe(CHUNK_BYTE_BUDGET / 2);
+    expect(packConfirmChunks([half, itemOfSize('/h2', CHUNK_BYTE_BUDGET / 2)]).chunks).toHaveLength(1);
+    expect(packConfirmChunks([half, itemOfSize('/h3', CHUNK_BYTE_BUDGET / 2 + 1)]).chunks).toHaveLength(2);
+  });
 });

--- a/src/client/lib/confirm-chunks.test.ts
+++ b/src/client/lib/confirm-chunks.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import {
+  packConfirmChunks,
+  serializedItemBytes,
+  CHUNK_BYTE_BUDGET,
+  MAX_SINGLE_ITEM_BYTES,
+  MAX_CHUNK_ITEMS,
+} from './confirm-chunks.js';
+import type { ImportConfirmItem } from '@/lib/api';
+
+/** A confirm item whose metadata blob pads it to roughly `bytes` serialized. */
+function itemOfSize(path: string, bytes: number): ImportConfirmItem {
+  const base: ImportConfirmItem = { path, title: 'T', metadata: { blob: '' } as never };
+  const overhead = serializedItemBytes(base);
+  const pad = Math.max(0, bytes - overhead);
+  return { path, title: 'T', metadata: { blob: 'x'.repeat(pad) } as never };
+}
+
+describe('packConfirmChunks (#1831)', () => {
+  it('packs small items into as few chunks as possible, each under budget', () => {
+    // 20 items each ~50 KiB → 8 fit per 400 KiB chunk → 3 chunks.
+    const items = Array.from({ length: 20 }, (_, i) => itemOfSize(`/b/${i}`, 50 * 1024));
+    const { chunks, tooLarge } = packConfirmChunks(items);
+
+    expect(tooLarge).toHaveLength(0);
+    expect(chunks.flat()).toHaveLength(20);
+    for (const chunk of chunks) {
+      const bytes = chunk.reduce((n, it) => n + serializedItemBytes(it), 0);
+      expect(bytes).toBeLessThanOrEqual(CHUNK_BYTE_BUDGET);
+    }
+    // Order is preserved across the flattened chunks.
+    expect(chunks.flat().map(i => i.path)).toEqual(items.map(i => i.path));
+  });
+
+  it('ships an item above the chunk budget but under the ceiling alone in its own chunk', () => {
+    const big = itemOfSize('/big', 600 * 1024); // > 400 KiB budget, < 900 KiB ceiling
+    const small = itemOfSize('/small', 10 * 1024);
+    const { chunks, tooLarge } = packConfirmChunks([small, big, small]);
+
+    expect(tooLarge).toHaveLength(0);
+    const bigChunk = chunks.find(c => c.some(i => i.path === '/big'));
+    expect(bigChunk).toHaveLength(1); // ships alone
+    // The lone big-item chunk is still under 1 MiB.
+    expect(serializedItemBytes(bigChunk![0]!)).toBeLessThan(1024 * 1024);
+  });
+
+  it('diverts a self-oversize item to tooLarge and never emits it in any chunk', () => {
+    const huge = itemOfSize('/huge', MAX_SINGLE_ITEM_BYTES + 50 * 1024);
+    const ok = itemOfSize('/ok', 20 * 1024);
+    const { chunks, tooLarge } = packConfirmChunks([ok, huge, ok]);
+
+    expect(tooLarge.map(i => i.path)).toEqual(['/huge']);
+    expect(chunks.flat().map(i => i.path)).toEqual(['/ok', '/ok']);
+    expect(chunks.flat().some(i => i.path === '/huge')).toBe(false);
+  });
+
+  it('respects the max-count secondary bound even when byte budget is not reached', () => {
+    // Tiny items — byte budget never trips, so only the count bound splits them.
+    const items = Array.from({ length: MAX_CHUNK_ITEMS + 5 }, (_, i) => ({ path: `/b/${i}`, title: 'T' }));
+    const { chunks } = packConfirmChunks(items);
+
+    expect(chunks[0]).toHaveLength(MAX_CHUNK_ITEMS);
+    expect(chunks[1]).toHaveLength(5);
+  });
+
+  it('carries review-step edits through into the packed items verbatim', () => {
+    const edited: ImportConfirmItem = { path: '/b', title: 'Edited Title', authorName: 'Edited Author', forceImport: true };
+    const { chunks } = packConfirmChunks([edited]);
+    expect(chunks[0]![0]).toEqual(edited);
+  });
+
+  it('returns no chunks when every item is self-oversize', () => {
+    const huge = itemOfSize('/huge', MAX_SINGLE_ITEM_BYTES + 1024);
+    const { chunks, tooLarge } = packConfirmChunks([huge]);
+    expect(chunks).toHaveLength(0);
+    expect(tooLarge).toHaveLength(1);
+  });
+});

--- a/src/client/lib/confirm-chunks.ts
+++ b/src/client/lib/confirm-chunks.ts
@@ -1,0 +1,77 @@
+import type { ImportConfirmItem } from '@/lib/api';
+
+/**
+ * Byte-budgeted chunk packer for the Library/Manual Import confirm POST (#1831).
+ *
+ * A first-run user with a large library selects hundreds–thousands of
+ * `ImportConfirmItem`s, each carrying an unbounded `metadata` pass-through blob
+ * (Audible descriptions run 1–4 KB+). Shipping them in one request blows past the
+ * 1 MiB body limit — Fastify's default and, more importantly, nginx's default
+ * `client_max_body_size` (which 413s at the proxy before Fastify is ever reached).
+ *
+ * So the client splits the selection into chunks packed greedily by *serialized
+ * byte size* and POSTs them sequentially. Every emitted chunk stays under
+ * {@link CHUNK_BYTE_BUDGET}; an item larger than the budget but under
+ * {@link MAX_SINGLE_ITEM_BYTES} ships alone in its own chunk (still under 1 MiB
+ * once the `{ books, mode }` envelope is added). An item whose *own* serialized
+ * size exceeds {@link MAX_SINGLE_ITEM_BYTES} is diverted to `tooLarge` and is
+ * NEVER packed or sent — no request that leaves the client can exceed 1 MiB by
+ * construction, so the guarantee does not rely on any server-side or proxy limit.
+ */
+
+/** Target per-chunk serialized size. Well under 1 MiB so many items batch per request. */
+export const CHUNK_BYTE_BUDGET = 400 * 1024; // 400 KiB
+/**
+ * Transport ceiling for a single item. Comfortably below the 1 MiB proxy floor once
+ * the `{ books, mode }` request envelope is added, so a lone item of this size still
+ * ships. An item above this is diverted to `tooLarge` pre-flight (never sent).
+ */
+export const MAX_SINGLE_ITEM_BYTES = 900 * 1024; // 900 KiB
+/** Secondary bound so a chunk of tiny items never balloons the request item count. */
+export const MAX_CHUNK_ITEMS = 200;
+
+export interface PackResult {
+  /** Chunks to POST sequentially. Each serializes under budget (or is a lone ship-alone item). */
+  chunks: ImportConfirmItem[][];
+  /** Items whose own serialized size exceeds the transport ceiling — never sent. */
+  tooLarge: ImportConfirmItem[];
+}
+
+/** Serialized UTF-8 byte size of a single confirm item (what actually crosses the wire). */
+export function serializedItemBytes(item: ImportConfirmItem): number {
+  return new TextEncoder().encode(JSON.stringify(item)).length;
+}
+
+export function packConfirmChunks(items: ImportConfirmItem[]): PackResult {
+  const chunks: ImportConfirmItem[][] = [];
+  const tooLarge: ImportConfirmItem[] = [];
+  let current: ImportConfirmItem[] = [];
+  let currentBytes = 0;
+
+  const flush = () => {
+    if (current.length > 0) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+  };
+
+  for (const item of items) {
+    const bytes = serializedItemBytes(item);
+    // Self-oversize: divert pre-flight, never pack or send (fail-open — stays selected upstream).
+    if (bytes > MAX_SINGLE_ITEM_BYTES) {
+      tooLarge.push(item);
+      continue;
+    }
+    // Start a new chunk when the current one would overflow the byte budget or the count bound.
+    // An item that alone exceeds the budget lands in an (otherwise empty) chunk and ships alone.
+    const overflowsBudget = currentBytes + bytes > CHUNK_BYTE_BUDGET;
+    const overflowsCount = current.length >= MAX_CHUNK_ITEMS;
+    if (current.length > 0 && (overflowsBudget || overflowsCount)) flush();
+    current.push(item);
+    currentBytes += bytes;
+  }
+  flush();
+
+  return { chunks, tooLarge };
+}

--- a/src/client/lib/confirm-chunks.ts
+++ b/src/client/lib/confirm-chunks.ts
@@ -37,9 +37,12 @@ export interface PackResult {
   tooLarge: ImportConfirmItem[];
 }
 
+/** Reused across every item serialization instead of ~5k per-pack allocations (#1833). */
+const encoder = new TextEncoder();
+
 /** Serialized UTF-8 byte size of a single confirm item (what actually crosses the wire). */
 export function serializedItemBytes(item: ImportConfirmItem): number {
-  return new TextEncoder().encode(JSON.stringify(item)).length;
+  return encoder.encode(JSON.stringify(item)).length;
 }
 
 export function packConfirmChunks(items: ImportConfirmItem[]): PackResult {

--- a/src/client/lib/import-outcome.test.ts
+++ b/src/client/lib/import-outcome.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect } from 'vitest';
-import { isCleanImport, importSkipSummary, buildOutcomeToast, acceptedItemPaths } from './import-outcome.js';
+import {
+  isCleanImport,
+  importSkipSummary,
+  buildOutcomeToast,
+  acceptedItemPaths,
+  buildChunkedOutcomeToast,
+  isChunkedCleanImport,
+  confirmErrorMessage,
+} from './import-outcome.js';
+import { ApiError } from '@/lib/api';
 import type { ImportResult } from '@/lib/api';
+import type { ChunkedConfirmResult } from './confirm-chunk-runner.js';
 
 const base: ImportResult = { accepted: 0, heldReview: [], skipped: [], failed: [] };
+
+/** A fully-submitted chunked run wrapping an aggregate ImportResult. */
+function submittedRun(aggregate: ImportResult): ChunkedConfirmResult {
+  return {
+    aggregateResult: aggregate,
+    submittedItems: [],
+    unsubmitted: { count: 0, inFlight: 0, remainder: 0, reason: null },
+    tooLarge: { count: 0 },
+  };
+}
 
 describe('isCleanImport (#1822)', () => {
   it('is clean only when held/skipped/failed are all empty', () => {
@@ -61,6 +81,56 @@ describe('buildOutcomeToast (#1822)', () => {
       .toEqual({ severity: 'warning', message: '1 already in your library' });
     expect(buildOutcomeToast({ ...base, accepted: 1, failed: [{ path: '/a', title: 'A', message: 'x' }] }, 'queued for import'))
       .toEqual({ severity: 'error', message: '1 queued for import · 1 failed' });
+  });
+});
+
+describe('isChunkedCleanImport (#1831)', () => {
+  it('is clean only when the aggregate is clean AND nothing is unsubmitted or too-large', () => {
+    expect(isChunkedCleanImport(submittedRun({ ...base, accepted: 3 }))).toBe(true);
+    const withUnsubmitted: ChunkedConfirmResult = { ...submittedRun({ ...base, accepted: 3 }), unsubmitted: { count: 2, inFlight: 1, remainder: 1, reason: 'x' } };
+    expect(isChunkedCleanImport(withUnsubmitted)).toBe(false);
+    const withTooLarge: ChunkedConfirmResult = { ...submittedRun({ ...base, accepted: 3 }), tooLarge: { count: 1 } };
+    expect(isChunkedCleanImport(withTooLarge)).toBe(false);
+  });
+});
+
+describe('buildChunkedOutcomeToast (#1831)', () => {
+  it('defers to buildOutcomeToast when everything packed was submitted', () => {
+    expect(buildChunkedOutcomeToast(submittedRun({ ...base, accepted: 2 }), 'registered'))
+      .toEqual({ severity: 'success', message: '2 books registered' });
+  });
+
+  it('mid-sequence failure: red toast naming accepted, the in-flight chunk, and the remainder', () => {
+    const res: ChunkedConfirmResult = {
+      aggregateResult: { ...base, accepted: 4 },
+      submittedItems: [],
+      unsubmitted: { count: 3, inFlight: 1, remainder: 2, reason: 'connection reset' },
+      tooLarge: { count: 0 },
+    };
+    expect(buildChunkedOutcomeToast(res, 'registered')).toEqual({
+      severity: 'error',
+      message: '4 registered · 1 not confirmed — connection failed mid-request; resubmitting is safe · 2 not submitted',
+    });
+  });
+
+  it('too-large only: amber toast naming the too-large rows, no green', () => {
+    const res: ChunkedConfirmResult = { ...submittedRun({ ...base, accepted: 2 }), tooLarge: { count: 1 } };
+    expect(buildChunkedOutcomeToast(res, 'registered')).toEqual({
+      severity: 'warning',
+      message: '2 registered · 1 too large to submit — remove or re-scan',
+    });
+  });
+});
+
+describe('confirmErrorMessage (#1831)', () => {
+  it('maps a 413 ApiError to actionable import-domain wording', () => {
+    const err = new ApiError(413, { error: 'Payload Too Large' });
+    expect(confirmErrorMessage(err)).toBe('The import request was too large to send. Select fewer books and try again.');
+  });
+
+  it('passes through a non-413 error message unchanged', () => {
+    expect(confirmErrorMessage(new ApiError(500, { error: 'boom' }))).toBe('boom');
+    expect(confirmErrorMessage(new Error('network failure'))).toBe('network failure');
   });
 });
 

--- a/src/client/lib/import-outcome.test.ts
+++ b/src/client/lib/import-outcome.test.ts
@@ -19,7 +19,7 @@ function submittedRun(aggregate: ImportResult): ChunkedConfirmResult {
   return {
     aggregateResult: aggregate,
     submittedItems: [],
-    unsubmitted: { count: 0, inFlight: 0, remainder: 0, reason: null },
+    unsubmitted: { count: 0, inFlight: 0, remainder: 0, reason: null, reasonKind: null },
     tooLarge: { count: 0 },
   };
 }
@@ -87,7 +87,7 @@ describe('buildOutcomeToast (#1822)', () => {
 describe('isChunkedCleanImport (#1831)', () => {
   it('is clean only when the aggregate is clean AND nothing is unsubmitted or too-large', () => {
     expect(isChunkedCleanImport(submittedRun({ ...base, accepted: 3 }))).toBe(true);
-    const withUnsubmitted: ChunkedConfirmResult = { ...submittedRun({ ...base, accepted: 3 }), unsubmitted: { count: 2, inFlight: 1, remainder: 1, reason: 'x' } };
+    const withUnsubmitted: ChunkedConfirmResult = { ...submittedRun({ ...base, accepted: 3 }), unsubmitted: { count: 2, inFlight: 1, remainder: 1, reason: 'x', reasonKind: 'transport' } };
     expect(isChunkedCleanImport(withUnsubmitted)).toBe(false);
     const withTooLarge: ChunkedConfirmResult = { ...submittedRun({ ...base, accepted: 3 }), tooLarge: { count: 1 } };
     expect(isChunkedCleanImport(withTooLarge)).toBe(false);
@@ -104,13 +104,26 @@ describe('buildChunkedOutcomeToast (#1831)', () => {
     const res: ChunkedConfirmResult = {
       aggregateResult: { ...base, accepted: 4 },
       submittedItems: [],
-      unsubmitted: { count: 3, inFlight: 1, remainder: 2, reason: 'connection reset' },
+      unsubmitted: { count: 3, inFlight: 1, remainder: 2, reason: 'connection reset', reasonKind: 'transport' },
       tooLarge: { count: 0 },
     };
     expect(buildChunkedOutcomeToast(res, 'registered')).toEqual({
       severity: 'error',
       message: '4 registered · 1 not confirmed — connection failed mid-request; resubmitting is safe · 2 not submitted',
     });
+  });
+
+  it('mid-sequence 413: red toast names the too-large cause and drops the resubmit-safe claim (#1833)', () => {
+    const res: ChunkedConfirmResult = {
+      aggregateResult: { ...base, accepted: 4 },
+      submittedItems: [],
+      unsubmitted: { count: 3, inFlight: 1, remainder: 2, reason: 'Payload Too Large', reasonKind: 'too-large' },
+      tooLarge: { count: 0 },
+    };
+    const toast = buildChunkedOutcomeToast(res, 'registered')!;
+    expect(toast.severity).toBe('error');
+    expect(toast.message).toContain('the import request was too large');
+    expect(toast.message).not.toContain('resubmitting is safe');
   });
 
   it('too-large only: amber toast naming the too-large rows, no green', () => {

--- a/src/client/lib/import-outcome.ts
+++ b/src/client/lib/import-outcome.ts
@@ -1,4 +1,7 @@
+import { ApiError } from '@/lib/api';
 import type { ImportResult, ImportConfirmItem } from '@/lib/api';
+import { getErrorMessage } from '@/lib/error-message.js';
+import type { ChunkedConfirmResult } from './confirm-chunk-runner.js';
 
 /**
  * Import-confirm outcome helpers (#1822). `confirmImport` returns four buckets —
@@ -86,4 +89,56 @@ export function acceptedItemPaths(submitted: ImportConfirmItem[], result: Import
     ...result.failed.map(f => f.path),
   ]);
   return new Set(submitted.map(i => i.path).filter(p => !nonAccepted.has(p)));
+}
+
+/**
+ * A run is fully clean only when the submitted aggregate is clean AND nothing was
+ * left unsubmitted (mid-run transport failure) or diverted as too-large (#1831).
+ * Green toast + navigation gate on this, not on the aggregate alone — otherwise a
+ * run with a never-sent remainder or a too-large row would report a false success.
+ */
+export function isChunkedCleanImport(res: ChunkedConfirmResult): boolean {
+  return isCleanImport(res.aggregateResult) && res.unsubmitted.count === 0 && res.tooLarge.count === 0;
+}
+
+/**
+ * Build the consolidated outcome toast for a chunked confirm run (#1831). When the
+ * run submitted everything it packed, this defers to {@link buildOutcomeToast} over
+ * the aggregate (identical to the single-request behavior). When a chunk failed
+ * mid-run or rows were diverted as too-large, it appends actionable, resubmit-safe
+ * clauses distinguishing the failing in-flight chunk, the never-sent remainder, and
+ * the too-large rows — and never colours the result green.
+ */
+export function buildChunkedOutcomeToast(res: ChunkedConfirmResult, acceptedVerb: string): OutcomeToast | null {
+  const agg = res.aggregateResult;
+  const { unsubmitted, tooLarge } = res;
+  if (unsubmitted.count === 0 && tooLarge.count === 0) {
+    return buildOutcomeToast(agg, acceptedVerb);
+  }
+
+  const parts: string[] = [];
+  if (agg.accepted > 0) parts.push(`${agg.accepted} ${acceptedVerb}`);
+  if (agg.skipped.length > 0) parts.push(importSkipSummary(agg.skipped));
+  if (agg.failed.length > 0) parts.push(`${agg.failed.length} failed`);
+  if (unsubmitted.inFlight > 0) parts.push(`${unsubmitted.inFlight} not confirmed — connection failed mid-request; resubmitting is safe`);
+  if (unsubmitted.remainder > 0) parts.push(`${unsubmitted.remainder} not submitted`);
+  if (tooLarge.count > 0) parts.push(`${tooLarge.count} too large to submit — remove or re-scan`);
+
+  // A transport failure (unsubmitted) or a hard confirm failure reads red; a batch that
+  // only skipped or diverted too-large rows reads amber.
+  const severity: OutcomeToast['severity'] = unsubmitted.count > 0 || agg.failed.length > 0 ? 'error' : 'warning';
+  return { severity, message: parts.join(' · ') };
+}
+
+/**
+ * Import-domain wording for a confirm/import failure (#1831). A 413 (from either the
+ * Fastify body limit or, more commonly, the nginx proxy hop that bypasses our error
+ * handler entirely) is mapped to an actionable message telling the user the request was
+ * too large — the raw "Payload Too Large" / generic message reads as a mystery failure.
+ */
+export function confirmErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status === 413) {
+    return 'The import request was too large to send. Select fewer books and try again.';
+  }
+  return getErrorMessage(error);
 }

--- a/src/client/lib/import-outcome.ts
+++ b/src/client/lib/import-outcome.ts
@@ -120,7 +120,13 @@ export function buildChunkedOutcomeToast(res: ChunkedConfirmResult, acceptedVerb
   if (agg.accepted > 0) parts.push(`${agg.accepted} ${acceptedVerb}`);
   if (agg.skipped.length > 0) parts.push(importSkipSummary(agg.skipped));
   if (agg.failed.length > 0) parts.push(`${agg.failed.length} failed`);
-  if (unsubmitted.inFlight > 0) parts.push(`${unsubmitted.inFlight} not confirmed — connection failed mid-request; resubmitting is safe`);
+  if (unsubmitted.inFlight > 0) {
+    // A deterministic 413 fails identically on every retry, so it must NOT claim
+    // resubmitting is safe — name the too-large cause with actionable wording instead (#1833).
+    parts.push(unsubmitted.reasonKind === 'too-large'
+      ? `${unsubmitted.inFlight} not sent — the import request was too large; select fewer books and try again`
+      : `${unsubmitted.inFlight} not confirmed — connection failed mid-request; resubmitting is safe`);
+  }
   if (unsubmitted.remainder > 0) parts.push(`${unsubmitted.remainder} not submitted`);
   if (tooLarge.count > 0) parts.push(`${tooLarge.count} too large to submit — remove or re-scan`);
 

--- a/src/client/pages/library-import/LibraryImportPage.test.tsx
+++ b/src/client/pages/library-import/LibraryImportPage.test.tsx
@@ -873,6 +873,45 @@ describe('LibraryImportPage (#133)', () => {
     });
   });
 
+  describe('chunked register progress label (#1833)', () => {
+    it('renders a non-zero first-chunk progress label during a multi-chunk register', async () => {
+      vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] });
+
+      // Big metadata blobs push each confirm item over half the chunk budget, so the runner
+      // splits the register into 2 chunks (1 book each). The first chunk must render
+      // "Registering 1 of 2" while POSTing — never "Registering 0 of 2".
+      const bigDesc = 'x'.repeat(300 * 1024);
+      mockApi.scanDirectory!.mockResolvedValue({
+        discoveries: [
+          { path: '/audiobooks/A/B1', parsedTitle: 'Book 1', parsedAuthor: 'A', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: false },
+          { path: '/audiobooks/A/B2', parsedTitle: 'Book 2', parsedAuthor: 'A', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: false },
+        ],
+        totalFolders: 2,
+      });
+      mockApi.getMatchJob!.mockResolvedValue({
+        id: 'job-1', status: 'completed', total: 2, matched: 2,
+        results: [
+          { path: '/audiobooks/A/B1', confidence: 'high', bestMatch: { title: 'Book 1', authors: [{ name: 'A' }], asin: 'A1', description: bigDesc }, alternatives: [] },
+          { path: '/audiobooks/A/B2', confidence: 'high', bestMatch: { title: 'Book 2', authors: [{ name: 'A' }], asin: 'A2', description: bigDesc }, alternatives: [] },
+        ],
+      });
+      // Deferred confirm — chunk 1 stays in-flight so the pending progress label is observable.
+      mockApi.confirmImport!.mockReturnValue(new Promise(() => {}));
+
+      renderWithProviders(<LibraryImportPage />);
+      await waitFor(() => { expect(screen.getByText('Book 1')).toBeInTheDocument(); });
+      await act(async () => { vi.advanceTimersByTime(2000); });
+      await waitFor(() => { expect(screen.getByRole('button', { name: /import 2 books/i })).toBeEnabled(); });
+
+      await userEvent.click(screen.getByRole('button', { name: /import 2 books/i }));
+
+      await waitFor(() => { expect(screen.getByText(/Registering 1 of 2/)).toBeInTheDocument(); });
+      expect(screen.queryByText(/Registering 0 of 2/)).not.toBeInTheDocument();
+
+      vi.useRealTimers();
+    });
+  });
+
   describe('relative path computation (AC1: uses segment-based pathUtils, not startsWith)', () => {
     it('passes relative portion as relativePath prop to ImportCard when book path is inside library root', async () => {
       mockApi.scanDirectory!.mockResolvedValue({

--- a/src/client/pages/library-import/LibraryImportPage.tsx
+++ b/src/client/pages/library-import/LibraryImportPage.tsx
@@ -6,6 +6,7 @@ import { ArrowLeftIcon, CheckIcon, AlertCircleIcon, LoadingSpinner } from '@/com
 import { PageHeader } from '@/components/PageHeader.js';
 import { makeRelativePath } from '@/lib/pathUtils.js';
 import { useLibraryImport } from './useLibraryImport.js';
+import { isLibraryDbDuplicate } from './isLibraryDbDuplicate.js';
 
 // eslint-disable-next-line max-lines-per-function, complexity -- page orchestrator with scan, match, duplicate, register flows
 export function LibraryImportPage() {
@@ -43,8 +44,7 @@ export function LibraryImportPage() {
   } = useLibraryImport();
 
   const [showExisting, setShowExisting] = useState(false);
-  const isDbDup = (r: typeof rows[number]) => r.book.isDuplicate && r.book.duplicateReason !== 'within-scan';
-  const displayedRows = rows.filter(r => showExisting || !isDbDup(r));
+  const displayedRows = rows.filter(r => showExisting || !isLibraryDbDuplicate(r.book));
   const rowIndexMap = new Map(rows.map((r, i) => [r, i]));
 
   return (
@@ -172,7 +172,7 @@ export function LibraryImportPage() {
                 {allSelected && <CheckIcon className="w-3 h-3" />}
               </button>
               <span className="text-xs font-medium text-muted-foreground">
-                {selectedCount} of {rows.filter(r => !isDbDup(r)).length} new selected
+                {selectedCount} of {rows.filter(r => !isLibraryDbDuplicate(r.book)).length} new selected
               </span>
               {duplicateCount > 0 && (
                 <button

--- a/src/client/pages/library-import/LibraryImportPage.tsx
+++ b/src/client/pages/library-import/LibraryImportPage.tsx
@@ -20,6 +20,7 @@ export function LibraryImportPage() {
     setEditIndex,
     isMatching,
     progress,
+    chunkProgress,
     libraryRoot,
     heldReview,
     handleToggle,
@@ -215,7 +216,9 @@ export function LibraryImportPage() {
               disabled={!!matchJobError}
               registerLabel={
                 registerMutation.isPending
-                  ? 'Importing...'
+                  ? (chunkProgress && chunkProgress.chunks > 1
+                      ? `Registering ${chunkProgress.current} of ${chunkProgress.total}…`
+                      : 'Importing...')
                   : `Import ${selectedCount} book${selectedCount !== 1 ? 's' : ''}`
               }
             />

--- a/src/client/pages/library-import/isLibraryDbDuplicate.test.ts
+++ b/src/client/pages/library-import/isLibraryDbDuplicate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { isLibraryDbDuplicate } from './isLibraryDbDuplicate.js';
+import type { DiscoveredBook } from '@/lib/api';
+
+type DuplicateReason = NonNullable<DiscoveredBook['duplicateReason']>;
+
+function book(overrides: Partial<DiscoveredBook>): DiscoveredBook {
+  return {
+    path: '/a/Book',
+    parsedTitle: 'Book',
+    parsedAuthor: 'Author',
+    parsedSeries: null,
+    fileCount: 1,
+    totalSize: 1000,
+    isDuplicate: false,
+    ...overrides,
+  };
+}
+
+describe('isLibraryDbDuplicate (#1833)', () => {
+  // Exhaustive over every DuplicateReason value so the hook and page — which both import this
+  // one predicate — provably agree about DB-duplicate status no matter how the enum grows.
+  const cases: Array<{ reason: DuplicateReason | undefined; isDuplicate: boolean; expected: boolean }> = [
+    { reason: 'path', isDuplicate: true, expected: true },
+    { reason: 'slug', isDuplicate: true, expected: true },
+    { reason: 'within-scan', isDuplicate: true, expected: false },
+    { reason: undefined, isDuplicate: false, expected: false },
+  ];
+
+  for (const { reason, isDuplicate, expected } of cases) {
+    it(`isDuplicate=${isDuplicate} reason=${String(reason)} → ${expected}`, () => {
+      expect(isLibraryDbDuplicate(book({ isDuplicate, ...(reason !== undefined && { duplicateReason: reason }) }))).toBe(expected);
+    });
+  }
+
+  it('a within-scan collision is never a DB duplicate even though isDuplicate is true', () => {
+    expect(isLibraryDbDuplicate(book({ isDuplicate: true, duplicateReason: 'within-scan' }))).toBe(false);
+  });
+});

--- a/src/client/pages/library-import/isLibraryDbDuplicate.ts
+++ b/src/client/pages/library-import/isLibraryDbDuplicate.ts
@@ -1,0 +1,19 @@
+import type { DiscoveredBook } from '@/lib/api';
+
+/**
+ * The single library-import DB-duplicate decision (#1833). A book is a DB-backed
+ * duplicate (already in the library by path or slug) when it is flagged `isDuplicate`
+ * for a reason OTHER than `within-scan` — a within-scan collision is two folders in the
+ * same scan, not something already owned, so it stays actionable.
+ *
+ * This decision drives BOTH selection/counts/pending/retry-match eligibility (the hook)
+ * AND row visibility/the "N new" denominator (the page). They MUST agree or the UI lies
+ * about importability when `duplicateReason` grows a case, so both sites call this one
+ * predicate rather than re-deriving it (the DRY-3 twin-drift class).
+ *
+ * NOTE: Manual import intentionally uses a different predicate (`row.book.isDuplicate`
+ * directly) — a different trust boundary — and must NOT be unified with this.
+ */
+export function isLibraryDbDuplicate(book: DiscoveredBook): boolean {
+  return book.isDuplicate && book.duplicateReason !== 'within-scan';
+}

--- a/src/client/pages/library-import/useLibraryImport.test.ts
+++ b/src/client/pages/library-import/useLibraryImport.test.ts
@@ -749,6 +749,43 @@ describe('useLibraryImport hook (#133)', () => {
     expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not confirmed'));
   });
 
+  it('held item from an early chunk survives a later chunk failure (#1831)', async () => {
+    // captureHeld REPLACES held state, so it must run once over the aggregate at run end —
+    // a per-chunk capture (or an onError that skips it) would drop chunk 1's held item.
+    mockScanDirectory.mockResolvedValue({
+      ...mockScanResult,
+      discoveries: [
+        { path: '/audiobooks/X/B1', parsedTitle: 'B1', parsedAuthor: 'X', parsedSeries: null, fileCount: 1, totalSize: 1, isDuplicate: false },
+        { path: '/audiobooks/Y/B2', parsedTitle: 'B2', parsedAuthor: 'Y', parsedSeries: null, fileCount: 1, totalSize: 1, isDuplicate: false },
+      ],
+    });
+    mockConfirmImport
+      .mockResolvedValueOnce({
+        accepted: 0,
+        heldReview: [{ path: '/audiobooks/X/B1', title: 'B1', reason: 'recording-review-required' }],
+        skipped: [],
+        failed: [],
+      })
+      .mockRejectedValueOnce(new Error('connection reset'));
+
+    const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.rows.length).toBe(2));
+
+    // Push each row over the chunk byte budget → two separate chunks.
+    act(() => result.current.handleEdit(0, { title: 'B1', author: 'X', series: '', metadata: bigMetadata(500 * 1024) }));
+    act(() => result.current.handleEdit(1, { title: 'B2', author: 'Y', series: '', metadata: bigMetadata(500 * 1024) }));
+    act(() => result.current.handleRegister());
+
+    await waitFor(() => expect(mockConfirmImport).toHaveBeenCalledTimes(2));
+    // Chunk 1's held item is captured despite chunk 2's failure.
+    await waitFor(() => expect(result.current.heldReview).toHaveLength(1));
+    expect(result.current.heldReview[0]!.path).toBe('/audiobooks/X/B1');
+    expect(toast.warning).toHaveBeenCalledWith('1 held for recording review');
+    // The run failure still surfaces, and nothing navigates.
+    expect(toast.error).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   // AC3: empty state (#141)
   it('returns emptyResult=true when scan returns zero discoveries', async () => {
     mockScanDirectory.mockResolvedValue({ discoveries: [], totalFolders: 0 });

--- a/src/client/pages/library-import/useLibraryImport.test.ts
+++ b/src/client/pages/library-import/useLibraryImport.test.ts
@@ -4,9 +4,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { useLibraryImport } from './useLibraryImport';
-import type { ScanResult } from '@/lib/api';
+import { ApiError } from '@/lib/api';
+import type { BookMetadata, ScanResult } from '@/lib/api';
 import { createMockSettings } from '@/__tests__/factories';
 import { toast } from 'sonner';
+
+/** A metadata blob padded so a confirm item serializes to roughly `bytes`. */
+const bigMetadata = (bytes: number): BookMetadata => ({ blob: 'x'.repeat(bytes) } as unknown as BookMetadata);
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async () => {
@@ -22,7 +26,12 @@ const mockCancelMatchJob = vi.fn();
 const mockGetSettings = vi.fn();
 const mockGetBookIdentifiers = vi.fn();
 
-vi.mock('@/lib/api', () => ({
+// Preserve the real runtime exports (notably `ApiError`, imported at runtime by the
+// 413 mapping in confirmErrorMessage — #1831) and override only `api`. Replacing the
+// barrel wholesale would drop ApiError and break the confirm error path
+// (vimock-barrel-replace-drops-named-exports).
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
   api: {
     scanDirectory: (...args: unknown[]) => mockScanDirectory(...args),
     confirmImport: (...args: unknown[]) => mockConfirmImport(...args),
@@ -66,6 +75,9 @@ describe('useLibraryImport hook (#133)', () => {
     mockStartMatchJob.mockResolvedValue({ jobId: 'job-1' });
     mockGetMatchJob.mockResolvedValue({ id: 'job-1', status: 'matching', total: 1, matched: 0, results: [] });
     mockCancelMatchJob.mockResolvedValue({ cancelled: true });
+    // Chunked confirm runner (#1831) expects each chunk POST to resolve with an ImportResult;
+    // tests that assert on outcomes override this.
+    mockConfirmImport.mockResolvedValue({ accepted: 0, heldReview: [], skipped: [], failed: [] });
   });
 
   it('on mount with library path configured: calls api.scanDirectory, starts match job, transitions to review state', async () => {
@@ -146,6 +158,15 @@ describe('useLibraryImport hook (#133)', () => {
   });
 
   it('post-match duplicate (F8): high-confidence result flagged isDuplicate deselects the row and excludes it from the confirm payload (#1662)', async () => {
+    // A selectable sibling keeps the confirm request non-empty so the payload actually ships;
+    // the flagged duplicate (Book1) must be absent from it.
+    mockScanDirectory.mockResolvedValue({
+      ...mockScanResult,
+      discoveries: [
+        ...mockScanResult.discoveries,
+        { path: '/audiobooks/AuthorD/Book4', parsedTitle: 'Book Four', parsedAuthor: 'Author D', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: false },
+      ],
+    });
     mockGetMatchJob.mockResolvedValue({
       id: 'job-1',
       status: 'completed',
@@ -177,10 +198,11 @@ describe('useLibraryImport hook (#133)', () => {
       expect(row?.selected).toBe(false);
     }, { timeout: 5000 });
 
-    // It is therefore absent from the confirm payload.
+    // It is therefore absent from the confirm payload (which still carries the sibling).
     act(() => result.current.handleRegister());
     await waitFor(() => expect(mockConfirmImport).toHaveBeenCalled());
-    const items = mockConfirmImport.mock.calls[0]![0] as Array<{ path: string }>;
+    const items = mockConfirmImport.mock.calls.flatMap(c => c[0] as Array<{ path: string }>);
+    expect(items.some(i => i.path === '/audiobooks/AuthorD/Book4')).toBe(true);
     expect(items.some(i => i.path === '/audiobooks/AuthorA/Book1')).toBe(false);
   });
 
@@ -663,8 +685,68 @@ describe('useLibraryImport hook (#133)', () => {
     await act(async () => { result.current.handleRegister(); });
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Registration failed: network failure');
+      expect(toast.error).toHaveBeenCalledWith('Import failed: network failure');
     });
+  });
+
+  it('413 confirm failure maps to import-domain wording (#1831)', async () => {
+    mockConfirmImport.mockRejectedValue(new ApiError(413, { error: 'Payload Too Large' }));
+
+    const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.step).toBe('review'));
+    await act(async () => { result.current.handleRegister(); });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Import failed: The import request was too large to send. Select fewer books and try again.',
+      );
+    });
+  });
+
+  it('self-oversize confirm item is diverted to tooLarge — never sent, row stays selected, no navigation (#1831)', async () => {
+    const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.step).toBe('review'));
+
+    // Edit Book1 to carry a metadata blob above the per-item transport ceiling (~900 KiB).
+    const idx = result.current.rows.findIndex(r => r.book.path === '/audiobooks/AuthorA/Book1');
+    act(() => result.current.handleEdit(idx, { title: 'Book One', author: 'Author A', series: '', metadata: bigMetadata(950 * 1024) }));
+
+    act(() => result.current.handleRegister());
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(expect.stringContaining('too large to submit')));
+    // No POST leaves the client, and nothing navigates.
+    expect(mockConfirmImport).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    // The too-large row stays selected (fail-open — nothing landed).
+    expect(result.current.rows.find(r => r.book.path === '/audiobooks/AuthorA/Book1')?.selected).toBe(true);
+  });
+
+  it('mid-sequence chunk failure applies completed chunks and keeps the remainder selected, no navigation (#1831)', async () => {
+    // Two selectable rows, each edited above the chunk byte budget → two separate chunks.
+    mockScanDirectory.mockResolvedValue({
+      ...mockScanResult,
+      discoveries: [
+        { path: '/audiobooks/X/B1', parsedTitle: 'B1', parsedAuthor: 'X', parsedSeries: null, fileCount: 1, totalSize: 1, isDuplicate: false },
+        { path: '/audiobooks/Y/B2', parsedTitle: 'B2', parsedAuthor: 'Y', parsedSeries: null, fileCount: 1, totalSize: 1, isDuplicate: false },
+      ],
+    });
+    mockConfirmImport
+      .mockResolvedValueOnce({ accepted: 1, heldReview: [], skipped: [], failed: [] })
+      .mockRejectedValueOnce(new Error('connection reset'));
+
+    const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.rows.length).toBe(2));
+
+    act(() => result.current.handleEdit(0, { title: 'B1', author: 'X', series: '', metadata: bigMetadata(500 * 1024) }));
+    act(() => result.current.handleEdit(1, { title: 'B2', author: 'Y', series: '', metadata: bigMetadata(500 * 1024) }));
+    act(() => result.current.handleRegister());
+
+    await waitFor(() => expect(mockConfirmImport).toHaveBeenCalledTimes(2));
+    // Completed chunk's row is deselected; the failing/never-sent row stays selected.
+    await waitFor(() => expect(result.current.rows.find(r => r.book.path === '/audiobooks/X/B1')?.selected).toBe(false));
+    expect(result.current.rows.find(r => r.book.path === '/audiobooks/Y/B2')?.selected).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not confirmed'));
   });
 
   // AC3: empty state (#141)

--- a/src/client/pages/library-import/useLibraryImport.ts
+++ b/src/client/pages/library-import/useLibraryImport.ts
@@ -11,7 +11,8 @@ import { useHeldReview, toConfirmItem } from '@/components/held-review';
 import type { DiscoveredBook } from '@/lib/api';
 import { getErrorMessage } from '@/lib/error-message.js';
 import { upgradeMatchConfidence } from '@/lib/upgrade-match-confidence.js';
-import { isCleanImport, buildOutcomeToast, acceptedItemPaths } from '@/lib/import-outcome.js';
+import { acceptedItemPaths, buildChunkedOutcomeToast, isChunkedCleanImport, confirmErrorMessage } from '@/lib/import-outcome.js';
+import { runChunkedConfirm } from '@/lib/confirm-chunk-runner.js';
 
 export type Step = 'scanning' | 'review' | 'error';
 
@@ -31,6 +32,8 @@ export function useLibraryImport() {
   const [emptyResult, setEmptyResult] = useState(false);
   const [rows, setRows] = useState<ImportRow[]>([]);
   const [editIndex, setEditIndex] = useState<number | null>(null);
+  // Progress across the sequential chunked confirm run (#1831) — drives "Registering X of Y…".
+  const [chunkProgress, setChunkProgress] = useState<{ current: number; total: number; chunks: number } | null>(null);
   // Items the server held for recording review (#1711) — surfaced for re-confirm.
   // Library always registers with mode `undefined`, so the snapshot is unused here.
   const { heldReview, captureHeld, clearHeld, handleReconfirmHeld } = useHeldReview({
@@ -122,40 +125,49 @@ export function useLibraryImport() {
   });
 
   const registerMutation = useMutation({
-    mutationFn: (items: ImportConfirmItem[]) => api.confirmImport(items, undefined),
-    onSuccess: (result, variables) => {
+    // Byte-budgeted chunked confirm (#1831). A large library exceeds the 1 MiB body
+    // limit in one request, so the runner packs the selection into sub-1-MiB chunks and
+    // POSTs them sequentially, resolving with the aggregate + the actually-submitted items.
+    mutationFn: (items: ImportConfirmItem[]) =>
+      runChunkedConfirm({ items, mode: undefined, confirm: api.confirmImport, onProgress: setChunkProgress }),
+    onSuccess: (res) => {
+      const { aggregateResult, submittedItems } = res;
       queryClient.invalidateQueries({ queryKey: queryKeys.books() });
 
-      // Held items (#1711): keep the user on the page so they can re-confirm them,
-      // instead of navigating. Surfaced separately from the outcome toast below so a
+      // Held items (#1711): keep the user on the page so they can re-confirm them, instead
+      // of navigating. Captured ONCE over the aggregate (#1831) — a per-chunk call would
+      // clobber earlier chunks' held items. Surfaced separately from the outcome toast so a
       // held + skipped/failed batch is never swallowed by an early return (#1822).
-      if (result.heldReview.length > 0) {
-        captureHeld(result.heldReview, undefined);
-        toast.warning(`${result.heldReview.length} held for recording review`);
+      if (aggregateResult.heldReview.length > 0) {
+        captureHeld(aggregateResult.heldReview, undefined);
+        toast.warning(`${aggregateResult.heldReview.length} held for recording review`);
       } else {
         clearHeld();
       }
 
-      // Report accepted/skipped/failed. Green fires ONLY on a fully-clean outcome
-      // (#1822) — a zero-accepted or partial batch shows amber/red naming the reason,
-      // never a green "0 registered" lie.
-      const outcome = buildOutcomeToast(result, 'registered');
+      // Report accepted/skipped/failed + the chunked transport splits (unsubmitted / too
+      // large). Green fires ONLY on a fully-clean, fully-submitted outcome (#1822/#1831).
+      const outcome = buildChunkedOutcomeToast(res, 'registered');
       if (outcome) toast[outcome.severity](outcome.message);
 
-      // Navigate only when everything landed as accepted; otherwise stay and deselect
-      // the accepted rows so a re-submit can't re-send them (#1822).
-      if (isCleanImport(result)) {
+      // Navigate only when the ENTIRE selection landed accepted (nothing held/skipped/
+      // failed/unsubmitted/too-large); otherwise stay and deselect the accepted rows over
+      // submittedItems — NOT the full selection — so the never-sent remainder stays selected.
+      if (isChunkedCleanImport(res)) {
         navigate('/library');
         return;
       }
-      const acceptedPaths = acceptedItemPaths(variables, result);
+      const acceptedPaths = acceptedItemPaths(submittedItems, aggregateResult);
       if (acceptedPaths.size > 0) {
         setRows(prev => prev.map(r => acceptedPaths.has(r.book.path) ? { ...r, selected: false } : r));
       }
     },
     onError: (error: Error) => {
-      toast.error(`Registration failed: ${getErrorMessage(error)}`);
+      // First-chunk failure (nothing submitted) rejects here, exactly as a single-request
+      // failure did. 413 (Fastify or the proxy hop) maps to import-domain wording (#1831).
+      toast.error(`Import failed: ${confirmErrorMessage(error)}`);
     },
+    onSettled: () => setChunkProgress(null),
   });
 
   // Auto-scan on mount once settings are loaded and we have a library path.
@@ -273,6 +285,7 @@ export function useLibraryImport() {
     setEditIndex,
     isMatching,
     progress,
+    chunkProgress,
     libraryRoot,
     heldReview,
 

--- a/src/client/pages/library-import/useLibraryImport.ts
+++ b/src/client/pages/library-import/useLibraryImport.ts
@@ -13,13 +13,9 @@ import { getErrorMessage } from '@/lib/error-message.js';
 import { upgradeMatchConfidence } from '@/lib/upgrade-match-confidence.js';
 import { acceptedItemPaths, buildChunkedOutcomeToast, isChunkedCleanImport, confirmErrorMessage } from '@/lib/import-outcome.js';
 import { runChunkedConfirm } from '@/lib/confirm-chunk-runner.js';
+import { isLibraryDbDuplicate } from './isLibraryDbDuplicate.js';
 
 export type Step = 'scanning' | 'review' | 'error';
-
-/** Returns true for DB-backed duplicates (path/slug), false for within-scan duplicates and non-duplicates. */
-function isDbDuplicate(book: DiscoveredBook): boolean {
-  return book.isDuplicate && book.duplicateReason !== 'within-scan';
-}
 
 // eslint-disable-next-line max-lines-per-function -- orchestrates scan, match job, and slug-duplicate recheck
 export function useLibraryImport() {
@@ -71,7 +67,7 @@ export function useLibraryImport() {
     setRows(prev => prev.map(row => {
       const match = resultMap.get(row.book.path);
       if (!match) return row;
-      if (isDbDuplicate(row.book)) return row;
+      if (isLibraryDbDuplicate(row.book)) return row;
       return mergeMatchIntoRow(row, match);
     }));
   }, []);
@@ -86,7 +82,7 @@ export function useLibraryImport() {
   const scanMutation = useMutation({
     mutationFn: (path: string) => api.scanDirectory(path),
     onSuccess: (result) => {
-      if (result.discoveries.length === 0 || result.discoveries.every(d => isDbDuplicate(d))) {
+      if (result.discoveries.length === 0 || result.discoveries.every(d => isLibraryDbDuplicate(d))) {
         setEmptyResult(true);
         setStep('review');
         return;
@@ -109,7 +105,7 @@ export function useLibraryImport() {
       setStep('review');
 
       const candidates = result.discoveries
-        .filter(d => !isDbDuplicate(d))
+        .filter(d => !isLibraryDbDuplicate(d))
         .map(d => ({
           path: d.path,
           title: d.parsedTitle,
@@ -192,9 +188,9 @@ export function useLibraryImport() {
 
   const handleSelectAll = useCallback(() => {
     setRows(prev => {
-      const selectableRows = prev.filter(r => !isDbDuplicate(r.book));
+      const selectableRows = prev.filter(r => !isLibraryDbDuplicate(r.book));
       const allSelected = selectableRows.length > 0 && selectableRows.every(r => r.selected);
-      return prev.map(r => isDbDuplicate(r.book) ? r : { ...r, selected: !allSelected });
+      return prev.map(r => isLibraryDbDuplicate(r.book) ? r : { ...r, selected: !allSelected });
     });
   }, []);
 
@@ -248,7 +244,7 @@ export function useLibraryImport() {
 
   const handleRetryMatch = useCallback(() => {
     const candidates = rows
-      .filter(r => !isDbDuplicate(r.book))
+      .filter(r => !isLibraryDbDuplicate(r.book))
       .map(r => ({
         path: r.book.path,
         title: r.edited.title,
@@ -263,13 +259,13 @@ export function useLibraryImport() {
   // Computed counts
   const selectedCount = rows.filter(r => r.selected).length;
   const selectedUnmatchedCount = rows.filter(r => r.selected && r.matchResult?.confidence === 'none').length;
-  const readyCount = rows.filter(r => r.selected && !isDbDuplicate(r.book) && r.matchResult?.confidence === 'high').length;
+  const readyCount = rows.filter(r => r.selected && !isLibraryDbDuplicate(r.book) && r.matchResult?.confidence === 'high').length;
   const reviewCount = rows.filter(r => r.matchResult?.confidence === 'medium').length;
   const noMatchCount = rows.filter(r => r.matchResult?.confidence === 'none').length;
-  const pendingCount = rows.filter(r => !r.matchResult && !isDbDuplicate(r.book)).length;
-  const selectedPendingCount = rows.filter(r => r.selected && !r.matchResult && !isDbDuplicate(r.book)).length;
-  const duplicateCount = rows.filter(r => isDbDuplicate(r.book)).length;
-  const allSelected = rows.length > 0 && rows.filter(r => !isDbDuplicate(r.book)).every(r => r.selected);
+  const pendingCount = rows.filter(r => !r.matchResult && !isLibraryDbDuplicate(r.book)).length;
+  const selectedPendingCount = rows.filter(r => r.selected && !r.matchResult && !isLibraryDbDuplicate(r.book)).length;
+  const duplicateCount = rows.filter(r => isLibraryDbDuplicate(r.book)).length;
+  const allSelected = rows.length > 0 && rows.filter(r => !isLibraryDbDuplicate(r.book)).every(r => r.selected);
 
   // Library root path for relative-path computation
   const libraryRoot = settings?.library.path ?? '';

--- a/src/client/pages/manual-import/ManualImportPage.test.tsx
+++ b/src/client/pages/manual-import/ManualImportPage.test.tsx
@@ -646,6 +646,44 @@ describe('ManualImportPage', () => {
     });
   });
 
+  describe('chunked register progress label (#1833)', () => {
+    it('multi-chunk register renders a non-zero first-chunk progress label', async () => {
+      // Big metadata blobs split the confirm run into 2 chunks (1 book each). The first chunk
+      // must render "Registering 1 of 2" while POSTing, never "Registering 0 of 2".
+      const bigDesc = 'x'.repeat(300 * 1024);
+      const books = [
+        makeDiscoveredBook({ path: '/a/B1', parsedTitle: 'B1' }),
+        makeDiscoveredBook({ path: '/a/B2', parsedTitle: 'B2' }),
+      ];
+      const { rerender } = await scanAndReview(books);
+      await simulateMatchResults(rerender, [
+        makeMatchResult({ path: '/a/B1', bestMatch: { title: 'B1', authors: [{ name: 'A' }], asin: 'A1', description: bigDesc } }),
+        makeMatchResult({ path: '/a/B2', bestMatch: { title: 'B2', authors: [{ name: 'A' }], asin: 'A2', description: bigDesc } }),
+      ]);
+
+      // Deferred confirm — chunk 1 stays in-flight so the pending progress label is observable.
+      mockConfirmImport.mockReturnValue(new Promise(() => {}));
+      await userEvent.click(screen.getByRole('button', { name: /Import 2/ }));
+
+      expect(await screen.findByText(/Registering 1 of 2/)).toBeInTheDocument();
+      expect(screen.queryByText(/Registering 0 of 2/)).not.toBeInTheDocument();
+    });
+
+    it('single-chunk register keeps the plain "Importing…" pending label', async () => {
+      const book = makeDiscoveredBook();
+      const { rerender } = await scanAndReview([book]);
+      await simulateMatchResults(rerender, [makeMatchResult()]);
+
+      // A single small item packs into one chunk — the multi-chunk "Registering X of Y" label
+      // is gated on chunks > 1, so the summary bar shows its default pending label instead.
+      mockConfirmImport.mockReturnValue(new Promise(() => {}));
+      await userEvent.click(screen.getByRole('button', { name: /Import 1/ }));
+
+      expect(await screen.findByText(/Importing\.\.\./)).toBeInTheDocument();
+      expect(screen.queryByText(/Registering/)).not.toBeInTheDocument();
+    });
+  });
+
   describe('held-review panel (#1732)', () => {
     it('renders held titles and a re-confirm button instead of navigating away', async () => {
       mockConfirmImport.mockResolvedValueOnce({

--- a/src/client/pages/manual-import/ManualImportPage.tsx
+++ b/src/client/pages/manual-import/ManualImportPage.tsx
@@ -22,7 +22,7 @@ export function ManualImportPage() {
   const libraryPath = settings?.library?.path ?? '';
 
   const { state, actions, mutations, counts } = useManualImport({ onScanSuccess: folderHistory.addRecent, libraryPath });
-  const { step, scanPath, setScanPath, scanError, setScanError, rows, mode, setMode, editIndex, setEditIndex, isMatching, progress, heldReview } = state;
+  const { step, scanPath, setScanPath, scanError, setScanError, rows, mode, setMode, editIndex, setEditIndex, isMatching, progress, chunkProgress, heldReview } = state;
   const { handleScan, handleToggle, handleToggleAll, handleEdit, handleImport, handleBack, handleReconfirmHeld } = actions;
   const { scanMutation, importMutation } = mutations;
   const { selectedCount, selectedUnmatchedCount, readyCount, reviewCount, noMatchCount, pendingCount, selectedPendingCount, duplicateCount, allSelected } = counts;
@@ -128,6 +128,9 @@ export function ManualImportPage() {
               onModeChange={setMode}
               onImport={handleImport}
               importing={importMutation.isPending}
+              {...(importMutation.isPending && chunkProgress && chunkProgress.chunks > 1
+                ? { registerLabel: `Registering ${chunkProgress.current} of ${chunkProgress.total}…` }
+                : {})}
             />
           </div>
         </div>

--- a/src/client/pages/manual-import/useManualImport.test.ts
+++ b/src/client/pages/manual-import/useManualImport.test.ts
@@ -3,6 +3,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement } from 'react';
 import { useManualImport } from './useManualImport';
+import { ApiError } from '@/lib/api';
 import type { ScanResult, BookMetadata } from '@/lib/api';
 
 const mockNavigate = vi.fn();
@@ -19,7 +20,12 @@ vi.mock('sonner', () => ({
   },
 }));
 
-vi.mock('@/lib/api', () => ({
+// Preserve the real runtime exports (notably `ApiError`, imported at runtime by the
+// 413 mapping in confirmErrorMessage — #1831) and override only `api`. Replacing the
+// barrel wholesale would drop ApiError and break the confirm error path
+// (vimock-barrel-replace-drops-named-exports).
+vi.mock('@/lib/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/api')>()),
   api: {
     scanDirectory: vi.fn(),
     confirmImport: vi.fn(),
@@ -98,6 +104,9 @@ const SCAN_RESULT_WITH_DUPLICATES: ScanResult = {
   ],
   totalFolders: 3,
 };
+
+/** A metadata blob padded so a confirm item serializes to roughly `bytes` (#1831). */
+const bigMetadata = (bytes: number): BookMetadata => ({ blob: 'x'.repeat(bytes) } as unknown as BookMetadata);
 
 const MATCH_METADATA: BookMetadata = {
   title: 'Book A (Official)',
@@ -746,6 +755,76 @@ describe('useManualImport', () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('Import failed: Server error');
     });
+  });
+
+  it('413 confirm failure maps to import-domain wording (#1831)', async () => {
+    vi.mocked(api.scanDirectory).mockResolvedValue(SCAN_RESULT);
+    vi.mocked(api.confirmImport).mockRejectedValue(new ApiError(413, { error: 'Payload Too Large' }));
+
+    const { result } = renderHook(() => useManualImport(), { wrapper: createWrapper() });
+
+    act(() => { result.current.state.setScanPath('/audiobooks'); });
+    await act(async () => { result.current.actions.handleScan(); });
+    await waitFor(() => { expect(result.current.state.rows).toHaveLength(2); });
+
+    await act(async () => { result.current.actions.handleImport(); });
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        'Import failed: The import request was too large to send. Select fewer books and try again.',
+      );
+    });
+  });
+
+  it('self-oversize confirm item is diverted to tooLarge — never sent, row stays selected, no navigation (#1831)', async () => {
+    vi.mocked(api.scanDirectory).mockResolvedValue({
+      discoveries: [
+        { path: '/audiobooks/Book A', parsedTitle: 'Book A', parsedAuthor: 'Author A', parsedSeries: null, fileCount: 1, totalSize: 1, isDuplicate: false },
+      ],
+      totalFolders: 1,
+    });
+
+    const { result } = renderHook(() => useManualImport(), { wrapper: createWrapper() });
+    act(() => { result.current.state.setScanPath('/audiobooks'); });
+    await act(async () => { result.current.actions.handleScan(); });
+    await waitFor(() => { expect(result.current.state.rows).toHaveLength(1); });
+
+    // Edit the only selected row to carry a metadata blob above the per-item ceiling (~900 KiB).
+    act(() => { result.current.actions.handleEdit(0, { title: 'Book A', author: 'Author A', series: '', metadata: bigMetadata(950 * 1024) }); });
+
+    await act(async () => { result.current.actions.handleImport(); });
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(expect.stringContaining('too large to submit')));
+    // No POST leaves the client, and nothing navigates.
+    expect(api.confirmImport).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+    // The too-large row stays selected (fail-open — nothing landed).
+    expect(result.current.state.rows.find(r => r.book.path === '/audiobooks/Book A')?.selected).toBe(true);
+  });
+
+  it('mid-sequence chunk failure applies completed chunks and keeps the remainder selected, no navigation (#1831)', async () => {
+    vi.mocked(api.scanDirectory).mockResolvedValue(SCAN_RESULT); // Book A + Book B, both selectable
+    vi.mocked(api.confirmImport)
+      .mockResolvedValueOnce({ accepted: 1, heldReview: [], skipped: [], failed: [] })
+      .mockRejectedValueOnce(new Error('connection reset'));
+
+    const { result } = renderHook(() => useManualImport(), { wrapper: createWrapper() });
+    act(() => { result.current.state.setScanPath('/audiobooks'); });
+    await act(async () => { result.current.actions.handleScan(); });
+    await waitFor(() => { expect(result.current.state.rows).toHaveLength(2); });
+
+    // Edit both selectable rows above the chunk byte budget → two separate chunks.
+    act(() => { result.current.actions.handleEdit(0, { title: 'Book A', author: 'Author A', series: '', metadata: bigMetadata(500 * 1024) }); });
+    act(() => { result.current.actions.handleEdit(1, { title: 'Book B', author: '', series: 'Series B', metadata: bigMetadata(500 * 1024) }); });
+
+    await act(async () => { result.current.actions.handleImport(); });
+
+    await waitFor(() => expect(api.confirmImport).toHaveBeenCalledTimes(2));
+    // Completed chunk's accepted row is deselected; the failing/never-sent row stays selected.
+    await waitFor(() => expect(result.current.state.rows.find(r => r.book.path === '/audiobooks/Book A')?.selected).toBe(false));
+    expect(result.current.state.rows.find(r => r.book.path === '/audiobooks/Book B')?.selected).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not confirmed'));
   });
 
   it('handleBack from review resets to path step', async () => {

--- a/src/client/pages/manual-import/useManualImport.ts
+++ b/src/client/pages/manual-import/useManualImport.ts
@@ -10,7 +10,8 @@ import { useHeldReview, toConfirmItem } from '@/components/held-review';
 import { isPathInsideLibrary } from '@/lib/pathUtils.js';
 import { getErrorMessage } from '@/lib/error-message.js';
 import { upgradeMatchConfidence } from '@/lib/upgrade-match-confidence.js';
-import { isCleanImport, buildOutcomeToast, acceptedItemPaths } from '@/lib/import-outcome.js';
+import { acceptedItemPaths, buildChunkedOutcomeToast, isChunkedCleanImport, confirmErrorMessage } from '@/lib/import-outcome.js';
+import { runChunkedConfirm } from '@/lib/confirm-chunk-runner.js';
 
 export type Step = 'path' | 'review';
 
@@ -31,6 +32,8 @@ export function useManualImport({ onScanSuccess, libraryPath }: UseManualImportO
   const [rows, setRows] = useState<ImportRow[]>([]);
   const [mode, setMode] = useState<ImportMode>('copy');
   const [editIndex, setEditIndex] = useState<number | null>(null);
+  // Progress across the sequential chunked confirm run (#1831) — drives "Registering X of Y…".
+  const [chunkProgress, setChunkProgress] = useState<{ current: number; total: number; chunks: number } | null>(null);
 
   // Held-review recovery (#1732). Re-confirm uses the mode snapshotted at the
   // original confirm attempt, not the still-editable `mode` selector.
@@ -112,47 +115,48 @@ export function useManualImport({ onScanSuccess, libraryPath }: UseManualImportO
   });
 
   const importMutation = useMutation({
-    // The mode is carried in the mutation variables so the held-review snapshot
-    // captures the value in effect at *this* confirm attempt (#1732), not a later
-    // selector change.
+    // The mode is carried in the mutation variables so the held-review snapshot captures
+    // the value in effect at *this* confirm attempt (#1732), not a later selector change,
+    // and is threaded to every chunk of the byte-budgeted chunked confirm (#1831).
     mutationFn: ({ items, mode: confirmMode }: { items: ImportConfirmItem[]; mode: ImportMode | undefined }) =>
-      api.confirmImport(items, confirmMode),
-    onSuccess: (result, variables) => {
+      runChunkedConfirm({ items, mode: confirmMode, confirm: api.confirmImport, onProgress: setChunkProgress }),
+    onSuccess: (res, variables) => {
+      const { aggregateResult, submittedItems } = res;
       queryClient.invalidateQueries({ queryKey: queryKeys.books() });
 
-      // Held items (#1711/#1732): keep the user on the page with a recovery panel
-      // instead of navigating away (the old "re-confirm from Library Import" path was
-      // a dead end — manual sources live outside the library root Library Import
-      // scans). Snapshot the confirm-attempt mode so a held Move never silently
-      // re-confirms as Copy. Surfaced separately from the outcome toast below so a
-      // held + skipped/failed batch is never swallowed by an early return (#1822).
-      if (result.heldReview.length > 0) {
-        captureHeld(result.heldReview, variables.mode);
-        toast.warning(`${result.heldReview.length} held for recording review`);
+      // Held items (#1711/#1732): keep the user on the page with a recovery panel instead
+      // of navigating away. Snapshot the confirm-attempt mode so a held Move never silently
+      // re-confirms as Copy. Captured ONCE over the aggregate (#1831). Surfaced separately
+      // from the outcome toast so a held + skipped/failed batch is never swallowed (#1822).
+      if (aggregateResult.heldReview.length > 0) {
+        captureHeld(aggregateResult.heldReview, variables.mode);
+        toast.warning(`${aggregateResult.heldReview.length} held for recording review`);
       } else {
         clearHeld();
       }
 
-      // Report accepted/skipped/failed. Green fires ONLY on a fully-clean outcome
-      // (#1822) — a zero-accepted or partial batch shows amber/red naming the reason,
-      // never a green "0 queued" lie.
-      const outcome = buildOutcomeToast(result, 'queued for import');
+      // Report accepted/skipped/failed + the chunked transport splits (unsubmitted / too
+      // large). Green fires ONLY on a fully-clean, fully-submitted outcome (#1822/#1831).
+      const outcome = buildChunkedOutcomeToast(res, 'queued for import');
       if (outcome) toast[outcome.severity](outcome.message);
 
-      // Navigate only when everything landed as accepted; otherwise stay and deselect
-      // the accepted rows so a re-submit can't re-send them (#1822).
-      if (isCleanImport(result)) {
+      // Navigate only when the ENTIRE selection landed accepted; otherwise stay and deselect
+      // the accepted rows over submittedItems — NOT the full selection — so the never-sent
+      // remainder and too-large rows stay selected (#1831).
+      if (isChunkedCleanImport(res)) {
         navigate('/library');
         return;
       }
-      const acceptedPaths = acceptedItemPaths(variables.items, result);
+      const acceptedPaths = acceptedItemPaths(submittedItems, aggregateResult);
       if (acceptedPaths.size > 0) {
         setRows(prev => prev.map(r => acceptedPaths.has(r.book.path) ? { ...r, selected: false } : r));
       }
     },
     onError: (error: Error) => {
-      toast.error(`Import failed: ${getErrorMessage(error)}`);
+      // 413 (Fastify or the proxy hop) maps to import-domain wording (#1831).
+      toast.error(`Import failed: ${confirmErrorMessage(error)}`);
     },
+    onSettled: () => setChunkProgress(null),
   });
 
   const handleScan = useCallback(() => {
@@ -227,6 +231,7 @@ export function useManualImport({ onScanSuccess, libraryPath }: UseManualImportO
       setEditIndex,
       isMatching,
       progress,
+      chunkProgress,
       heldReview,
     },
     actions: {

--- a/src/server/plugins/error-handler.test.ts
+++ b/src/server/plugins/error-handler.test.ts
@@ -61,6 +61,26 @@ function createTestApp() {
   app.get('/throw-marker-conflict', async () => { throw new MarkerPathConflictError('/library/Author/Title.import-commit-pending'); });
   app.get('/throw-generic', async () => { throw new Error('disk full'); });
   app.get('/throw-non-error', async () => { throw 'string error'; });
+  // #1831 — genuine Fastify framework 4xx (e.g. body-too-large) is surfaced verbatim…
+  app.get('/throw-fst-413', async () => {
+    const err = new Error('Request body is too large') as Error & { code: string; statusCode: number };
+    err.code = 'FST_ERR_CTP_BODY_TOO_LARGE';
+    err.statusCode = 413;
+    throw err;
+  });
+  // …but a 5xx-coded framework error is NOT passed through (stays masked).
+  app.get('/throw-fst-500', async () => {
+    const err = new Error('framework blew up with secrets') as Error & { code: string; statusCode: number };
+    err.code = 'FST_ERR_SOMETHING';
+    err.statusCode = 500;
+    throw err;
+  });
+  // …and an arbitrary thrown object carrying a statusCode (no FST_ code) stays masked.
+  app.get('/throw-status-401', async () => {
+    const err = new Error('sensitive: db password is hunter2') as Error & { statusCode: number };
+    err.statusCode = 401;
+    throw err;
+  });
   app.get('/success', async () => ({ ok: true }));
 
   // Route with schema validation for F3
@@ -296,6 +316,27 @@ describe('error-handler plugin', () => {
       const res = await app.inject({ method: 'GET', url: '/success' });
       expect(res.statusCode).toBe(200);
       expect(JSON.parse(res.payload)).toEqual({ ok: true });
+    });
+  });
+
+  // #1831 — scoped Fastify framework client-error passthrough
+  describe('Fastify framework 4xx passthrough (#1831)', () => {
+    it('passes through a FST_-coded 4xx (body-too-large) with an accurate { error } message', async () => {
+      const res = await app.inject({ method: 'GET', url: '/throw-fst-413' });
+      expect(res.statusCode).toBe(413);
+      expect(JSON.parse(res.payload)).toEqual({ error: 'Request body is too large' });
+    });
+
+    it('masks a FST_-coded 5xx framework error as a generic 500 (no message leak)', async () => {
+      const res = await app.inject({ method: 'GET', url: '/throw-fst-500' });
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.payload)).toEqual({ error: 'Internal server error' });
+    });
+
+    it('masks an arbitrary thrown object carrying statusCode 401 as a generic 500', async () => {
+      const res = await app.inject({ method: 'GET', url: '/throw-status-401' });
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.payload)).toEqual({ error: 'Internal server error' });
     });
   });
 

--- a/src/server/plugins/error-handler.ts
+++ b/src/server/plugins/error-handler.ts
@@ -92,6 +92,23 @@ async function errorHandlerPluginInner(app: FastifyInstance) {
       });
     }
 
+    // Genuine Fastify framework client errors (#1831) — e.g. FST_ERR_CTP_BODY_TOO_LARGE
+    // (413) when a confirm/match request exceeds the body limit on a direct, un-proxied
+    // deployment. The message is framework-generated (never an internal/stack leak), so
+    // it is safe to surface with an accurate status. Scoped strictly to `FST_`-coded 4xx:
+    // a blanket "has statusCode → pass through" would forward 5xx-coded framework errors
+    // and arbitrary thrown objects carrying a statusCode, defeating the no-leak mask below.
+    const fstError = error as { code?: string; statusCode?: number };
+    if (
+      fstError.code?.startsWith('FST_') &&
+      typeof fstError.statusCode === 'number' &&
+      fstError.statusCode >= 400 &&
+      fstError.statusCode < 500
+    ) {
+      request.log.warn({ code: fstError.code, statusCode: fstError.statusCode }, error.message);
+      return reply.status(fstError.statusCode).send({ error: error.message });
+    }
+
     // Untyped errors — 500 with generic message (no stack leak)
     request.log.error(error, error.message || 'Unhandled error');
     return reply.status(500).send({ error: 'Internal server error' });

--- a/src/server/routes/library-scan.test.ts
+++ b/src/server/routes/library-scan.test.ts
@@ -338,6 +338,33 @@ describe('library-scan routes', () => {
       expect(services.matchJob.createJob).not.toHaveBeenCalled();
     });
 
+    // Positive boundary: without these, the raise is untestable — createTestApp's default
+    // 1 MiB cap would 413 the 11 MiB negatives above even if the route option were deleted.
+    it('confirm route accepts a ~3 MiB body (over the 1 MiB default, under the route limit)', async () => {
+      (services.libraryScan.confirmImport as ReturnType<typeof vi.fn>)
+        .mockResolvedValue({ accepted: 1, heldReview: [], skipped: [], failed: [] });
+      const midsize = 'x'.repeat(3 * 1024 * 1024);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/library/import/confirm',
+        payload: { books: [{ path: '/a/b', title: 'Book', metadata: { blob: midsize } }] },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(services.libraryScan.confirmImport).toHaveBeenCalled();
+    });
+
+    it('match route accepts a ~3 MiB body (over the 1 MiB default, under the route limit)', async () => {
+      (services.matchJob.createJob as ReturnType<typeof vi.fn>).mockReturnValue('job-3mib');
+      const midsize = 'x'.repeat(3 * 1024 * 1024);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/library/import/match',
+        payload: { books: [{ path: '/a/b', title: midsize }] },
+      });
+      expect(res.statusCode).toBe(200);
+      expect(services.matchJob.createJob).toHaveBeenCalled();
+    });
+
     it('leaves the global 1 MiB default in place on other routes (scan 413s above 1 MiB)', async () => {
       (services.libraryScan.scanDirectory as ReturnType<typeof vi.fn>)
         .mockResolvedValue({ discoveries: [], totalFolders: 0 });

--- a/src/server/routes/library-scan.test.ts
+++ b/src/server/routes/library-scan.test.ts
@@ -308,6 +308,50 @@ describe('library-scan routes', () => {
     });
   });
 
+  // #1831 — per-route body-size headroom (defense-in-depth for un-proxied deployments).
+  // A body over the ~10 MiB confirm/match limit surfaces a 413 with an accurate message
+  // (via the scoped error-handler passthrough), while other routes still cap at 1 MiB.
+  describe('per-route bodyLimit (#1831)', () => {
+    it('confirm route 413s with an accurate message when the body exceeds ~10 MiB', async () => {
+      (services.libraryScan.confirmImport as ReturnType<typeof vi.fn>)
+        .mockResolvedValue({ accepted: 1, heldReview: [], skipped: [], failed: [] });
+      const oversized = 'x'.repeat(11 * 1024 * 1024);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/library/import/confirm',
+        payload: { books: [{ path: '/a/b', title: 'Book', metadata: { blob: oversized } }] },
+      });
+      expect(res.statusCode).toBe(413);
+      // The scoped passthrough surfaces the framework message rather than a masked 500.
+      expect(JSON.parse(res.payload).error).toMatch(/too large/i);
+      expect(services.libraryScan.confirmImport).not.toHaveBeenCalled();
+    });
+
+    it('match route 413s when the body exceeds ~10 MiB', async () => {
+      const oversized = 'x'.repeat(11 * 1024 * 1024);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/library/import/match',
+        payload: { books: [{ path: '/a/b', title: oversized }] },
+      });
+      expect(res.statusCode).toBe(413);
+      expect(services.matchJob.createJob).not.toHaveBeenCalled();
+    });
+
+    it('leaves the global 1 MiB default in place on other routes (scan 413s above 1 MiB)', async () => {
+      (services.libraryScan.scanDirectory as ReturnType<typeof vi.fn>)
+        .mockResolvedValue({ discoveries: [], totalFolders: 0 });
+      const overOneMib = 'x'.repeat(2 * 1024 * 1024);
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/library/import/scan',
+        payload: { path: overOneMib },
+      });
+      expect(res.statusCode).toBe(413);
+      expect(services.libraryScan.scanDirectory).not.toHaveBeenCalled();
+    });
+  });
+
   // Wave 11.2 (#755) — single-book scan/import routes retired
   describe('removed routes', () => {
     it('POST /api/library/import/scan-single returns 404', async () => {

--- a/src/server/routes/library-scan.ts
+++ b/src/server/routes/library-scan.ts
@@ -23,6 +23,16 @@ import { serializeError } from '../utils/serialize-error.js';
 import { mintPreviewToken } from '../services/preview-token.js';
 
 
+/**
+ * Per-route body-size headroom for the confirm + match routes (#1831). Defense-in-depth
+ * for un-proxied *direct* deployments only: the byte-budgeted chunked client keeps every
+ * request it sends well under 1 MiB, so behind the default nginx proxy (`client_max_body_size
+ * 1m`) this raise is inert — the proxy emits its own 413 before Fastify sees the body. It is
+ * explicitly NOT the mechanism for a self-oversize confirm item (that is diverted pre-flight
+ * client-side). The global 1 MiB default stays on every other route.
+ */
+const CONFIRM_MATCH_BODY_LIMIT = 10 * 1024 * 1024; // 10 MiB
+
 type ScanDirectoryBody = z.infer<typeof scanDirectoryBodySchema>;
 type ImportConfirmBody = z.infer<typeof importConfirmBodySchema>;
 type MatchStartBody = z.infer<typeof matchStartBodySchema>;
@@ -102,7 +112,7 @@ export async function libraryScanRoutes(
   // success outcome (#1711): some items enqueued, some held for recording review.
   app.post<{ Body: ImportConfirmBody }>(
     '/api/library/import/confirm',
-    { schema: { body: importConfirmBodySchema } },
+    { schema: { body: importConfirmBodySchema }, bodyLimit: CONFIRM_MATCH_BODY_LIMIT },
     async (request, reply) => {
       const { books: items, mode } = request.body;
 
@@ -123,7 +133,7 @@ export async function libraryScanRoutes(
   // Start a match job for discovered books
   app.post<{ Body: MatchStartBody }>(
     '/api/library/import/match',
-    { schema: { body: matchStartBodySchema } },
+    { schema: { body: matchStartBodySchema }, bodyLimit: CONFIRM_MATCH_BODY_LIMIT },
     async (request) => {
       const { books: candidates } = request.body;
 


### PR DESCRIPTION
Three commits: the #1831 byte-budgeted chunked confirm + match submission (fixes the 413 dead-end on large-library imports, honest transport errors), the cross-model-review test-hardening batch (2e8bd450), and the #1833 hardening pass (poll-identity guard, cancelled-status semantics, 413-honest mid-run toast, progress label fix, shared dup predicate, envelope byte budget). #1833 delivery independently verified 9/9 ACs via /review:assess.