### PR TITLE
Release: develop -> main (duration band 90s -> 240s)

### DIFF
--- a/src/core/utils/recording-identity.test.ts
+++ b/src/core/utils/recording-identity.test.ts
@@ -414,11 +414,11 @@ describe('resolveRecordingIdentity (#1710)', () => {
 
     // UNITS REGRESSION GUARD (AC8): two editions ~2 min apart are >90s but <90 min.
     // With the mandatory internal * 60 conversion this is review; if the conversion
-    // were dropped it would land inside a 90-*minute* band (|602-600| = 2 ≤ 90) and
+    // were dropped it would land inside a 240-*minute* band (|606-600| = 6 ≤ 240) and
     // wrongly return same-recording. This case is the durable guard against that.
-    it('units regression: ~2 min apart (>90s, <90 min) → review, NOT same-recording', () => {
-      // library 600min (36000s) vs candidate 602min (36120s) → Δ120s > 90s.
-      expect(verdictOf(candidate({ ...eq, duration: 602 }), library({ ...eqLib, duration: 600 }))).toBe('review');
+    it('units regression: ~6 min apart (>240s, <240 min) → review, NOT same-recording', () => {
+      // library 600min (36000s) vs candidate 606min (36360s) → Δ360s > 240s.
+      expect(verdictOf(candidate({ ...eq, duration: 606 }), library({ ...eqLib, duration: 600 }))).toBe('review');
     });
 
     it('duration never yields different-recording for equal narrators', () => {
@@ -428,17 +428,17 @@ describe('resolveRecordingIdentity (#1710)', () => {
       }
     });
 
-    // Inclusive-at-90 boundary parity (AC5): Δ exactly 90s is inside, 91s outside —
+    // Inclusive-at-240 boundary parity (AC5): Δ exactly 240s is inside, 241s outside —
     // identically to quality-gate and match-job. Fractional minutes land the * 60
     // product on the exact second boundary (library 600min = 36000s).
-    it('exact 90s boundary → same-recording (inclusive)', () => {
-      // candidate 601.5min = 36090s → Δ90s.
-      expect(verdictOf(candidate({ ...eq, duration: 36090 / 60 }), library({ ...eqLib, duration: 600 }))).toBe('same-recording');
+    it('exact 240s boundary → same-recording (inclusive)', () => {
+      // candidate 604min = 36240s → Δ240s.
+      expect(verdictOf(candidate({ ...eq, duration: 604 }), library({ ...eqLib, duration: 600 }))).toBe('same-recording');
     });
 
-    it('one tick beyond 90s → review', () => {
-      // candidate 36091s → Δ91s.
-      expect(verdictOf(candidate({ ...eq, duration: 36091 / 60 }), library({ ...eqLib, duration: 600 }))).toBe('review');
+    it('one tick beyond 240s → review', () => {
+      // candidate 36241s → Δ241s.
+      expect(verdictOf(candidate({ ...eq, duration: 36241 / 60 }), library({ ...eqLib, duration: 600 }))).toBe('review');
     });
   });
 

--- a/src/core/utils/recording-identity.ts
+++ b/src/core/utils/recording-identity.ts
@@ -199,7 +199,7 @@ function productionTypesConflict(candidate: string | null | undefined, library: 
  * `different-recording`. Two corroborators, in priority order:
  *
  *  1. Duration (authoritative when present): both sides present + within the
- *     absolute 90s band → `same-recording` (the Tehanu case); beyond the band →
+ *     absolute shared band (240s) → `same-recording` (the Tehanu case); beyond the band →
  *     `review` (`duration-mismatch`). When duration corroborates, production form
  *     is ignored — two unabridged readings whose `productionType` happens to differ
  *     must not be forced to review when their durations agree.

--- a/src/server/services/book.service.dedup.integration.test.ts
+++ b/src/server/services/book.service.dedup.integration.test.ts
@@ -157,13 +157,13 @@ describe('BookService.findDuplicate — 3-way + multi-incumbent (DB-backed, #171
       expect(res.book?.id).toBe(id);
     });
 
-    it('outside the 90s duration band over equal narrators → review (#1854)', async () => {
-      // library 60min (3600s) vs candidate 62min (3720s) → Δ120s > 90s, downgrades an
+    it('outside the 240s duration band over equal narrators → review (#1854)', async () => {
+      // library 60min (3600s) vs candidate 66min (3960s) → Δ360s > 240s, downgrades an
       // equal-narrator match to review over real hydrated rows. The adapter's minutes
       // column feeds the resolver, which converts * 60 before the band.
       const id = await seed({ title: 'Beyond Boundary', author: 'Dur Author', narrators: ['Jim Dale'], duration: 60 });
       const res = await service.findDuplicate({
-        title: 'Beyond Boundary', authors: [{ name: 'Dur Author' }], narrators: ['Jim Dale'], duration: 62,
+        title: 'Beyond Boundary', authors: [{ name: 'Dur Author' }], narrators: ['Jim Dale'], duration: 66,
       });
       expect(res.verdict).toBe('review');
       expect(res.book?.id).toBe(id);

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -742,9 +742,9 @@ describe('resolveConfidenceFromDuration', () => {
     expect(result).toEqual({ confidence: 'high' });
   });
 
-  it('returns medium duration mismatch when the gap exceeds 90s', () => {
-    // provider 60min → 3600s; scanned 3750s → Δ150s — beyond 90s
-    const result = resolveConfidenceFromDuration([{ meta: makeBook({ duration: 60 }) }], 3750);
+  it('returns medium duration mismatch when the gap exceeds the band', () => {
+    // provider 60min → 3600s; scanned 3900s → Δ300s — beyond 240s
+    const result = resolveConfidenceFromDuration([{ meta: makeBook({ duration: 60 }) }], 3900);
     expect(result.confidence).toBe('medium');
     expect(result.reason).toContain('Duration mismatch');
   });
@@ -759,12 +759,12 @@ describe('resolveConfidenceFromDuration', () => {
 
   it('multi-result mismatch reason uses the shared FLOOR formatter on both sides (F1)', () => {
     // Discriminates floor from round on the SCANNED side of the line-166 reason:
-    // provider 1789min → 107340s (29h 49m); scanned 107440s → Δ100s beyond 90s.
-    // 107440s floors to 29h 50m (round-based formatting would render 29h 51m), so
+    // provider 1789min → 107340s (29h 49m); scanned 107620s → Δ280s beyond 240s.
+    // 107620s floors to 29h 53m (round-based formatting would render 29h 54m), so
     // this exact-string assertion fails if line 166 ever reverts to round semantics.
-    const result = resolveConfidenceFromDuration([{ meta: makeBook({ duration: 1789 }) }], 107440);
+    const result = resolveConfidenceFromDuration([{ meta: makeBook({ duration: 1789 }) }], 107620);
     expect(result.confidence).toBe('medium');
-    expect(result.reason).toBe('Duration mismatch — scanned 29h 50m vs expected 29h 49m');
+    expect(result.reason).toBe('Duration mismatch — scanned 29h 53m vs expected 29h 49m');
   });
 });
 
@@ -794,14 +794,14 @@ describe('isDurationVerified', () => {
     expect(isDurationVerified(makeBook({ duration: 60 }), 3650)).toBe(true);
   });
 
-  it('returns true at exactly 90s (inclusive boundary)', () => {
-    // provider 60min → 3600s; scanned 3690s → Δ90s
-    expect(isDurationVerified(makeBook({ duration: 60 }), 3690)).toBe(true);
+  it('returns true at exactly 240s (inclusive boundary)', () => {
+    // provider 60min → 3600s; scanned 3840s → Δ240s
+    expect(isDurationVerified(makeBook({ duration: 60 }), 3840)).toBe(true);
   });
 
-  it('returns false beyond the 90s band', () => {
-    // provider 60min → 3600s; scanned 3720s → Δ120s
-    expect(isDurationVerified(makeBook({ duration: 60 }), 3720)).toBe(false);
+  it('returns false beyond the 240s band', () => {
+    // provider 60min → 3600s; scanned 3900s → Δ300s
+    expect(isDurationVerified(makeBook({ duration: 60 }), 3900)).toBe(false);
   });
 
   it('compares in seconds — a sub-minute delta near a minute boundary verifies (no rounding inflation)', () => {
@@ -876,15 +876,15 @@ describe('resolveSingleResultConfidence', () => {
     expect(result.reason).toBe('Duration mismatch — scanned 10h 0m vs expected 11h 0m');
   });
 
-  it('a sub-decimal mismatch renders visibly different values (h:mm regression)', () => {
-    // provider 1789min → 107340s; scanned 107440s → Δ100s beyond 90s. Under the old
-    // one-decimal hours display BOTH sides rendered "29.8hrs" — a flagged mismatch
-    // whose message showed no difference. Minute resolution must keep them distinct.
-    // Shared floor formatter (#1854): 107440s floors to 29h 50m (not the old
-    // round-based 29h 51m); still visibly distinct from expected 29h 49m.
-    const result = resolveSingleResultConfidence(makeBook({ duration: 1789 }), 107440);
+  it('mismatch reason renders h:mm via the shared floor formatter', () => {
+    // provider 1789min → 107340s; scanned 107620s → Δ280s beyond 240s. Historical
+    // note: at the old 90s band a flagged mismatch could render identically at
+    // one-decimal hours ("29.8hrs vs 29.8hrs"); at a 240s band any mismatch is
+    // ≥4min (≥0.067h) so that collision is impossible — h:mm stays for readability
+    // and this test now pins the FLOOR semantic (107620s → 29h 53m; round → 29h 54m).
+    const result = resolveSingleResultConfidence(makeBook({ duration: 1789 }), 107620);
     expect(result.confidence).toBe('medium');
-    expect(result.reason).toBe('Duration mismatch — scanned 29h 50m vs expected 29h 49m');
+    expect(result.reason).toBe('Duration mismatch — scanned 29h 53m vs expected 29h 49m');
   });
 });
 

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -1377,9 +1377,9 @@ describe('MatchJobService', () => {
       expect(result!.reason).toContain('Duration mismatch');
     });
 
-    it('high combined score (1.0) + duration just beyond 90s → confidence medium', async () => {
+    it('high combined score (1.0) + duration just beyond the band → confidence medium', async () => {
       (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({
-        totalDuration: 36120, // 600min provider (36000s) + 120s → Δ120s
+        totalDuration: 36300, // 600min provider (36000s) + 300s → Δ300s
         files: [],
       });
 

--- a/src/server/services/quality-gate.helpers.ts
+++ b/src/server/services/quality-gate.helpers.ts
@@ -83,8 +83,8 @@ export function buildQualityAssessment(
   if (book && book.path !== null && existingInputs) {
     if (existingInputs.durationSeconds && existingInputs.durationSeconds > 0 && newDurationSeconds > 0) {
       // The ratio is still computed and persisted for telemetry (unchanged shape),
-      // but the HOLD decision moved to the shared absolute 90s band (#1854): both
-      // operands are already SECONDS, so no conversion. Δ ≤ 90s → no hold; > 90s →
+      // but the HOLD decision moved to the shared absolute band (240s, #1854): both
+      // operands are already SECONDS, so no conversion. Δ within the band → no hold; beyond →
       // held (inclusive at 90, matching every other duration-band call site).
       durationDelta = (newDurationSeconds - existingInputs.durationSeconds) / existingInputs.durationSeconds;
       if (!withinDurationTolerance(newDurationSeconds, existingInputs.durationSeconds)) {

--- a/src/server/services/quality-gate.service.test.ts
+++ b/src/server/services/quality-gate.service.test.ts
@@ -546,42 +546,42 @@ describe('QualityGateService', () => {
   // 90s band. baseBook.audioDuration = 36000s, so the existing durationSeconds is
   // 36000; the boundary is Δ90s inclusive. The `durationDelta` ratio is still
   // computed and persisted (unchanged shape) — only the HOLD decision changed.
-  describe('processDownload — duration delta (absolute 90s band)', () => {
-    it('does not hold at exactly +90s duration delta (inclusive boundary)', async () => {
+  describe('processDownload — duration delta (absolute 240s band)', () => {
+    it('does not hold at exactly +240s duration delta (inclusive boundary)', async () => {
       const { service, db } = createService();
       db.update.mockReturnValue(mockDbChain([]));
 
-      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 36090 }));
+      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 36240 }));
 
       expect(result.reason.holdReasons).not.toContain('duration_delta');
       // Ratio still populated with its unchanged shape.
-      expect(result.reason.durationDelta).toBeCloseTo(90 / 36000, 6);
+      expect(result.reason.durationDelta).toBeCloseTo(240 / 36000, 6);
     });
 
-    it('holds for review at +91s duration delta (one tick beyond)', async () => {
+    it('holds for review at +241s duration delta (one tick beyond)', async () => {
       const { service, db } = createService();
       db.update.mockReturnValue(mockDbChain([]));
 
-      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 36091 }));
+      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 36241 }));
 
       expect(result.reason.holdReasons).toContain('duration_delta');
-      expect(result.reason.durationDelta).toBeCloseTo(91 / 36000, 6);
+      expect(result.reason.durationDelta).toBeCloseTo(241 / 36000, 6);
     });
 
-    it('does not hold at exactly -90s duration delta (inclusive boundary)', async () => {
+    it('does not hold at exactly -240s duration delta (inclusive boundary)', async () => {
       const { service, db } = createService();
       db.update.mockReturnValue(mockDbChain([]));
 
-      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 35910 }));
+      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 35760 }));
 
       expect(result.reason.holdReasons).not.toContain('duration_delta');
     });
 
-    it('holds for review at -91s duration delta (one tick beyond)', async () => {
+    it('holds for review at -241s duration delta (one tick beyond)', async () => {
       const { service, db } = createService();
       db.update.mockReturnValue(mockDbChain([]));
 
-      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 35909 }));
+      const result = await service.processDownload(baseDownload, baseBook, makeScan({ totalSize: 600_000_000, totalDuration: 35759 }));
 
       expect(result.reason.holdReasons).toContain('duration_delta');
     });

--- a/src/shared/duration-tolerance.test.ts
+++ b/src/shared/duration-tolerance.test.ts
@@ -1,27 +1,34 @@
 import { describe, it, expect } from 'vitest';
 import { DURATION_TOLERANCE_SECONDS, withinDurationTolerance } from './duration-tolerance.js';
 
-describe('withinDurationTolerance (#1854)', () => {
-  it('the band is 90 absolute seconds', () => {
-    expect(DURATION_TOLERANCE_SECONDS).toBe(90);
+describe('withinDurationTolerance (#1854, widened 2026-07-15)', () => {
+  it('the band is 240 absolute seconds', () => {
+    expect(DURATION_TOLERANCE_SECONDS).toBe(240);
   });
 
   it('true at Δ0', () => {
     expect(withinDurationTolerance(3600, 3600)).toBe(true);
   });
 
-  it('true at exactly Δ90 (inclusive boundary)', () => {
-    expect(withinDurationTolerance(3600, 3690)).toBe(true);
-    expect(withinDurationTolerance(3690, 3600)).toBe(true);
+  it('true at exactly Δ240 (inclusive boundary)', () => {
+    expect(withinDurationTolerance(3600, 3840)).toBe(true);
+    expect(withinDurationTolerance(3840, 3600)).toBe(true);
   });
 
-  it('false at Δ91 (one tick beyond)', () => {
-    expect(withinDurationTolerance(3600, 3691)).toBe(false);
-    expect(withinDurationTolerance(3691, 3600)).toBe(false);
+  it('false at Δ241 (one tick beyond)', () => {
+    expect(withinDurationTolerance(3600, 3841)).toBe(false);
+    expect(withinDurationTolerance(3841, 3600)).toBe(false);
+  });
+
+  it('still separates the closest verified different-recording pair (Martian Δ6m)', () => {
+    // Bray 653min vs Wheaton 659min — the closest marquee re-record pair in the
+    // #1854 catalog study, caught live in the production library. The band must
+    // stay below 360s or this real pair silently merges.
+    expect(withinDurationTolerance(653 * 60, 659 * 60)).toBe(false);
   });
 
   it('argument order is symmetric', () => {
-    expect(withinDurationTolerance(100, 250)).toBe(withinDurationTolerance(250, 100));
+    expect(withinDurationTolerance(100, 400)).toBe(withinDurationTolerance(400, 100));
     expect(withinDurationTolerance(3600, 3650)).toBe(withinDurationTolerance(3650, 3600));
   });
 
@@ -30,10 +37,10 @@ describe('withinDurationTolerance (#1854)', () => {
   // predicate filters out zero/negative inputs.
   it('does no guarding — zero and negative inputs behave as plain absolute difference', () => {
     expect(withinDurationTolerance(0, 0)).toBe(true);
-    expect(withinDurationTolerance(0, 50)).toBe(true);
-    expect(withinDurationTolerance(0, 200)).toBe(false);
-    // Negative inputs: |(-10) - 10| = 20 ≤ 90 → true; |(-100) - 100| = 200 → false.
+    expect(withinDurationTolerance(0, 200)).toBe(true);
+    expect(withinDurationTolerance(0, 500)).toBe(false);
+    // Negative inputs: |(-10) - 10| = 20 ≤ 240 → true; |(-200) - 200| = 400 → false.
     expect(withinDurationTolerance(-10, 10)).toBe(true);
-    expect(withinDurationTolerance(-100, 100)).toBe(false);
+    expect(withinDurationTolerance(-200, 200)).toBe(false);
   });
 });

--- a/src/shared/duration-tolerance.ts
+++ b/src/shared/duration-tolerance.ts
@@ -2,13 +2,22 @@
  * Single home for the audiobook duration-match tolerance band (#1850/#1854).
  *
  * A same-edition scanned runtime and a provider's stated runtime differ by a
- * *fixed-size* amount — the "This is Audible" intro + end credits (~40s) plus the
- * provider's whole-minute runtime granularity (±30s) — that does NOT scale with
- * book length (212 ASIN-verified same-edition pairs, 2026-07-07: max Δ 69s at any
- * length, correlation with length ≈ 0.096). 90s = the 69s observed ceiling + ~21s
- * headroom. #1854 folded the two remaining relative-15%-band call sites
+ * *fixed-size* amount — intro/outro credits plus the provider's whole-minute
+ * runtime granularity — that does NOT scale with book length (212 ASIN-verified
+ * same-edition pairs, 2026-07-07: max Δ 69s; correlation with length ≈ 0.096).
+ * #1854 folded the two remaining relative-15%-band call sites
  * (`recording-identity.ts`, `quality-gate.helpers.ts`) onto this one absolute band
  * so a third copy-instead-of-import drift can't recur.
+ *
+ * 90s → 240s (2026-07-15, live Library-Import UAT): the 90s ceiling was derived
+ * from CLEAN same-edition pairs; real-world rips — especially multi-part rips
+ * merged into one file, carrying per-part intro/outro credits — routinely run a
+ * couple of honest minutes over the catalog runtime (e.g. a 29h41m book scanning
+ * 29h43m) and were flooding import review. 4 minutes still separates every
+ * verified different-recording pair that matters: the closest marquee re-records
+ * are Martian Bray/Wheaton Δ6m, HP1 Dale/Fry Δ7m, NOTW Podehl/Degas Δ8m, and only
+ * ~5% of the 491-pair catalog study sits inside 4m (vs 2% inside 90s), nearly all
+ * narrator-gated classics (evidence: #1854 data comment + .scratch/duration-band-data/).
  *
  * Layer placement: `src/shared/` is importable from `core`, `server`, AND
  * `client` (unlike `server`, which `core` may not import — the original reason
@@ -17,7 +26,7 @@
  * UAT-tunable: raise it if live UAT shows too many false Reviews rather than
  * reintroducing a relative/score tier.
  */
-export const DURATION_TOLERANCE_SECONDS = 90;
+export const DURATION_TOLERANCE_SECONDS = 240;
 
 /**
  * True when two runtimes are within the absolute duration-match band.
@@ -26,10 +35,10 @@ export const DURATION_TOLERANCE_SECONDS = 90;
  * The provider `runtimeLengthMin` and the `books.duration` DB column are MINUTES,
  * so callers reading those sides multiply by 60 BEFORE calling this (the units
  * bug class `book-duration-minutes-vs-quality-seconds`: a raw-minutes argument
- * into a 90-*second* band yields an effective 90-*minute* tolerance, 60× too
- * loose). The scanner value and the quality chain are already seconds.
+ * into a seconds band yields an effective 60×-too-loose tolerance). The scanner
+ * value and the quality chain are already seconds.
  *
- * Boundary is INCLUSIVE at 90 (Δ90s inside, Δ91s outside), matching #1850. The
+ * Boundary is INCLUSIVE at the band (Δ240s inside, Δ241s outside), matching #1850. The
  * predicate does NO guarding — a missing/zero/negative input is compared as a
  * plain absolute difference; call sites own their present/positive guards.
  */

--- a/src/shared/format-duration.ts
+++ b/src/shared/format-duration.ts
@@ -8,8 +8,8 @@
  *
  * FLOOR (not round) is the chosen semantic: hours = `Math.floor(seconds/3600)`,
  * minutes = `Math.floor((seconds%3600)/60)`. Minute resolution is load-bearing
- * for the match-job mismatch reason: the mismatch band is 90 seconds (#1850), and
- * two values more than 90s apart can never fall in the same 60-second minute
+ * for the match-job mismatch reason: the mismatch band is absolute seconds-scale (#1850/#1854), and
+ * two values a band-width apart can never fall in the same 60-second minute
  * bucket, so this display always shows a visible difference for every mismatch it
  * accompanies (the old one-decimal-hours display rendered both sides of a real
  * mismatch identically).


### PR DESCRIPTION
Single change: widen the shared duration-tolerance band from 90s to 240s (4 minutes).

Live Library-Import UAT showed real-world rips — especially multi-part rips merged into one file, carrying per-part credits — routinely run honest minutes over the catalog runtime, flooding import review at 90s. Four minutes still separates every verified different-recording pair in the #1854 catalog study (closest marquee re-record: The Martian Bray/Wheaton at 6m, now pinned by a regression test); only ~5% of the 491-pair study sits inside 4m, nearly all narrator-gated classics.

One-line constant change via the #1854 single home (hits match confidence, recording-identity dedup, and the quality-gate hold together); boundary test fixtures moved to Δ240/Δ241.