### PR TITLE
Release: develop -> main (match tiebreaker + Hardcover custom lists)

### DIFF
--- a/src/client/components/settings/ImportListCard.test.tsx
+++ b/src/client/components/settings/ImportListCard.test.tsx
@@ -572,4 +572,98 @@ describe('ImportListCard', () => {
       expect(payloadSettings).toHaveProperty('list', 'audio-fiction');
     });
   });
+
+  // #1879 — Hardcover list-type change handler leak matrix through the real card.
+  // Complements the ImportListProviderSettings suite (AC12): the list-type dropdown
+  // scrubs foreign keys, proven here against the onFormTest payload.
+  describe('#1879 — Hardcover list-type change scrubs foreign keys', () => {
+    const CUSTOM_URL = 'https://hardcover.app/@LisaRae/lists/2025-year-in-books';
+
+    it('custom → trending drops listUrl/importMax from the Test payload', async () => {
+      const user = userEvent.setup();
+      const onFormTest = vi.fn();
+      renderWithProviders(<ImportListCard mode="create" onSubmit={noop} onFormTest={onFormTest} />);
+
+      await user.selectOptions(screen.getByLabelText('Provider Type'), 'hardcover');
+      await user.selectOptions(screen.getByLabelText('List Type'), 'custom');
+      await user.type(await screen.findByLabelText('List URL'), CUSTOM_URL);
+      await user.selectOptions(screen.getByLabelText('Import Max'), '100');
+
+      // Switch List Type back to trending — handler drops listUrl/importMax.
+      await user.selectOptions(screen.getByLabelText('List Type'), 'trending');
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+      const payloadSettings = onFormTest.mock.calls.at(-1)![0].settings as Record<string, unknown>;
+      expect(payloadSettings).not.toHaveProperty('listUrl');
+      expect(payloadSettings).not.toHaveProperty('importMax');
+      expect(payloadSettings).toMatchObject({ listType: 'trending' });
+    });
+
+    it('shelf → custom drops shelfId from the Test payload', async () => {
+      const user = userEvent.setup();
+      const onFormTest = vi.fn();
+      renderWithProviders(<ImportListCard mode="create" onSubmit={noop} onFormTest={onFormTest} />);
+
+      await user.selectOptions(screen.getByLabelText('Provider Type'), 'hardcover');
+      await user.selectOptions(screen.getByLabelText('List Type'), 'shelf');
+      await user.type(await screen.findByLabelText('Shelf ID'), '42');
+
+      // Switch List Type to custom — handler drops shelfId.
+      await user.selectOptions(screen.getByLabelText('List Type'), 'custom');
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+      const payloadSettings = onFormTest.mock.calls.at(-1)![0].settings as Record<string, unknown>;
+      expect(payloadSettings).not.toHaveProperty('shelfId');
+      expect(payloadSettings).toMatchObject({ listType: 'custom' });
+    });
+
+    // F7 — AC12 requires custom→shelf in the real-card payload matrix. Populate the
+    // minted listUrl/importMax first so the assertion reds a shelf-branch scrub that
+    // forgot to drop them (not merely empty defaults).
+    it('custom → shelf drops the minted listUrl/importMax from the Test payload', async () => {
+      const user = userEvent.setup();
+      const onFormTest = vi.fn();
+      renderWithProviders(<ImportListCard mode="create" onSubmit={noop} onFormTest={onFormTest} />);
+
+      await user.selectOptions(screen.getByLabelText('Provider Type'), 'hardcover');
+      await user.selectOptions(screen.getByLabelText('List Type'), 'custom');
+      await user.type(await screen.findByLabelText('List URL'), CUSTOM_URL);
+      await user.selectOptions(screen.getByLabelText('Import Max'), '100');
+
+      // Switch List Type to shelf — handler drops the custom-only keys.
+      await user.selectOptions(screen.getByLabelText('List Type'), 'shelf');
+      await screen.findByLabelText('Shelf ID');
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+      const payloadSettings = onFormTest.mock.calls.at(-1)![0].settings as Record<string, unknown>;
+      expect(payloadSettings).not.toHaveProperty('listUrl');
+      expect(payloadSettings).not.toHaveProperty('importMax');
+      expect(payloadSettings).toMatchObject({ listType: 'shelf' });
+    });
+
+    // F7 — populated-custom → provider switch. The existing #908 provider-switch tests
+    // only mint/assert shelfId; this proves handleTypeChange's registry reset also drops
+    // the dynamically minted listUrl/importMax when leaving the hardcover provider entirely.
+    it('provider switch away from a populated custom list drops listUrl/importMax (and listType)', async () => {
+      const user = userEvent.setup();
+      const onFormTest = vi.fn();
+      renderWithProviders(<ImportListCard mode="create" onSubmit={noop} onFormTest={onFormTest} />);
+
+      await user.selectOptions(screen.getByLabelText('Provider Type'), 'hardcover');
+      await user.selectOptions(screen.getByLabelText('List Type'), 'custom');
+      await user.type(await screen.findByLabelText('List URL'), CUSTOM_URL);
+      await user.selectOptions(screen.getByLabelText('Import Max'), 'all');
+
+      // Switch Provider Type to nyt — handleTypeChange resets settings to nyt defaults.
+      await user.selectOptions(screen.getByLabelText('Provider Type'), 'nyt');
+      await screen.findByLabelText('Bestseller List');
+      await user.click(screen.getByRole('button', { name: 'Test Connection' }));
+
+      const payloadSettings = onFormTest.mock.calls.at(-1)![0].settings as Record<string, unknown>;
+      expect(payloadSettings).not.toHaveProperty('listUrl');
+      expect(payloadSettings).not.toHaveProperty('importMax');
+      expect(payloadSettings).not.toHaveProperty('listType');
+      expect(payloadSettings).toMatchObject({ list: 'audio-fiction' });
+    });
+  });
 });

--- a/src/client/pages/settings/ImportListProviderSettings.test.tsx
+++ b/src/client/pages/settings/ImportListProviderSettings.test.tsx
@@ -165,4 +165,103 @@ describe('ProviderSettings', () => {
       expect('shelfId' in lastCall).toBe(false);
     });
   });
+
+  // ── #1879 — custom list by URL ──────────────────────────────────────────────
+  describe('HardcoverSettings — custom list (#1879)', () => {
+    const CUSTOM_URL = 'https://hardcover.app/@LisaRae/lists/2025-year-in-books';
+
+    it('reveals List URL + Import Max only for the custom list type (AC11)', async () => {
+      const user = userEvent.setup();
+      render(<StatefulProvider type="hardcover" initial={{ apiKey: 'k' }} />);
+
+      // Trending default — neither field present.
+      expect(screen.queryByLabelText('List URL')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Import Max')).not.toBeInTheDocument();
+
+      await user.selectOptions(screen.getByLabelText('List Type'), 'custom');
+
+      expect(screen.getByLabelText('List URL')).toBeInTheDocument();
+      // Import Max is a select (50 / 100 / All), not a number input.
+      const importMax = screen.getByLabelText('Import Max') as HTMLSelectElement;
+      expect(importMax.tagName).toBe('SELECT');
+      expect(Array.from(importMax.options).map((o) => o.value)).toEqual(['50', '100', 'all']);
+    });
+
+    it('Import Max emits numbers for 50/100 and the string "all" (F11)', async () => {
+      const spy = vi.fn();
+      const user = userEvent.setup();
+      render(<StatefulProvider type="hardcover" initial={{ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL }} onChangeSpy={spy} />);
+
+      await user.selectOptions(screen.getByLabelText('Import Max'), '100');
+      let last = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(last.importMax).toBe(100);
+      expect(typeof last.importMax).toBe('number');
+
+      await user.selectOptions(screen.getByLabelText('Import Max'), 'all');
+      last = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(last.importMax).toBe('all');
+
+      await user.selectOptions(screen.getByLabelText('Import Max'), '50');
+      last = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(last.importMax).toBe(50);
+      expect(typeof last.importMax).toBe('number');
+    });
+
+    it('renders an inline error for an invalid List URL and clears it when corrected (AC13, F23)', async () => {
+      const user = userEvent.setup();
+      render(<StatefulProvider type="hardcover" initial={{ apiKey: 'k', listType: 'custom' }} />);
+
+      const input = screen.getByLabelText('List URL');
+      await user.type(input, 'https://example.com/not-hardcover');
+      expect(await screen.findByText('Not a Hardcover list URL')).toBeInTheDocument();
+
+      await user.clear(input);
+      await user.type(input, CUSTOM_URL);
+      expect(screen.queryByText('Not a Hardcover list URL')).not.toBeInTheDocument();
+    });
+
+    it('empty List URL shows no inline error', () => {
+      render(<ProviderSettings type="hardcover" settings={{ apiKey: 'k', listType: 'custom' }} onChange={vi.fn()} />);
+      expect(screen.queryByText('Not a Hardcover list URL')).not.toBeInTheDocument();
+    });
+
+    // Leak matrix via the dedicated list-type change handler (AC12, F15, F20, F35).
+    describe('type-scoped list-type change handler — no foreign-key leak', () => {
+      it('custom → trending drops listUrl and importMax', async () => {
+        const spy = vi.fn();
+        const user = userEvent.setup();
+        render(<StatefulProvider type="hardcover" initial={{ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: 100 }} onChangeSpy={spy} />);
+
+        await user.selectOptions(screen.getByLabelText('List Type'), 'trending');
+
+        const last = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+        expect(last).toEqual({ apiKey: 'k', listType: 'trending' });
+      });
+
+      it('custom → shelf drops listUrl/importMax (shelfId added separately)', async () => {
+        const spy = vi.fn();
+        const user = userEvent.setup();
+        render(<StatefulProvider type="hardcover" initial={{ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: 'all' }} onChangeSpy={spy} />);
+
+        await user.selectOptions(screen.getByLabelText('List Type'), 'shelf');
+
+        const last = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+        expect(last).not.toHaveProperty('listUrl');
+        expect(last).not.toHaveProperty('importMax');
+        expect(last).toMatchObject({ apiKey: 'k', listType: 'shelf' });
+      });
+
+      it('shelf → custom drops shelfId', async () => {
+        const spy = vi.fn();
+        const user = userEvent.setup();
+        render(<StatefulProvider type="hardcover" initial={{ apiKey: 'k', listType: 'shelf', shelfId: 42 }} onChangeSpy={spy} />);
+
+        await user.selectOptions(screen.getByLabelText('List Type'), 'custom');
+
+        const last = spy.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+        expect(last).not.toHaveProperty('shelfId');
+        expect(last).toMatchObject({ apiKey: 'k', listType: 'custom' });
+      });
+    });
+  });
 });

--- a/src/client/pages/settings/ImportListProviderSettings.tsx
+++ b/src/client/pages/settings/ImportListProviderSettings.tsx
@@ -1,5 +1,6 @@
 import { SelectWithChevron } from '@/components/settings/SelectWithChevron';
 import { compactInputClass as inputClass } from '@/components/settings/formStyles';
+import { parseHardcoverListUrl } from '../../../shared/hardcover-list-url.js';
 
 interface SettingsProps {
   settings: Record<string, unknown>;
@@ -37,6 +38,26 @@ function NytSettings({ settings, onChange }: SettingsProps) {
 
 function HardcoverSettings({ settings, onChange }: SettingsProps) {
   const listType = (settings.listType as string) ?? 'trending';
+  const listUrl = (settings.listUrl as string) ?? '';
+  const importMax = settings.importMax === 'all' ? 'all' : String((settings.importMax as number | undefined) ?? 50);
+
+  // Advisory local feedback only (the server schema + test() are authoritative,
+  // #1879 AC13): a non-empty listUrl that fails to parse renders inline; empty
+  // and parseable values clear it.
+  const urlError = listUrl.trim() !== '' && parseHardcoverListUrl(listUrl) === null
+    ? 'Not a Hardcover list URL'
+    : null;
+
+  // Dedicated list-type change handler (AC12): preserve apiKey + only the target
+  // type's own keys, deleting every foreign key — listUrl/importMax when leaving
+  // custom, shelfId when entering custom or trending. Replaces the bare
+  // `onChange({ ...settings, listType })` so no stale foreign key survives.
+  function handleListTypeChange(next: string) {
+    const scoped: Record<string, unknown> = { ...settings, listType: next };
+    if (next !== 'custom') { delete scoped.listUrl; delete scoped.importMax; }
+    if (next !== 'shelf') { delete scoped.shelfId; }
+    onChange(scoped);
+  }
 
   return (
     <>
@@ -56,10 +77,11 @@ function HardcoverSettings({ settings, onChange }: SettingsProps) {
         <SelectWithChevron
           id="hc-listType"
           value={listType}
-          onChange={(e) => onChange({ ...settings, listType: e.target.value })}
+          onChange={(e) => handleListTypeChange(e.target.value)}
         >
           <option value="trending">Trending</option>
           <option value="shelf">Shelf</option>
+          <option value="custom">Custom List (by URL)</option>
         </SelectWithChevron>
       </div>
       {listType === 'shelf' && (
@@ -82,6 +104,37 @@ function HardcoverSettings({ settings, onChange }: SettingsProps) {
             placeholder="Your Hardcover shelf ID"
           />
         </div>
+      )}
+      {listType === 'custom' && (
+        <>
+          <div>
+            <label htmlFor="hc-listUrl" className="block text-sm font-medium mb-1">List URL</label>
+            <input
+              id="hc-listUrl"
+              type="text"
+              value={listUrl}
+              onChange={(e) => onChange({ ...settings, listUrl: e.target.value })}
+              className={inputClass}
+              placeholder="https://hardcover.app/@username/lists/list-slug"
+            />
+            {urlError && <p className="mt-1 text-sm text-destructive">{urlError}</p>}
+          </div>
+          <div>
+            <label htmlFor="hc-importMax" className="block text-sm font-medium mb-1">Import Max</label>
+            <SelectWithChevron
+              id="hc-importMax"
+              value={importMax}
+              onChange={(e) => {
+                const v = e.target.value;
+                onChange({ ...settings, importMax: v === 'all' ? 'all' : Number(v) });
+              }}
+            >
+              <option value="50">50</option>
+              <option value="100">100</option>
+              <option value="all">All</option>
+            </SelectWithChevron>
+          </div>
+        </>
       )}
     </>
   );

--- a/src/core/import-lists/hardcover-provider.test.ts
+++ b/src/core/import-lists/hardcover-provider.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { useMswServer } from '../__tests__/msw/server.js';
-import { HardcoverProvider } from './hardcover-provider.js';
+import { HardcoverProvider, type HardcoverConfig } from './hardcover-provider.js';
 import { ImportListError } from './errors.js';
 
 const GQL_URL = 'https://api.hardcover.app/v1/graphql';
@@ -581,6 +581,440 @@ describe('HardcoverProvider', () => {
       const result = await provider.test();
       expect(result.success).toBe(false);
       expect(result.message).toMatch(/validation failed/i);
+    });
+  });
+
+  // ── #1879 — custom list by URL ──────────────────────────────────────────────
+  describe('fetchItems — custom list (#1879)', () => {
+    const CUSTOM_URL = 'https://hardcover.app/@LisaRae/lists/2025-year-in-books';
+
+    const makeProvider = (overrides: Partial<HardcoverConfig> = {}) =>
+      new HardcoverProvider({ apiKey: 'test-key', listType: 'custom', listUrl: CUSTOM_URL, ...overrides });
+
+    const isCustomQuery = (query: string): boolean => query.includes('lists(');
+
+    const row = (id: number, book: unknown = { id, title: `Book ${id}`, contributions: [] }) =>
+      ({ id, position: id, book });
+
+    const rowsRange = (start: number, end: number) =>
+      Array.from({ length: end - start }, (_, i) => row(start + i));
+
+    const listResponse = (rows: unknown, booksCount: number | null = null, extra: Record<string, unknown> = {}) =>
+      ({ data: { lists: [{ id: 1, name: 'L', ranked: true, books_count: booksCount, list_books: rows, ...extra }] } });
+
+    // Serves paged windows from a virtual list of `total` rows, honouring the
+    // request `offset`/`limit`. `booksCount` defaults to `total`.
+    function pagedHandler(opts: { total: number; booksCount?: number | null; onRequest?: (vars: Record<string, unknown>) => void }) {
+      return http.post(GQL_URL, async ({ request }) => {
+        const body = await request.json() as GqlBody;
+        const vars = body.variables ?? {};
+        opts.onRequest?.(vars);
+        const offset = Number(vars.offset ?? 0);
+        const limit = Number(vars.limit ?? PAGE_SIZE);
+        const rows = rowsRange(offset, Math.min(offset + limit, opts.total));
+        return HttpResponse.json(listResponse(rows, opts.booksCount === undefined ? opts.total : opts.booksCount));
+      });
+    }
+
+    // Serves pre-scripted full responses in order, one per request.
+    function scriptedHandler(pages: unknown[], onRequest?: (vars: Record<string, unknown>, index: number) => void) {
+      let i = 0;
+      return http.post(GQL_URL, async ({ request }) => {
+        const body = await request.json() as GqlBody;
+        onRequest?.(body.variables ?? {}, i);
+        const page = pages[Math.min(i, pages.length - 1)] as Record<string, unknown>;
+        i += 1;
+        return HttpResponse.json(page);
+      });
+    }
+
+    const PAGE_SIZE = 100;
+
+    // F3 — the provider-level invalid/missing-URL failure (`requireParsedUrl`) is a
+    // trust boundary shared by fetchItems() and test(); assert its consequence
+    // directly (parser/schema tests don't cover the provider throw) and prove no
+    // network request is issued.
+    describe('invalid / missing List URL (F3)', () => {
+      const guardNoNetwork = () => {
+        let hits = 0;
+        server.use(http.post(GQL_URL, () => { hits += 1; return HttpResponse.json(listResponse([])); }));
+        return () => hits;
+      };
+
+      it('fetchItems() rejects with ImportListError and issues no request for an invalid URL', async () => {
+        const hits = guardNoNetwork();
+        const err = await makeProvider({ listUrl: 'https://example.com/not-hardcover' }).fetchItems().catch((e: unknown) => e);
+        expect(err).toBeInstanceOf(ImportListError);
+        expect((err as ImportListError).message).toBe('Not a Hardcover list URL');
+        expect(hits()).toBe(0);
+      });
+
+      it('fetchItems() rejects with ImportListError and issues no request for a missing URL', async () => {
+        const hits = guardNoNetwork();
+        const err = await new HardcoverProvider({ apiKey: 'test-key', listType: 'custom' }).fetchItems().catch((e: unknown) => e);
+        expect(err).toBeInstanceOf(ImportListError);
+        expect((err as ImportListError).message).toBe('Not a Hardcover list URL');
+        expect(hits()).toBe(0);
+      });
+
+      it('test() returns a failed result and issues no request for an invalid URL', async () => {
+        const hits = guardNoNetwork();
+        const result = await makeProvider({ listUrl: 'not-a-url' }).test();
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('Not a Hardcover list URL');
+        expect(hits()).toBe(0);
+      });
+    });
+
+    describe('query shape & variables (AC1, AC6)', () => {
+      it('sends citext/String variables, the public gate, and the array-form order_by', async () => {
+        let body: GqlBody | null = null;
+        server.use(http.post(GQL_URL, async ({ request }) => {
+          body = await request.json() as GqlBody;
+          return HttpResponse.json(listResponse([]));
+        }));
+
+        await makeProvider({ importMax: 50 }).fetchItems();
+
+        expect(body).not.toBeNull();
+        expect(isCustomQuery(body!.query)).toBe(true);
+        expect(body!.query).toContain('$username: citext!');
+        expect(body!.query).toContain('$slug: String!');
+        expect(body!.query).toContain('$offset: Int!');
+        expect(body!.query).toContain('public: { _eq: true }');
+        expect(body!.query).toContain('order_by: [{ position: asc_nulls_last }, { id: asc }]');
+        // Parsed from the URL, sent as variables (never interpolated).
+        expect(body!.variables).toMatchObject({ username: 'LisaRae', slug: '2025-year-in-books', limit: 50, offset: 0 });
+      });
+
+      it('reuses the shared BookFields fragment / mapBook (audio-edition asin + cover) (AC3)', async () => {
+        let body: GqlBody | null = null;
+        server.use(http.post(GQL_URL, async ({ request }) => {
+          body = await request.json() as GqlBody;
+          return HttpResponse.json(listResponse([row(7, {
+            id: 7,
+            title: 'Project Hail Mary',
+            description: 'Space.',
+            image: { url: 'https://hc.app/print.jpg' },
+            contributions: [{ author: { name: 'Andy Weir' } }],
+            default_audio_edition: { asin: 'B08G9XR74C', isbn_13: '9780593135228', image: { url: 'https://hc.app/audio.jpg' } },
+            editions: [{ asin: 'PRINT_ASIN' }],
+          })]));
+        }));
+
+        const items = await makeProvider({ importMax: 50 }).fetchItems();
+
+        expect(body!.query).toContain('...BookFields');
+        expect(body!.query).toContain('default_audio_edition { asin isbn_13 isbn_10 image { url } }');
+        expect(items).toEqual([{
+          title: 'Project Hail Mary',
+          author: 'Andy Weir',
+          asin: 'B08G9XR74C',
+          isbn: '9780593135228',
+          coverUrl: 'https://hc.app/audio.jpg',
+          description: 'Space.',
+        }]);
+      });
+    });
+
+    describe('Import Max — fixed limits (AC4)', () => {
+      it('importMax=50 issues a single query with limit 50, offset 0', async () => {
+        let count = 0;
+        const vars: Record<string, unknown>[] = [];
+        server.use(http.post(GQL_URL, async ({ request }) => {
+          count += 1;
+          const body = await request.json() as GqlBody;
+          vars.push(body.variables ?? {});
+          return HttpResponse.json(listResponse(rowsRange(0, 50)));
+        }));
+
+        const items = await makeProvider({ importMax: 50 }).fetchItems();
+        expect(count).toBe(1);
+        expect(vars[0]).toMatchObject({ limit: 50, offset: 0 });
+        expect(items).toHaveLength(50);
+      });
+
+      it('importMax=100 issues a single query with limit 100', async () => {
+        let capturedLimit: unknown;
+        server.use(http.post(GQL_URL, async ({ request }) => {
+          const body = await request.json() as GqlBody;
+          capturedLimit = body.variables?.limit;
+          return HttpResponse.json(listResponse(rowsRange(0, 100)));
+        }));
+
+        const items = await makeProvider({ importMax: 100 }).fetchItems();
+        expect(capturedLimit).toBe(100);
+        expect(items).toHaveLength(100);
+      });
+
+      it('defaults to limit 50 when importMax is omitted', async () => {
+        let capturedLimit: unknown;
+        server.use(http.post(GQL_URL, async ({ request }) => {
+          const body = await request.json() as GqlBody;
+          capturedLimit = body.variables?.limit;
+          return HttpResponse.json(listResponse(rowsRange(0, 10)));
+        }));
+
+        await makeProvider().fetchItems();
+        expect(capturedLimit).toBe(50);
+      });
+    });
+
+    describe("Import Max — 'all' pagination (AC5, AC6)", () => {
+      it('pages until a short page, concatenating rows with correct offsets', async () => {
+        const offsets: unknown[] = [];
+        server.use(pagedHandler({ total: 130, onRequest: (v) => offsets.push(v.offset) }));
+
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(offsets).toEqual([0, 100]);
+        expect(items).toHaveLength(130);
+        expect(items[0]!.title).toBe('Book 0');
+        expect(items[129]!.title).toBe('Book 129');
+      });
+
+      it('terminates on the empty page after an exact multiple of 100 (no throw)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 100, onRequest: () => { count += 1; } }));
+
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(count).toBe(2); // full page (0) then empty page (100)
+        expect(items).toHaveLength(100);
+      });
+
+      it('first request always fires; budget derives from the first response books_count (F30)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 130, booksCount: 130, onRequest: () => { count += 1; } }));
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(count).toBe(2);
+        expect(items).toHaveLength(130);
+      });
+
+      it('null books_count falls back to MAX_LIST_PAGES without breaking the loop (F30)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 130, booksCount: null, onRequest: () => { count += 1; } }));
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(count).toBe(2);
+        expect(items).toHaveLength(130);
+      });
+
+      it('4999 rows: 49 full pages + a 99-row short page → returns 4999, no throw (F36a)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 4999, onRequest: () => { count += 1; } }));
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(count).toBe(50);
+        expect(items).toHaveLength(4999);
+      });
+
+      it('exactly 5000 rows: 50 full pages + an empty terminal page → returns 5000, no throw (F36b)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 5000, onRequest: () => { count += 1; } }));
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(count).toBe(51);
+        expect(items).toHaveLength(5000);
+      });
+
+      it('a 51st FULL page (> 5000 full rows) → deterministic ImportListError, no partial result (F36c)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 5100, booksCount: 5100, onRequest: () => { count += 1; } }));
+        await expect(makeProvider({ importMax: 'all' }).fetchItems()).rejects.toBeInstanceOf(ImportListError);
+        expect(count).toBe(51); // 50 full pages accepted, throws on the 51st full page
+      });
+
+      it('a large/corrupt books_count is still clamped at MAX_LIST_PAGES full pages (F34)', async () => {
+        let count = 0;
+        server.use(pagedHandler({ total: 5100, booksCount: 999999, onRequest: () => { count += 1; } }));
+        await expect(makeProvider({ importMax: 'all' }).fetchItems()).rejects.toThrow(ImportListError);
+        expect(count).toBe(51);
+      });
+
+      it('books_count-derived budget throws on the first full page beyond it (F28)', async () => {
+        let count = 0;
+        // books_count 250 → ceil(250/100)=3 full-page budget; server keeps serving full pages.
+        server.use(pagedHandler({ total: 500, booksCount: 250, onRequest: () => { count += 1; } }));
+        await expect(makeProvider({ importMax: 'all' }).fetchItems()).rejects.toThrow(ImportListError);
+        expect(count).toBe(4); // 3 full pages accepted, throws on the 4th
+      });
+
+      it('advances past a full page with an unmappable row; the row still consumes its id slot (F14)', async () => {
+        const page1 = rowsRange(0, 100);
+        page1[50] = row(50, { id: 50, title: null, contributions: [] }); // titleless → dropped
+        server.use(scriptedHandler([
+          listResponse(page1),
+          listResponse(rowsRange(100, 120)), // short second page of new rows
+        ]));
+
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        // 99 mappable from page 1 (row 50 dropped) + 20 from page 2.
+        expect(items).toHaveLength(119);
+        expect(items.some((i) => i.title === 'Book 50')).toBe(false);
+      });
+
+      it('an exact-repeat full page (zero new ids) → deterministic ImportListError (F31)', async () => {
+        let count = 0;
+        const page = rowsRange(0, 100);
+        server.use(scriptedHandler([listResponse(page), listResponse(page)], () => { count += 1; }));
+        await expect(makeProvider({ importMax: 'all' }).fetchItems()).rejects.toThrow(/repeated page/i);
+        expect(count).toBe(2);
+      });
+
+      // F5 — deletion-sensitive proof that a row's RAW id enters `seen` BEFORE (and
+      // independently of) book mapping. The repeated page's ONLY unmappable row is the
+      // titleless one at id 50; every other row is mappable and would enter `seen`
+      // regardless. If `seen.add(id)` were moved after successful mapping, id 50 would be
+      // "new" on page 2, the zero-new-id guard would NOT fire, and pagination would run
+      // past the second request (eventually a runaway, not a repeated-page error). Pinning
+      // exactly two requests + the repeated-page error kills that mutation.
+      it('an exact-repeat full page whose only unmappable row is titleless still triggers the repeated-page guard after the 2nd request (F5)', async () => {
+        let count = 0;
+        const page = rowsRange(0, 100);
+        page[50] = row(50, { id: 50, title: null, contributions: [] }); // titleless → dropped from output, id must still be consumed
+        server.use(scriptedHandler([listResponse(page), listResponse(page)], () => { count += 1; }));
+        await expect(makeProvider({ importMax: 'all' }).fetchItems()).rejects.toThrow(/repeated page/i);
+        expect(count).toBe(2);
+      });
+
+      // F5 companion — overlap (not exact repeat): page 2 re-sends the titleless row 50
+      // plus genuinely new ids. The titleless row is never emitted, and because its raw id
+      // was already consumed on page 1 it is not re-counted; pagination continues to the
+      // short page rather than erroring.
+      it('an overlapping page re-sending an already-seen titleless row does not re-emit or error (F5)', async () => {
+        const page1 = rowsRange(0, 100);
+        page1[50] = row(50, { id: 50, title: null, contributions: [] });
+        const page2 = [page1[50], ...rowsRange(100, 199)]; // full page: titleless id 50 (seen) + 99 new ids
+        server.use(scriptedHandler([
+          listResponse(page1),
+          listResponse(page2),
+          listResponse(rowsRange(199, 210)), // short terminal page
+        ]));
+
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(items.some((i) => i.title === 'Book 50')).toBe(false);
+        // 99 mappable from page 1 + 99 new from page 2 + 11 from the short page.
+        expect(items).toHaveLength(209);
+      });
+
+      it('partially overlapping full pages are de-duplicated by raw id and continue (F19)', async () => {
+        server.use(scriptedHandler([
+          listResponse(rowsRange(0, 100)),    // ids 0..99
+          listResponse(rowsRange(50, 150)),   // overlap 50..99, new 100..149
+          listResponse(rowsRange(150, 170)),  // short
+        ]));
+
+        const items = await makeProvider({ importMax: 'all' }).fetchItems();
+        expect(items).toHaveLength(170);
+        expect(items[0]!.title).toBe('Book 0');
+        expect(items[169]!.title).toBe('Book 169');
+      });
+    });
+
+    describe('list resolution & null/missing dispositions (AC7, AC8)', () => {
+      const fetchErr = async (response: Record<string, unknown>) => {
+        server.use(http.post(GQL_URL, () => HttpResponse.json(response)));
+        return makeProvider({ importMax: 50 }).fetchItems().catch((e: unknown) => e);
+      };
+
+      it('lists: [] → "List not found or private" (NOT [])', async () => {
+        const err = await fetchErr({ data: { lists: [] } });
+        expect(err).toBeInstanceOf(ImportListError);
+        expect((err as ImportListError).message).toBe('List not found or private');
+      });
+
+      it('resolved-empty list_books: [] → returns [] (distinct from not-found)', async () => {
+        server.use(http.post(GQL_URL, () => HttpResponse.json(listResponse([]))));
+        await expect(makeProvider({ importMax: 50 }).fetchItems()).resolves.toEqual([]);
+      });
+
+      it('lists: null and omitted lists → unexpected-response error', async () => {
+        expect(await fetchErr({ data: { lists: null } })).toBeInstanceOf(ImportListError);
+        expect(await fetchErr({ data: {} })).toBeInstanceOf(ImportListError);
+      });
+
+      it('nested list_books null / omitted → unexpected-response error', async () => {
+        expect(await fetchErr({ data: { lists: [{ id: 1, list_books: null }] } })).toBeInstanceOf(ImportListError);
+        expect(await fetchErr({ data: { lists: [{ id: 1 }] } })).toBeInstanceOf(ImportListError);
+      });
+
+      it('row id null / omitted → unexpected-response error', async () => {
+        expect(await fetchErr(listResponse([{ id: null, position: 1, book: { title: 'X' } }]))).toBeInstanceOf(ImportListError);
+        expect(await fetchErr(listResponse([{ position: 1, book: { title: 'X' } }]))).toBeInstanceOf(ImportListError);
+      });
+
+      it('null/missing/titleless book rows are dropped (not errors); the mappable remainder returns (F32)', async () => {
+        server.use(http.post(GQL_URL, () => HttpResponse.json(listResponse([
+          row(1, null),
+          row(2),                                   // mappable
+          { id: 3, position: 3 },                   // omitted book
+          row(4, { id: 4, title: null, contributions: [] }), // titleless
+        ]))));
+
+        const items = await makeProvider({ importMax: 50 }).fetchItems();
+        expect(items).toHaveLength(1);
+        expect(items[0]!.title).toBe('Book 2');
+      });
+
+      it('surfaces a GraphQL errors[] message', async () => {
+        server.use(http.post(GQL_URL, () => HttpResponse.json({ errors: [{ message: 'Rate limited' }] })));
+        await expect(makeProvider({ importMax: 50 }).fetchItems()).rejects.toThrow('Hardcover GraphQL error: Rate limited');
+      });
+
+      it('a malformed later page throws with NO partial result (F38)', async () => {
+        for (const badPage2 of [
+          { data: { lists: [] } },
+          { data: { lists: null } },
+          { data: { lists: [{ id: 1, list_books: null }] } },
+          listResponse([{ id: null, position: 1, book: { title: 'X' } }]),
+        ]) {
+          server.use(scriptedHandler([listResponse(rowsRange(0, 100)), badPage2]));
+          await expect(makeProvider({ importMax: 'all' }).fetchItems()).rejects.toBeInstanceOf(ImportListError);
+        }
+      });
+    });
+
+    describe('test() probe (AC9)', () => {
+      it('sends the complete { username, slug, limit: 1, offset: 0 } variable set (F33)', async () => {
+        let body: GqlBody | null = null;
+        server.use(http.post(GQL_URL, async ({ request }) => {
+          body = await request.json() as GqlBody;
+          return HttpResponse.json(listResponse(rowsRange(0, 1)));
+        }));
+
+        const result = await makeProvider({ importMax: 50 }).test();
+        expect(result).toEqual({ success: true });
+        expect(body!.variables).toEqual({ username: 'LisaRae', slug: '2025-year-in-books', limit: 1, offset: 0 });
+      });
+
+      it('succeeds for a resolved list, resolved-empty, and null-book-only rows', async () => {
+        for (const rows of [rowsRange(0, 1), [], [row(9, null)]]) {
+          server.use(http.post(GQL_URL, () => HttpResponse.json(listResponse(rows))));
+          await expect(makeProvider({ importMax: 50 }).test()).resolves.toEqual({ success: true });
+        }
+      });
+
+      it('lists: [] → not-found/private failure', async () => {
+        server.use(http.post(GQL_URL, () => HttpResponse.json({ data: { lists: [] } })));
+        const result = await makeProvider({ importMax: 50 }).test();
+        expect(result).toEqual({ success: false, message: 'List not found or private' });
+      });
+
+      it('null/missing lists, list_books, or row id → unexpected-response failure', async () => {
+        for (const response of [
+          { data: { lists: null } },
+          { data: { lists: [{ id: 1, list_books: null }] } },
+          listResponse([{ id: null, position: 1, book: { title: 'X' } }]),
+        ]) {
+          server.use(http.post(GQL_URL, () => HttpResponse.json(response as Record<string, unknown>)));
+          const result = await makeProvider({ importMax: 50 }).test();
+          expect(result.success).toBe(false);
+        }
+      });
+
+      it('401/403 → "Invalid API key"', async () => {
+        for (const status of [401, 403]) {
+          server.use(http.post(GQL_URL, () => new HttpResponse(null, { status })));
+          const result = await makeProvider({ importMax: 50 }).test();
+          expect(result).toEqual({ success: false, message: 'Invalid API key' });
+        }
+      });
     });
   });
 });

--- a/src/core/import-lists/hardcover-provider.ts
+++ b/src/core/import-lists/hardcover-provider.ts
@@ -5,14 +5,32 @@ import { formatZodError } from './format-zod-error.js';
 import { getErrorMessage } from '../../shared/error-message.js';
 import { fetchWithTimeout } from '../utils/network-service.js';
 import { IMPORT_LIST_TIMEOUT_MS } from '../utils/constants.js';
+import { parseHardcoverListUrl } from '../../shared/hardcover-list-url.js';
+import type { HardcoverListType, HardcoverImportMax } from '../../shared/hardcover-list-types.js';
 
 export interface HardcoverConfig {
   apiKey: string;
-  listType: 'trending' | 'shelf';
+  listType: HardcoverListType;
   shelfId?: number;
+  listUrl?: string;
+  importMax?: HardcoverImportMax;
 }
 
 const GRAPHQL_URL = 'https://api.hardcover.app/v1/graphql';
+
+// #1879 — custom-list ('all') pagination bounds. `PAGE_SIZE` is the per-request
+// window; `MAX_LIST_PAGES` is an absolute cap on FULL data pages (≤ 5000 rows)
+// that even a large/corrupt `books_count` cannot exceed (AC5).
+const PAGE_SIZE = 100;
+const MAX_LIST_PAGES = 50;
+
+const NOT_FOUND_MSG = 'List not found or private';
+const UNEXPECTED_LISTS_MSG = 'Hardcover returned an unexpected response (missing lists)';
+const UNEXPECTED_ROWS_MSG = 'Hardcover returned an unexpected response (missing list_books)';
+const UNEXPECTED_ROW_ID_MSG = 'Hardcover returned an unexpected response (list row without a numeric id)';
+const REPEATED_PAGE_MSG = 'Hardcover returned a repeated page (offset appears to be ignored)';
+const RUNAWAY_MSG = 'Hardcover list exceeds the supported size (pagination runaway guard)';
+const BAD_URL_MSG = 'Not a Hardcover list URL';
 
 // Trending window: `books_trending` ranks books over a [from, to] date range.
 // `from = today − TRENDING_WINDOW_DAYS`, `to = today`. No settings field — these
@@ -68,6 +86,37 @@ const SHELF_QUERY = `
   ${BOOK_FRAGMENT}
 `;
 
+// #1879 — resolve one public list by `@username` + slug, then page its ordered
+// rows. `public: { _eq: true }` gates a private list out at the query level (an
+// unresolved list comes back as `lists: []`). Multi-column ordering MUST use the
+// array-of-single-key-objects form — Hasura's `order_by` is a list and does not
+// preserve key order inside one input object (matches src/core/metadata/hardcover.ts).
+const CUSTOM_LIST_QUERY = `
+  query CustomList($username: citext!, $slug: String!, $limit: Int!, $offset: Int!) {
+    lists(
+      where: {
+        slug: { _eq: $slug },
+        user: { username: { _eq: $username } },
+        public: { _eq: true }
+      },
+      limit: 1
+    ) {
+      id
+      name
+      ranked
+      books_count
+      list_books(order_by: [{ position: asc_nulls_last }, { id: asc }], limit: $limit, offset: $offset) {
+        id
+        position
+        book {
+          ...BookFields
+        }
+      }
+    }
+  }
+  ${BOOK_FRAGMENT}
+`;
+
 const editionSchema = z.object({
   asin: z.string().nullish(),
   isbn_13: z.string().nullish(),
@@ -93,16 +142,48 @@ const hardcoverBookSchema = z.object({
 type HardcoverBook = z.infer<typeof hardcoverBookSchema>;
 type HardcoverEdition = z.infer<typeof editionSchema>;
 
+// #1879 — custom list rows. Every externally-parsed field is `.nullish()`
+// (zod-nullish-external-api); the algorithm's post-parse dispositions (AC8) are
+// what guard the fields it depends on (`id` must be numeric; `list_books` must
+// be a real array, not null/missing).
+const hardcoverListBookSchema = z.object({
+  id: z.number().nullish(),
+  position: z.number().nullish(),
+  book: hardcoverBookSchema.nullish(),
+}).passthrough();
+
+const hardcoverListSchema = z.object({
+  id: z.number().nullish(),
+  name: z.string().nullish(),
+  ranked: z.boolean().nullish(),
+  books_count: z.number().nullish(),
+  list_books: z.array(hardcoverListBookSchema).nullish(),
+}).passthrough();
+
+type HardcoverList = z.infer<typeof hardcoverListSchema>;
+type HardcoverListBook = z.infer<typeof hardcoverListBookSchema>;
+
 const hardcoverResponseSchema = z.object({
   data: z.object({
     books_trending: z.object({ ids: z.array(z.number()).nullish() }).passthrough().nullish(),
     books: z.array(hardcoverBookSchema).nullish(),
     user_books: z.array(z.object({ book: hardcoverBookSchema.nullish() }).passthrough()).nullish(),
+    lists: z.array(hardcoverListSchema).nullish(),
   }).passthrough().nullish(),
   errors: z.array(z.object({ message: z.string() }).passthrough()).nullish(),
 }).passthrough();
 
 type HardcoverResponse = z.infer<typeof hardcoverResponseSchema>;
+
+// Freeze the FULL-page budget from the first response's `books_count`: the ceil
+// of pages the count implies, clamped to the absolute MAX_LIST_PAGES cap. A
+// missing/null/non-positive/non-finite count falls back to the cap (AC5).
+function customPageBudget(booksCount: number | null | undefined): number {
+  const base = (typeof booksCount === 'number' && Number.isFinite(booksCount) && booksCount > 0)
+    ? Math.ceil(booksCount / PAGE_SIZE)
+    : MAX_LIST_PAGES;
+  return Math.min(MAX_LIST_PAGES, base);
+}
 
 function editionAsin(edition: HardcoverEdition | null | undefined): string | undefined {
   return edition?.asin || undefined;
@@ -157,17 +238,121 @@ export class HardcoverProvider implements ImportListProvider {
   readonly name = 'Hardcover';
 
   private apiKey: string;
-  private listType: 'trending' | 'shelf';
+  private listType: HardcoverListType;
   private shelfId?: number;
+  private listUrl?: string;
+  private importMax?: HardcoverImportMax;
 
   constructor(config: HardcoverConfig) {
     this.apiKey = config.apiKey;
     this.listType = config.listType;
     if (config.shelfId !== undefined) this.shelfId = config.shelfId;
+    if (config.listUrl !== undefined) this.listUrl = config.listUrl;
+    if (config.importMax !== undefined) this.importMax = config.importMax;
   }
 
   async fetchItems(): Promise<ImportListItem[]> {
+    if (this.listType === 'custom') return this.fetchCustomList();
     return this.listType === 'shelf' ? this.fetchShelf() : this.fetchTrending();
+  }
+
+  private async fetchCustomList(): Promise<ImportListItem[]> {
+    const { username, slug } = this.requireParsedUrl();
+    const importMax = this.importMax ?? 50;
+    if (importMax === 'all') return this.fetchAllPages(username, slug);
+
+    // Fixed limit — a single query for the first N rows by list position.
+    const data = await this.executeQuery(CUSTOM_LIST_QUERY, { username, slug, limit: importMax, offset: 0 });
+    const rows = this.resolveRows(data);
+    this.validateRowIds(rows);
+    return this.emitRows(rows, new Set<number>());
+  }
+
+  // `all` — bounded pagination over `list_books` keyed on the RAW `list_books.id`.
+  // Validity + de-dup happen on raw rows BEFORE (and independent of) book mapping,
+  // so a row `mapBook` drops still consumes its id slot (AC5/AC6).
+  private async fetchAllPages(username: string, slug: string): Promise<ImportListItem[]> {
+    const seen = new Set<number>();
+    const items: ImportListItem[] = [];
+    let offset = 0;
+    let fullPageBudget = MAX_LIST_PAGES;
+    let budgetFrozen = false;
+    let fullPagesFetched = 0;
+
+    for (;;) {
+      const data = await this.executeQuery(CUSTOM_LIST_QUERY, { username, slug, limit: PAGE_SIZE, offset });
+      const list = this.resolveList(data);
+      const rows = this.requireRows(list);
+      this.validateRowIds(rows);
+
+      if (!budgetFrozen) {
+        // Freeze the budget from the FIRST response only — `books_count` cannot
+        // change the bound mid-run (F17).
+        fullPageBudget = customPageBudget(list.books_count);
+        budgetFrozen = true;
+      }
+
+      const isFullPage = rows.length === PAGE_SIZE;
+      const newRows = rows.filter((row) => !seen.has(row.id as number));
+      // A FULL page contributing zero new ids means the server ignored `offset`.
+      if (isFullPage && newRows.length === 0) throw new ImportListError(this.name, REPEATED_PAGE_MSG);
+
+      items.push(...this.emitRows(newRows, seen));
+
+      // Terminal short/empty page is ALWAYS permitted — the budget bounds only FULL pages.
+      if (!isFullPage) return items;
+
+      fullPagesFetched += 1;
+      if (fullPagesFetched > fullPageBudget) throw new ImportListError(this.name, RUNAWAY_MSG);
+      offset += PAGE_SIZE;
+    }
+  }
+
+  private requireParsedUrl(): { username: string; slug: string } {
+    const parsed = parseHardcoverListUrl(this.listUrl ?? '');
+    if (!parsed) throw new ImportListError(this.name, BAD_URL_MSG);
+    return parsed;
+  }
+
+  // `lists: []` → not-found/private (AC7); `lists` null/missing → malformed (AC8).
+  private resolveList(data: HardcoverResponse): HardcoverList {
+    const lists = data.data?.lists;
+    if (lists == null) throw new ImportListError(this.name, UNEXPECTED_LISTS_MSG);
+    if (lists.length === 0) throw new ImportListError(this.name, NOT_FOUND_MSG);
+    return lists[0]!;
+  }
+
+  // A resolved list's `list_books: []` is a genuine empty list (success); null/
+  // missing is a malformed nested response (AC8), distinct from a real empty array.
+  private requireRows(list: HardcoverList): HardcoverListBook[] {
+    const rows = list.list_books;
+    if (rows == null) throw new ImportListError(this.name, UNEXPECTED_ROWS_MSG);
+    return rows;
+  }
+
+  private resolveRows(data: HardcoverResponse): HardcoverListBook[] {
+    return this.requireRows(this.resolveList(data));
+  }
+
+  // Every row needs a numeric id — it is the stable dedup/loop-guard key (AC8).
+  private validateRowIds(rows: HardcoverListBook[]): void {
+    for (const row of rows) {
+      if (typeof row.id !== 'number') throw new ImportListError(this.name, UNEXPECTED_ROW_ID_MSG);
+    }
+  }
+
+  // Emit output for unseen rows in query order; a row whose `book` is null/missing/
+  // unmappable still consumes its id slot (added to `seen`) but is dropped from output.
+  private emitRows(rows: HardcoverListBook[], seen: Set<number>): ImportListItem[] {
+    const out: ImportListItem[] = [];
+    for (const row of rows) {
+      const id = row.id as number;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const item = row.book != null ? mapBook(row.book) : null;
+      if (item) out.push(item);
+    }
+    return out;
   }
 
   private async fetchTrending(): Promise<ImportListItem[]> {
@@ -264,6 +449,18 @@ export class HardcoverProvider implements ImportListProvider {
         return { success: false, message: `Hardcover GraphQL error: ${parsed.data.errors[0]!.message}` };
       }
 
+      // A custom probe must apply the same list-resolution dispositions as a real
+      // sync: `lists: []` → not-found/private, null/missing lists/list_books or a
+      // null-id row → unexpected-response failure (AC9). A resolved list (including
+      // resolved-empty and null-book-only rows) clears the probe.
+      if (this.listType === 'custom') {
+        try {
+          this.validateRowIds(this.resolveRows(parsed.data));
+        } catch (error: unknown) {
+          return { success: false, message: getErrorMessage(error) };
+        }
+      }
+
       return { success: true };
     } catch (error: unknown) {
       return { success: false, message: `Connection failed: ${getErrorMessage(error)}` };
@@ -273,6 +470,11 @@ export class HardcoverProvider implements ImportListProvider {
   // Minimal real query for the configured list type (limit 1) so `test()` exercises
   // the same fields a real sync uses.
   private buildProbe(): { query: string; variables: Record<string, unknown> } {
+    if (this.listType === 'custom') {
+      const { username, slug } = this.requireParsedUrl();
+      // The operation declares `$offset: Int!`, so `offset` is required (AC9/F33).
+      return { query: CUSTOM_LIST_QUERY, variables: { username, slug, limit: 1, offset: 0 } };
+    }
     if (this.listType === 'shelf') {
       return { query: SHELF_QUERY, variables: { statusId: this.shelfId, limit: 1 } };
     }

--- a/src/core/import-lists/registry.test.ts
+++ b/src/core/import-lists/registry.test.ts
@@ -78,8 +78,9 @@ describe('Import List IMPORT_LIST_ADAPTER_FACTORIES', () => {
       IMPORT_LIST_ADAPTER_FACTORIES.hardcover({ apiKey: 'key', listType: 'trending', shelfId: undefined });
       // Producer-omit pattern: undefined shelfId is dropped from the
       // constructor payload, not passed through as explicit undefined
-      // (eopt invariant per #939 AC4).
-      const ctorArg = vi.mocked(HardcoverProvider).mock.calls[0]![0];
+      // (eopt invariant per #939 AC4). Read the LAST call — this file does not
+      // clear mocks between tests, so `.calls[0]` would inspect an earlier test's call.
+      const ctorArg = vi.mocked(HardcoverProvider).mock.calls.at(-1)![0];
       expect(ctorArg).not.toHaveProperty('shelfId');
     });
 
@@ -88,6 +89,32 @@ describe('Import List IMPORT_LIST_ADAPTER_FACTORIES', () => {
       expect(HardcoverProvider).toHaveBeenCalledWith(
         expect.objectContaining({ shelfId: 42 }),
       );
+    });
+
+    // #1879 — custom-list field forwarding (AC1, F2)
+    it('hardcover factory forwards listUrl + numeric importMax for a custom list', () => {
+      const url = 'https://hardcover.app/@LisaRae/lists/2025-year-in-books';
+      IMPORT_LIST_ADAPTER_FACTORIES.hardcover({ apiKey: 'key', listType: 'custom', listUrl: url, importMax: 100 });
+      expect(HardcoverProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ apiKey: 'key', listType: 'custom', listUrl: url, importMax: 100 }),
+      );
+    });
+
+    it("hardcover factory forwards importMax: 'all'", () => {
+      const url = 'https://hardcover.app/@LisaRae/lists/2025-year-in-books';
+      IMPORT_LIST_ADAPTER_FACTORIES.hardcover({ apiKey: 'key', listType: 'custom', listUrl: url, importMax: 'all' });
+      expect(HardcoverProvider).toHaveBeenCalledWith(
+        expect.objectContaining({ importMax: 'all' }),
+      );
+    });
+
+    it('hardcover factory omits listUrl/importMax for a non-custom list', () => {
+      IMPORT_LIST_ADAPTER_FACTORIES.hardcover({ apiKey: 'key', listType: 'trending' });
+      // Read the LAST call — this file does not clear mocks between tests, so
+      // `.calls[0]` would inspect an earlier test's call and pass vacuously (F4).
+      const ctorArg = vi.mocked(HardcoverProvider).mock.calls.at(-1)![0];
+      expect(ctorArg).not.toHaveProperty('listUrl');
+      expect(ctorArg).not.toHaveProperty('importMax');
     });
   });
 });

--- a/src/core/import-lists/registry.ts
+++ b/src/core/import-lists/registry.ts
@@ -13,6 +13,8 @@ const TYPED_FACTORIES: { [K in ImportListType]: (settings: ImportListSettingsMap
     apiKey: s.apiKey,
     listType: s.listType || 'trending',
     ...(s.shelfId !== undefined && { shelfId: s.shelfId }),
+    ...(s.listUrl !== undefined && { listUrl: s.listUrl }),
+    ...(s.importMax !== undefined && { importMax: s.importMax }),
   }),
 };
 

--- a/src/server/services/download-blockers.test.ts
+++ b/src/server/services/download-blockers.test.ts
@@ -47,7 +47,7 @@ describe('isPipelineBlocker (#1857 F59)', () => {
     expect(isPipelineBlocker(dl({ clientStatus: 'completed', pipelineStage }))).toBe(true);
   });
 
-  it('blocks a tracked completed row (externalId != null) — QG-eligible', () => {
+  it('blocks a tracked completed row (non-empty externalId) — QG-eligible', () => {
     expect(isPipelineBlocker(dl({ clientStatus: 'completed', pipelineStage: 'idle', externalId: 'ext-1' }))).toBe(true);
   });
 

--- a/src/server/services/download-blockers.ts
+++ b/src/server/services/download-blockers.ts
@@ -44,15 +44,16 @@ export function isClientStageReplaceable(d: Pick<DownloadRow, 'clientStatus' | '
  * import pipeline — a **non-replaceable** blocker. Enumerated by an exact
  * predicate (F59):
  *   - any non-idle pipeline stage (`checking`/`pending_review`/`importing`), OR
- *   - a *tracked* `completed`-display download with a non-null `externalId`
+ *   - a *tracked* `completed`-display download with a non-empty `externalId`
  *     (QG-eligible). This mirrors the quality gate's own batch query exactly
- *     (`quality-gate.service.ts:39` — `... AND isNotNull(downloads.externalId)`),
- *     so a row counts as a "will-be-imported" blocker iff the QG will actually
- *     pick it up.
+ *     (both delegate row eligibility to the shared
+ *     `qualityGateEligibleDownloadCondition` / `isQualityGateEligibleRow`
+ *     predicate), so a row counts as a "will-be-imported" blocker iff the QG
+ *     will actually pick it up.
  *
- * A **Blackhole handoff** `(completed, idle, externalId = null)` is deliberately
- * NOT a blocker: not QG-eligible, terminal, and the accepted post-settlement
- * re-grab must proceed.
+ * A **Blackhole handoff** `(completed, idle, externalId = null OR '')` is
+ * deliberately NOT a blocker: not QG-eligible, terminal, and the accepted
+ * post-settlement re-grab must proceed.
  */
 export function isPipelineBlocker(d: BlockerFields): boolean {
   if (d.pipelineStage === 'checking' || d.pipelineStage === 'pending_review' || d.pipelineStage === 'importing') {
@@ -73,8 +74,9 @@ export interface BookBlockers {
 }
 
 /** SQL selecting the rows relevant to blocker classification for one book:
- *  in-progress rows PLUS tracked (`externalId != null`) completed rows. A
- *  Blackhole handoff (completed, externalId null) is excluded by construction. */
+ *  in-progress rows PLUS tracked (non-empty `externalId`) completed rows. A
+ *  Blackhole handoff (completed, externalId null OR '') is excluded by
+ *  construction. */
 function bookBlockerRowsCondition(bookId: number) {
   return and(
     eq(downloads.bookId, bookId),

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -26,6 +26,7 @@ import {
   rankResultsCleaned,
   rankResults,
   positionTiebreak,
+  durationTiebreak,
   resolveConfidenceFromDuration,
   resolveSingleResultConfidence,
   parsePublishedYear,
@@ -709,6 +710,192 @@ describe('rankResultsCleaned position tiebreaker', () => {
     const ranked = rankResultsCleaned([noPos, alsoNoPos], { title: 'Fablehaven', author: 'Brandon Mull', seriesPosition: 1 });
     expect(ranked[0]!.meta.publishedDate).toBe('2008');
     expect(ranked[1]!.meta.publishedDate).toBe('2006');
+  });
+});
+
+// ============================================================================
+// durationTiebreak — shared edition comparator (#1882)
+// ============================================================================
+
+describe('durationTiebreak', () => {
+  // Provider `duration` is MINUTES; scanned seconds is SECONDS. Dogs of War:
+  // 598min (9h58m) = 35,880s, Δ56s ≤ 240 → verified; 568min (9h28m) = 34,080s,
+  // Δ1,856s → not verified. Scanned = 35,936s.
+  const SCANNED = 35_936;
+  const agree = makeBook({ duration: 598 });
+  const disagree = makeBook({ duration: 568 });
+  const missing = makeBook({ duration: undefined });
+  const zero = makeBook({ duration: 0 });
+
+  it('invalid scannedSeconds (undefined) → 0 for any two candidates', () => {
+    expect(durationTiebreak(agree, disagree, undefined)).toBe(0);
+  });
+
+  it('invalid scannedSeconds (0) → 0', () => {
+    expect(durationTiebreak(agree, disagree, 0)).toBe(0);
+  });
+
+  it('invalid scannedSeconds (negative) → 0', () => {
+    expect(durationTiebreak(agree, disagree, -100)).toBe(0);
+  });
+
+  it('valid scan: the agreeing candidate sorts first (negative → a first, positive swapped)', () => {
+    expect(durationTiebreak(agree, disagree, SCANNED)).toBeLessThan(0);
+    expect(durationTiebreak(disagree, agree, SCANNED)).toBeGreaterThan(0);
+  });
+
+  it('verified beats a missing-duration candidate (missing folds into non-verified, case 2)', () => {
+    expect(durationTiebreak(agree, missing, SCANNED)).toBeLessThan(0);
+    expect(durationTiebreak(missing, agree, SCANNED)).toBeGreaterThan(0);
+  });
+
+  it('verified beats a zero-duration candidate', () => {
+    expect(durationTiebreak(agree, zero, SCANNED)).toBeLessThan(0);
+  });
+
+  it('both candidates agree → 0 (stable, case 3)', () => {
+    const alsoAgree = makeBook({ duration: 599 }); // 35,940s, Δ4s ≤ 240 → verified
+    expect(durationTiebreak(agree, alsoAgree, SCANNED)).toBe(0);
+  });
+
+  it('both candidates disagree → 0', () => {
+    const alsoDisagree = makeBook({ duration: 777 }); // 46,620s → not verified
+    expect(durationTiebreak(disagree, alsoDisagree, SCANNED)).toBe(0);
+  });
+
+  it('two non-verified candidates (one missing, one present-but-off) → 0 (case 4, absence never demotes)', () => {
+    expect(durationTiebreak(missing, disagree, SCANNED)).toBe(0);
+    expect(durationTiebreak(disagree, missing, SCANNED)).toBe(0);
+  });
+
+  it('introduces no new duration primitive: delegates entirely to isDurationVerified', () => {
+    // A candidate exactly on the 240s band edge verifies via withinDurationTolerance
+    // (inclusive) with no re-derived conversion in the tiebreak itself.
+    const edge = makeBook({ duration: 600 }); // 36,000s vs 36,240s scanned → Δ240 ≤ 240 → verified
+    const off = makeBook({ duration: 600 });
+    expect(durationTiebreak(edge, makeBook({ duration: undefined }), 36_240)).toBeLessThan(0);
+    expect(durationTiebreak(edge, off, 36_240)).toBe(0);
+  });
+});
+
+// ============================================================================
+// Duration-agreement tiebreaker in the rankers (#1882) — Dogs of War
+// ============================================================================
+
+describe('rankResults duration tiebreaker', () => {
+  // Same title/author/narrators, different runtimes: text score is tied, so
+  // duration must decide. Scanned 35,936s → 598min edition verifies.
+  const edition568 = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 568 });
+  const edition598 = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 598 });
+  const SCANNED = 35_936;
+
+  it('promotes the duration-agreeing (9h58m) sibling when text scores are tied', () => {
+    // Provider returned the wrong 9h28m sibling first.
+    const candidate: MatchCandidate = { path: '/audiobooks/Dogs of War', title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+    const ranked = rankResults([edition568, edition598], candidate, SCANNED);
+    expect(ranked[0]!.meta.duration).toBe(598);
+  });
+
+  it('does NOT flip a clearly better text-score winner (duration is only a tiebreaker)', () => {
+    // The 568 edition has the RIGHT title, the 598 edition a clearly worse one.
+    const strongText = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 568 });
+    const weakText = makeBook({ title: 'Cats of Peace', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 598 });
+    const candidate: MatchCandidate = { path: '/audiobooks/Dogs of War', title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+    const ranked = rankResults([strongText, weakText], candidate, SCANNED);
+    // Duration agrees with the weak-text candidate, but the score gap exceeds
+    // the 0.001 epsilon → the stronger text match stays first.
+    expect(ranked[0]!.meta.title).toBe('Dogs of War');
+  });
+
+  it('no scanned duration → order unchanged (comparator no-ops)', () => {
+    const candidate: MatchCandidate = { path: '/audiobooks/Dogs of War', title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+    const ranked = rankResults([edition568, edition598], candidate);
+    expect(ranked[0]!.meta.duration).toBe(568);
+  });
+
+  it('no candidate durations → order unchanged', () => {
+    const a = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }] });
+    const b = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }] });
+    const candidate: MatchCandidate = { path: '/audiobooks/Dogs of War', title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+    const ranked = rankResults([a, b], candidate, SCANNED);
+    expect(ranked[0]!.meta).toBe(a);
+  });
+
+  it('neither candidate agrees → order unchanged', () => {
+    const a = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 100 });
+    const b = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 200 });
+    const candidate: MatchCandidate = { path: '/audiobooks/Dogs of War', title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+    const ranked = rankResults([a, b], candidate, SCANNED);
+    expect(ranked[0]!.meta).toBe(a);
+  });
+
+  it('both candidates agree → stable (input order preserved)', () => {
+    const a = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 598 });
+    const b = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 599 });
+    const candidate: MatchCandidate = { path: '/audiobooks/Dogs of War', title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+    const ranked = rankResults([a, b], candidate, SCANNED);
+    expect(ranked[0]!.meta).toBe(a);
+  });
+
+  it('position tiebreaker runs BEFORE duration: position-matching candidate wins even if the other agrees on duration', () => {
+    // #1 has a disagreeing duration; #2 agrees. Position wanted=1 must still win.
+    const p1Disagree = makeBook({ title: 'Series', authors: [{ name: 'A' }], series: [{ name: 'Series', position: 1 }], duration: 568 });
+    const p2Agree = makeBook({ title: 'Series', authors: [{ name: 'A' }], series: [{ name: 'Series', position: 2 }], duration: 598 });
+    const candidate: MatchCandidate = { path: '/audiobooks/Series', title: 'Series', author: 'A', seriesPosition: 1 };
+    const ranked = rankResults([p2Agree, p1Disagree], candidate, SCANNED);
+    expect(pickPos(ranked[0]!.meta)).toBe(1);
+  });
+
+  it('position tie → duration decides, ahead of the year tiebreaker', () => {
+    // Both position 1; the year-wrong candidate agrees on duration → duration wins.
+    const yearWrongAgrees = makeBook({ title: 'S', authors: [{ name: 'A' }], series: [{ name: 'S', position: 1 }], publishedDate: '2008', duration: 598 });
+    const yearRightDisagrees = makeBook({ title: 'S', authors: [{ name: 'A' }], series: [{ name: 'S', position: 1 }], publishedDate: '2006', duration: 568 });
+    const candidate: MatchCandidate = { path: '/audiobooks/S (2006)', title: 'S', author: 'A', seriesPosition: 1 };
+    const ranked = rankResults([yearRightDisagrees, yearWrongAgrees], candidate, SCANNED);
+    expect(ranked[0]!.meta.duration).toBe(598);
+  });
+});
+
+describe('rankResultsCleaned duration tiebreaker', () => {
+  const edition568 = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 568 });
+  const edition598 = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 598 });
+  const SCANNED = 35_936;
+  const tagQuery = { title: 'Dogs of War', author: 'Adrian Tchaikovsky' };
+
+  it('promotes the duration-agreeing (9h58m) sibling when text scores are tied', () => {
+    const ranked = rankResultsCleaned([edition568, edition598], tagQuery, SCANNED);
+    expect(ranked[0]!.meta.duration).toBe(598);
+  });
+
+  it('does NOT flip a clearly better text-score winner', () => {
+    const strongText = makeBook({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 568 });
+    const weakText = makeBook({ title: 'Cats of Peace', authors: [{ name: 'Adrian Tchaikovsky' }], duration: 598 });
+    const ranked = rankResultsCleaned([strongText, weakText], tagQuery, SCANNED);
+    expect(ranked[0]!.meta.title).toBe('Dogs of War');
+  });
+
+  it('scannedSeconds omitted → order unchanged (backward-compatible callers)', () => {
+    const ranked = rankResultsCleaned([edition568, edition598], tagQuery);
+    expect(ranked[0]!.meta.duration).toBe(568);
+  });
+
+  it('zero scanned duration (tag path no-signal) → order unchanged', () => {
+    const ranked = rankResultsCleaned([edition568, edition598], tagQuery, 0);
+    expect(ranked[0]!.meta.duration).toBe(568);
+  });
+
+  it('position tiebreaker runs BEFORE duration', () => {
+    const p1Disagree = makeBook({ title: 'Series', authors: [{ name: 'A' }], series: [{ name: 'Series', position: 1 }], duration: 568 });
+    const p2Agree = makeBook({ title: 'Series', authors: [{ name: 'A' }], series: [{ name: 'Series', position: 2 }], duration: 598 });
+    const ranked = rankResultsCleaned([p2Agree, p1Disagree], { title: 'Series', author: 'A', seriesPosition: 1 }, SCANNED);
+    expect(pickPos(ranked[0]!.meta)).toBe(1);
+  });
+
+  it('position tie → duration decides, ahead of the year tiebreaker', () => {
+    const yearWrongAgrees = makeBook({ title: 'S', authors: [{ name: 'A' }], series: [{ name: 'S', position: 1 }], publishedDate: '2008', duration: 598 });
+    const yearRightDisagrees = makeBook({ title: 'S', authors: [{ name: 'A' }], series: [{ name: 'S', position: 1 }], publishedDate: '2006', duration: 568 });
+    const ranked = rankResultsCleaned([yearRightDisagrees, yearWrongAgrees], { title: 'S', author: 'A', year: '2006', seriesPosition: 1 }, SCANNED);
+    expect(ranked[0]!.meta.duration).toBe(598);
   });
 });
 

--- a/src/server/services/match-job.helpers.ts
+++ b/src/server/services/match-job.helpers.ts
@@ -144,8 +144,11 @@ export function isDurationVerified(
 }
 
 /**
- * Determines confidence from duration data without overriding the similarity-ranked winner.
- * The bestMatch stays as the top similarity-ranked result; duration only affects confidence level.
+ * Determines confidence from duration data; it does NOT itself pick or reorder
+ * the winner. The bestMatch is whatever the ranker returned as `scored[0]` —
+ * primarily the top text-scored result, with duration only ever breaking a
+ * score tie between sibling editions upstream (#1882, `durationTiebreak`); this
+ * verdict then reads `high`/`medium` off that chosen top candidate.
  * The high-vs-medium decision is delegated to `isDurationVerified` so the single
  * absolute band lives in exactly one place (#1266/#1850). `scannedSeconds` is the
  * unrounded scanner runtime in SECONDS; the mismatch reason renders it from
@@ -374,6 +377,39 @@ export function positionTiebreak(a: BookMetadata, b: BookMetadata, wanted: numbe
 }
 
 /**
+ * Shared duration-agreement tiebreaker (#1882), consumed by BOTH `rankResults`
+ * (folder pass) and `rankResultsCleaned` (tag pass). On a score tie between
+ * sibling editions of one book (identical title/author/narrators, different
+ * runtimes — e.g. the four Audible editions of "Dogs of War"), prefer the
+ * candidate whose provider runtime agrees with the scanned duration.
+ *
+ * It is a TIEBREAKER, never a ranker: it runs only inside the existing
+ * `< 0.001` score-tie branch, AFTER `positionTiebreak` (position disambiguates
+ * different BOOKS in a series; duration disambiguates EDITIONS of one book) and
+ * BEFORE the year tiebreaker.
+ *
+ * The whole duration/units decision is delegated to `isDurationVerified` →
+ * `withinDurationTolerance` — no new predicate, no new tolerance constant, no
+ * re-derived minutes→seconds conversion (the DRY mandate that keeps the tiebreak
+ * judging with the same ruler as the post-match verdict, so pick and verdict
+ * cannot disagree). Four-state contract, all falling out of the two booleans:
+ *  - Invalid `scannedSeconds` (undefined/0/negative) → `isDurationVerified` is
+ *    false on both sides → `0` (whole comparator no-ops; absent scan cannot
+ *    decide, the #1850 "absent must not demote" doctrine).
+ *  - Valid scan: a VERIFIED candidate beats a NON-VERIFIED one. "Non-verified"
+ *    folds together missing/zero AND present-but-off candidate duration —
+ *    `isDurationVerified` returns false for all of them.
+ *  - verified vs verified → `0` (both agree, nothing to decide).
+ *  - non-verified vs non-verified → `0` (absence/disagreement never demotes one
+ *    non-match below another).
+ */
+export function durationTiebreak(a: BookMetadata, b: BookMetadata, scannedSeconds: number | undefined): number {
+  const aMatch = isDurationVerified(a, scannedSeconds) ? 1 : 0;
+  const bMatch = isDurationVerified(b, scannedSeconds) ? 1 : 0;
+  return bMatch - aMatch;
+}
+
+/**
  * Tag-pass scoring: composes the result-side title from `result.title` +
  * the canonical primary-series ref via `tagTitleScore`, removing the
  * cleanName-derived symmetry assumption from #984. Author side is preserved exactly from #995 —
@@ -384,15 +420,20 @@ export function positionTiebreak(a: BookMetadata, b: BookMetadata, wanted: numbe
  * `src/core/utils/similarity.ts:62-84`; we re-derive the combined score
  * inline because we no longer call `scoreResult` for the title side.
  *
- * Tiebreakers (score tie within 0.001): the shared `positionTiebreak` (#1849)
- * runs first — series position is the stronger series-disambiguation signal —
- * then the year tiebreaker (#995): candidates whose publishedDate year matches
- * tagYear rank first. Both are tag-derived only; folder year is NOT consulted
- * here (Pass 2's signal stays out of Pass 1).
+ * Tiebreakers (score tie within 0.001), in precedence order: the shared
+ * `positionTiebreak` (#1849) runs first — series position is the stronger
+ * series-disambiguation signal — then `durationTiebreak` (#1882) prefers the
+ * sibling edition whose runtime agrees with the scanned duration, then the year
+ * tiebreaker (#995): candidates whose publishedDate year matches tagYear rank
+ * first. Position/year are tag-derived only; folder year is NOT consulted here
+ * (Pass 2's signal stays out of Pass 1). `scannedSeconds` is the unrounded
+ * scanner runtime in SECONDS; it is optional so direct/backward-compatible
+ * callers (unit tests) may omit it — the comparator no-ops on an absent scan.
  */
 export function rankResultsCleaned(
   detailed: BookMetadata[],
   tagQuery: TagQuery,
+  scannedSeconds?: number,
 ): { meta: BookMetadata; score: number }[] {
   const normalizedAuthor = normalizeNarrator(tagQuery.author);
   const scored = detailed.map(meta => {
@@ -418,6 +459,10 @@ export function rankResultsCleaned(
       // position is absent it no-ops and year decides exactly as before.
       const posCmp = positionTiebreak(a.meta, b.meta, tagQuery.seriesPosition);
       if (posCmp !== 0) return posCmp;
+      // Edition disambiguation (#1882): after position, prefer the sibling whose
+      // runtime agrees with the scan; no-ops on an absent/zero scan.
+      const durCmp = durationTiebreak(a.meta, b.meta, scannedSeconds);
+      if (durCmp !== 0) return durCmp;
       if (tagYear) {
         const aYear = parsePublishedYear(a.meta.publishedDate);
         const bYear = parsePublishedYear(b.meta.publishedDate);
@@ -431,10 +476,17 @@ export function rankResultsCleaned(
   return scored;
 }
 
-/** Scores and ranks results by title+author similarity with year tiebreaker. */
+/**
+ * Scores and ranks results by title+author similarity. On a score tie the
+ * precedence is `positionTiebreak` (#1849) → `durationTiebreak` (#1882) →
+ * folder-year. `scannedSeconds` is the unrounded scanner runtime in SECONDS and
+ * is optional: the folder scan can be absent, so an undefined value no-ops the
+ * duration comparator (direct unit-test callers may omit it too).
+ */
 export function rankResults(
   detailed: BookMetadata[],
   book: MatchCandidate,
+  scannedSeconds?: number,
 ): { meta: BookMetadata; score: number }[] {
   const context = { title: book.title, ...(book.author !== undefined && { author: book.author }) };
   const scored = detailed.map(meta => ({
@@ -452,6 +504,10 @@ export function rankResults(
       // no-ops when the wanted position is absent so year decides as before.
       const posCmp = positionTiebreak(a.meta, b.meta, book.seriesPosition);
       if (posCmp !== 0) return posCmp;
+      // Edition disambiguation (#1882): after position, prefer the sibling whose
+      // runtime agrees with the scan; no-ops on an absent/zero scan.
+      const durCmp = durationTiebreak(a.meta, b.meta, scannedSeconds);
+      if (durCmp !== 0) return durCmp;
       if (folderYear) {
         const aYear = parsePublishedYear(a.meta.publishedDate);
         const bYear = parsePublishedYear(b.meta.publishedDate);

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -1736,6 +1736,40 @@ describe('MatchJobService', () => {
     });
   });
 
+  // #1882 — folder/Pass-2 duration-agreement tiebreaker end-to-end: the scanned
+  // seconds must reach `rankResults(detailed, context, audioResult?.totalDuration)`
+  // and select the sibling edition whose runtime agrees. This fails if the
+  // production call omits the scanned seconds (the direct rankResults test can't
+  // catch a caller that never supplies them).
+  describe('duration tiebreaker (folder pass, #1882)', () => {
+    it('Dogs of War — selects the 9h58m sibling and verifies high on a same-title edition tie', async () => {
+      // Scanned 35,936s. 598min (9h58m) = 35,880s, Δ56s ≤ 240 → verified;
+      // 568min (9h28m) = 34,080s, Δ1,856s → not verified. Provider ordered the
+      // wrong 9h28m sibling first.
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 35_936, files: [] });
+      const candidate: MatchCandidate = {
+        path: '/audiobooks/Dogs of War',
+        title: 'Dogs of War',
+        author: 'Adrian Tchaikovsky',
+      };
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], providerId: 'p1' }),
+        makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], providerId: 'p2' }),
+      ]);
+      (metadataService.getBook as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ asin: 'B0FFH568', duration: 568 })
+        .mockResolvedValueOnce({ asin: 'B0BT2T598', duration: 598 });
+
+      const id = service.createJob([candidate]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0];
+      expect(result!.bestMatch!.asin).toBe('B0BT2T598');
+      expect(result!.bestMatch!.duration).toBe(598);
+      expect(result!.confidence).toBe('high');
+    });
+  });
+
   describe('structured search params', () => {
     it('sends structured title and author via options when parsed data available', async () => {
       (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
@@ -2493,6 +2527,32 @@ describe('MatchJobService', () => {
         const result = service.getJob(id)!.results[0];
         expect(result!.bestMatch?.asin).toBe('B1');
         expect(pickPrimarySeries(result!.bestMatch!)?.position).toBe(1);
+      });
+
+      // #1882 — the scanned seconds must survive the `runTagSearch → tryAttempt`
+      // hop and reach rankResultsCleaned on the REAL tag path, so a same-title
+      // edition tie resolves to the runtime-agreeing sibling. This is the tag
+      // twin of the folder regression above — the direct rankResultsCleaned test
+      // bypasses the threading these two hops perform.
+      it('threads totalDuration through runTagSearch → tryAttempt so the edition tiebreaker picks the 9h58m sibling', async () => {
+        // Scanned 35,936s → 598min sibling verifies; 568min does not. Provider
+        // ordered the wrong 9h28m sibling first. Both carry a full asin so
+        // fetchDetails passes them through with their duration.
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeTaggedScan('Dogs of War', 'Adrian Tchaikovsky', 35_936),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], asin: 'B0FFH568', duration: 568 }),
+          makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], asin: 'B0BT2T598', duration: 598 }),
+        ]);
+
+        const id = service.createJob([taggedCandidate]);
+        await waitForJob(service, id);
+
+        const result = service.getJob(id)!.results[0];
+        expect(result!.bestMatch?.asin).toBe('B0BT2T598');
+        expect(result!.bestMatch?.duration).toBe(598);
+        expect(result!.confidence).toBe('high');
       });
 
       it('does NOT fall through to Pass 2 when tag-derived match is accepted', async () => {

--- a/src/server/services/match-job.service.ts
+++ b/src/server/services/match-job.service.ts
@@ -254,8 +254,10 @@ class MatchJob {
         // Fetch full detail for all results to get ASIN/duration
         const detailed = await this.fetchDetails(trace.results);
 
-        // Score, re-rank, and apply year tiebreaker
-        const scored = rankResults(detailed, context);
+        // Score, re-rank, and apply the position → duration → year tiebreakers.
+        // The scanned seconds (#1882) disambiguate sibling editions on a score
+        // tie; the folder scan can be absent, so this is genuinely optional.
+        const scored = rankResults(detailed, context, audioResult?.totalDuration);
         const topScored = scored[0];
         if (!topScored) {
           // §6.1 — fetchDetails breaks on cancellation, so detailed (and thus
@@ -296,7 +298,9 @@ class MatchJob {
           resolved = { path: book.path, bestMatch: topScored.meta, alternatives: [], ...resolveSingleResultConfidence(topScored.meta, audioResult?.totalDuration) };
           capCtx = { log: this.log, matchSource: 'filename-single', durationVerified: isDurationVerified(topScored.meta, audioResult?.totalDuration) };
         } else {
-          // Multiple results — use duration to determine confidence (not to override winner).
+          // Multiple results — the winner was already chosen by `rankResults`
+          // (text score, with duration only breaking a score tie, #1882); this
+          // step reads confidence off that top candidate's runtime agreement.
           // Unrounded seconds (#1850); `duration` (minutes) below is logging only.
           const { confidence, reason } = resolveConfidenceFromDuration(scored, audioResult?.totalDuration);
           this.log.debug(
@@ -404,7 +408,10 @@ class MatchJob {
 
     const attempts = planTagSearchAttempts(audioResult, tagQuery);
     for (const attempt of attempts) {
-      const outcome = await this.tryAttempt(book, tagQuery, attempt);
+      // Thread the scanned seconds (#1882) so the edition tiebreaker reaches
+      // `rankResultsCleaned`. The tag path always owns a non-null scan, so this
+      // is `0` (no signal → no-op) rather than absent when the scan found none.
+      const outcome = await this.tryAttempt(book, tagQuery, attempt, audioResult.totalDuration);
       if (outcome) return outcome;
     }
     this.log.debug(
@@ -443,6 +450,7 @@ class MatchJob {
     book: MatchCandidate,
     tagQuery: TagQuery,
     attempt: TagSearchAttempt,
+    scannedSeconds: number,
   ): Promise<TagSearchOutcome | null> {
     let candidates: BookMetadata[];
     try {
@@ -470,7 +478,8 @@ class MatchJob {
     // TagQuery from `attempt`, so without this the position never reaches
     // `rankResultsCleaned` on the real tag path. `!== undefined` so position 0 survives.
     const attemptQuery: TagQuery = { title: attempt.title, author: attempt.author, ...(tagQuery.year ? { year: tagQuery.year } : {}), ...(tagQuery.seriesPosition !== undefined && { seriesPosition: tagQuery.seriesPosition }) };
-    const scored = rankResultsCleaned(detailed, attemptQuery);
+    // Thread scanned seconds (#1882) so the edition tiebreaker sees the runtime.
+    const scored = rankResultsCleaned(detailed, attemptQuery, scannedSeconds);
     const top = scored[0];
     if (!top) return null;
 

--- a/src/server/utils/download-state.test.ts
+++ b/src/server/utils/download-state.test.ts
@@ -99,7 +99,7 @@ describe('display-status query conditions', () => {
   });
 });
 
-// #1857 F16 — the QG-eligibility rule ("completed display + non-null externalId")
+// #1857 F16 — the QG-eligibility rule ("completed display + non-empty externalId")
 // is a safety-critical decision shared by the QG batch query and the replace
 // blocker classification. This named consistency test pins the in-memory twin so
 // it cannot drift from the intended set the SQL condition selects.
@@ -107,7 +107,7 @@ describe('isQualityGateEligibleRow (QG-eligibility twin, #1857 F16)', () => {
   const row = (clientStatus: ClientStatus, pipelineStage: PipelineStage, externalId: string | null) =>
     ({ clientStatus, pipelineStage, externalId });
 
-  it('is eligible ONLY for a tracked (externalId != null) completed-display row', () => {
+  it('is eligible ONLY for a tracked (non-empty externalId) completed-display row', () => {
     expect(isQualityGateEligibleRow(row('completed', 'idle', 'ext-1'))).toBe(true);
   });
 

--- a/src/shared/hardcover-list-types.ts
+++ b/src/shared/hardcover-list-types.ts
@@ -1,0 +1,14 @@
+// Single source of truth for the Hardcover list-type discriminant, shared by the
+// provider config/state (core) and the settings + form Zod enums (shared), so the
+// contracts cannot drift when a variant is added (#1879 DRY-1). Mirrors the
+// IMPORT_LIST_TYPES → importListTypeSchema pattern in import-list-registry.ts.
+export const HARDCOVER_LIST_TYPES = ['trending', 'shelf', 'custom'] as const;
+export type HardcoverListType = typeof HARDCOVER_LIST_TYPES[number];
+
+// Single source of truth for the custom-list "Import Max" closed set, shared by
+// the settings Zod schema (built via z.literal on this tuple), the shared
+// settings type, and the provider config/state — so the four contracts cannot
+// drift (#1879 DRY-1, mirrors HARDCOVER_LIST_TYPES). `50`/`100` = a fixed limit;
+// `'all'` = bounded pagination.
+export const HARDCOVER_IMPORT_MAX_VALUES = [50, 100, 'all'] as const;
+export type HardcoverImportMax = typeof HARDCOVER_IMPORT_MAX_VALUES[number];

--- a/src/shared/hardcover-list-url.test.ts
+++ b/src/shared/hardcover-list-url.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parseHardcoverListUrl } from './hardcover-list-url.js';
+
+describe('parseHardcoverListUrl (#1879 AC2)', () => {
+  const expected = { username: 'LisaRae', slug: '2025-year-in-books' };
+
+  describe('valid forms', () => {
+    it('parses the canonical https URL', () => {
+      expect(parseHardcoverListUrl('https://hardcover.app/@LisaRae/lists/2025-year-in-books')).toEqual(expected);
+    });
+
+    it('parses a trailing-slash URL', () => {
+      expect(parseHardcoverListUrl('https://hardcover.app/@LisaRae/lists/2025-year-in-books/')).toEqual(expected);
+    });
+
+    it('parses an http:// URL', () => {
+      expect(parseHardcoverListUrl('http://hardcover.app/@LisaRae/lists/2025-year-in-books')).toEqual(expected);
+    });
+
+    it('parses a bare-host URL (no scheme)', () => {
+      expect(parseHardcoverListUrl('hardcover.app/@LisaRae/lists/2025-year-in-books')).toEqual(expected);
+    });
+
+    it('tolerates a missing @ on the username', () => {
+      expect(parseHardcoverListUrl('https://hardcover.app/LisaRae/lists/2025-year-in-books')).toEqual(expected);
+    });
+
+    it('tolerates a www. host and a trailing query/hash', () => {
+      expect(parseHardcoverListUrl('https://www.hardcover.app/@LisaRae/lists/2025-year-in-books?ref=x')).toEqual(expected);
+      expect(parseHardcoverListUrl('https://hardcover.app/@LisaRae/lists/2025-year-in-books#top')).toEqual(expected);
+    });
+
+    it('trims surrounding whitespace before parsing', () => {
+      expect(parseHardcoverListUrl('  https://hardcover.app/@LisaRae/lists/2025-year-in-books  ')).toEqual(expected);
+    });
+  });
+
+  describe('invalid forms → null', () => {
+    it('rejects a non-Hardcover host', () => {
+      expect(parseHardcoverListUrl('https://goodreads.com/@LisaRae/lists/2025-year-in-books')).toBeNull();
+    });
+
+    it('rejects a profile URL without /lists/', () => {
+      expect(parseHardcoverListUrl('https://hardcover.app/@LisaRae')).toBeNull();
+    });
+
+    it('rejects a list URL missing the slug', () => {
+      expect(parseHardcoverListUrl('https://hardcover.app/@LisaRae/lists/')).toBeNull();
+      expect(parseHardcoverListUrl('https://hardcover.app/@LisaRae/lists')).toBeNull();
+    });
+
+    it('rejects a bare slug', () => {
+      expect(parseHardcoverListUrl('2025-year-in-books')).toBeNull();
+    });
+
+    it('rejects empty and whitespace-only input', () => {
+      expect(parseHardcoverListUrl('')).toBeNull();
+      expect(parseHardcoverListUrl('   ')).toBeNull();
+    });
+  });
+});

--- a/src/shared/hardcover-list-url.ts
+++ b/src/shared/hardcover-list-url.ts
@@ -1,0 +1,21 @@
+// Pure parser for Hardcover public-list URLs — the single source of truth for
+// URL validity + extraction, shared by BOTH the client settings UI (inline
+// validation, #1879 AC13), the shared Zod schema (`hardcoverSettingsSchema`),
+// and the core provider (`fetchCustomList`). It lives in `src/shared/**` because
+// `eslint.config.js` forbids every production import from `src/shared/**` into
+// `src/core/**`; a shared leaf is importable by client, shared, and core alike.
+//
+// Canonical form: `https://hardcover.app/@{username}/lists/{slug}`. We accept
+// `http`/`https` (or a bare host), an optional `www.`, an optional trailing
+// slash, a trailing query/hash, and tolerate the leading `@` on the username.
+
+const HARDCOVER_LIST_URL_RE =
+  /^(?:https?:\/\/)?(?:www\.)?hardcover\.app\/@?([^/@?#]+)\/lists\/([^/?#]+)\/?(?:[?#].*)?$/i;
+
+export function parseHardcoverListUrl(input: string): { username: string; slug: string } | null {
+  const match = HARDCOVER_LIST_URL_RE.exec(input.trim());
+  if (!match) return null;
+  const [, username, slug] = match;
+  if (!username || !slug) return null;
+  return { username, slug };
+}

--- a/src/shared/schemas/import-list.test.ts
+++ b/src/shared/schemas/import-list.test.ts
@@ -222,6 +222,104 @@ describe('hardcoverSettingsSchema — numeric shelfId (#732)', () => {
   });
 });
 
+// #1879 — Hardcover custom list (listType 'custom' + listUrl + importMax)
+describe('hardcoverSettingsSchema — custom list (#1879)', () => {
+  const CUSTOM_URL = 'https://hardcover.app/@LisaRae/lists/2025-year-in-books';
+
+  describe('custom validation & importMax default (AC10)', () => {
+    it('rejects custom without listUrl', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ['listUrl'] }));
+      }
+    });
+
+    it('rejects an unparseable listUrl for custom', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: 'https://example.com/nope' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ['listUrl'], message: 'Not a Hardcover list URL' }));
+      }
+    });
+
+    it('rejects a whitespace-only listUrl (zod-trim-min-one)', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: '   ' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a valid custom listUrl and defaults importMax to 50 when omitted', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: 50 });
+      }
+    });
+
+    it("accepts importMax: 'all'", () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: 'all' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.importMax).toBe('all');
+    });
+  });
+
+  describe('importMax strict union — no coercion (F39)', () => {
+    it.each([50, 100])('accepts numeric %s', (value) => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: value });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.importMax).toBe(value);
+    });
+
+    it.each([75, 0, '50'])('rejects %s', (value) => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: value });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('type-scoped strip (F26, F35)', () => {
+    it('strips stale listUrl/importMax from a trending payload', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'trending', listUrl: CUSTOM_URL, importMax: 100, shelfId: 5 });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toEqual({ apiKey: 'k', listType: 'trending' });
+    });
+
+    it('strips stale listUrl/importMax from a shelf payload but preserves shelfId', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'shelf', shelfId: 7, listUrl: CUSTOM_URL, importMax: 100 });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toEqual({ apiKey: 'k', listType: 'shelf', shelfId: 7 });
+    });
+
+    it('strips a stale shelfId from a custom payload', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, shelfId: 7 });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ apiKey: 'k', listType: 'custom', listUrl: CUSTOM_URL, importMax: 50 });
+        expect(result.data).not.toHaveProperty('shelfId');
+      }
+    });
+
+    it('does not leak the custom importMax default into a plain trending parse', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', listType: 'trending' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).not.toHaveProperty('importMax');
+    });
+  });
+
+  describe('omitted-listType compatibility (F37)', () => {
+    it('an apiKey-only payload still parses (as trending-scoped, no listType key)', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toEqual({ apiKey: 'k' });
+    });
+
+    it('an omitted-listType payload with stale shelfId/listUrl/importMax parses with all three stripped', () => {
+      const result = hardcoverSettingsSchema.safeParse({ apiKey: 'k', shelfId: 5, listUrl: CUSTOM_URL, importMax: 'all' });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data).toEqual({ apiKey: 'k' });
+    });
+  });
+});
+
 describe('updateImportListSchema — type required when settings present', () => {
   it('accepts update with settings + type', () => {
     const result = updateImportListSchema.safeParse({

--- a/src/shared/schemas/import-list.ts
+++ b/src/shared/schemas/import-list.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import { IMPORT_LIST_REGISTRY, IMPORT_LIST_TYPES, type ImportListType } from '../import-list-registry';
+import { parseHardcoverListUrl } from '../hardcover-list-url.js';
+import { HARDCOVER_LIST_TYPES, HARDCOVER_IMPORT_MAX_VALUES, type HardcoverListType, type HardcoverImportMax } from '../hardcover-list-types.js';
 
 // ============================================================================
 // Import List schemas
@@ -14,20 +16,58 @@ export const nytSettingsSchema = z.object({
   list: z.string().trim().optional(),
 }).strict();
 
+// #1879 — strict Import Max (custom lists), built from the shared canonical set
+// so schema + types cannot drift (#1879 F6). A multi-literal, NOT a coercion:
+// `75`/`0`/`'50'` are rejected outright.
+const hardcoverImportMaxSchema = z.literal(HARDCOVER_IMPORT_MAX_VALUES);
+
+// Type-scoped parsed Hardcover settings. Every branch keeps `apiKey` plus only
+// the effective list type's own keys; the `.transform` below strips any stale
+// foreign key the input carried (#1879 AC10). `listType` stays optional — an
+// omitted value is treated exactly as `trending` (factory default `registry.ts`).
+export type HardcoverSettings = {
+  apiKey: string;
+  listType?: HardcoverListType;
+  shelfId?: number;
+  listUrl?: string;
+  importMax?: HardcoverImportMax;
+};
+
 export const hardcoverSettingsSchema = z.object({
   apiKey: z.string().trim().min(1),
-  listType: z.enum(['trending', 'shelf']).optional(),
+  listType: z.enum(HARDCOVER_LIST_TYPES).optional(),
   shelfId: z.coerce.number().int().positive().optional(),
+  // Free user text (#1879 AC2) — `.trim().min(1)` rejects spaces-only before URL parsing.
+  listUrl: z.string().trim().min(1).optional(),
+  importMax: hardcoverImportMaxSchema.optional(),
 }).strict().superRefine((data, ctx) => {
   if (data.listType === 'shelf' && data.shelfId === undefined) {
     ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['shelfId'], message: 'Shelf ID is required when list type is "shelf"' });
   }
+  if (data.listType === 'custom') {
+    if (data.listUrl === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['listUrl'], message: 'List URL is required when list type is "custom"' });
+    } else if (parseHardcoverListUrl(data.listUrl) === null) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ['listUrl'], message: 'Not a Hardcover list URL' });
+    }
+  }
+}).transform((data): HardcoverSettings => {
+  // Runs only on a clean parse (Zod skips the transform when superRefine added
+  // an issue), so the `!` assertions below are guaranteed present. Output is
+  // type-scoped: only the effective list type's own keys survive.
+  if (data.listType === 'custom') {
+    return { apiKey: data.apiKey, listType: 'custom', listUrl: data.listUrl!, importMax: data.importMax ?? 50 };
+  }
+  if (data.listType === 'shelf') {
+    return { apiKey: data.apiKey, listType: 'shelf', ...(data.shelfId !== undefined && { shelfId: data.shelfId }) };
+  }
+  // trending OR omitted listType — strip shelfId/listUrl/importMax.
+  return { apiKey: data.apiKey, ...(data.listType !== undefined && { listType: data.listType }) };
 });
 
 // ── Settings types and dispatch map ─────────────────────────────────────────
 
 export type NytSettings = z.infer<typeof nytSettingsSchema>;
-export type HardcoverSettings = z.infer<typeof hardcoverSettingsSchema>;
 
 export type ImportListSettingsMap = {
   nyt: NytSettings;
@@ -104,7 +144,9 @@ export const createImportListFormSchema = z.object({
     list: z.string().optional(),
     // Hardcover
     shelfId: z.number().int().positive().optional(),
-    listType: z.enum(['trending', 'shelf']).optional(),
+    listType: z.enum(HARDCOVER_LIST_TYPES).optional(),
+    listUrl: z.string().optional(),
+    importMax: hardcoverImportMaxSchema.optional(),
   }),
 }).superRefine((data, ctx) => {
   const meta = IMPORT_LIST_REGISTRY[data.type];


### PR DESCRIPTION
Three pipeline-merged changes since v0.9.7:

- #1882 Match ranking: duration-agreement tiebreaker for sibling editions
- #1879 Import lists: Hardcover custom list by URL (listType 'custom' + List URL + Import Max)
- #1865 Align blocker docs/test titles to the non-empty externalId invariant

Will be tagged v0.9.8.