### PR TITLE
Release: develop -> main (music-metadata 11.14.0 bump)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "fastify": "^5.8.5",
     "fastify-plugin": "^5.1.0",
     "fastify-type-provider-zod": "^6.1.0",
-    "music-metadata": "^11.13.0",
+    "music-metadata": "^11.14.0",
     "nodemailer": "^9.0.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^6.1.0
         version: 6.1.0(@fastify/swagger@9.7.0)(fastify@5.8.5)(openapi-types@12.1.3)(zod@4.4.1)
       music-metadata:
-        specifier: ^11.13.0
-        version: 11.13.0
+        specifier: ^11.14.0
+        version: 11.14.0
       nodemailer:
         specifier: ^9.0.1
         version: 9.0.1
@@ -2445,8 +2445,8 @@ packages:
       typescript:
         optional: true
 
-  music-metadata@11.13.0:
-    resolution: {integrity: sha512-uXRaov9dfjSpQufXIU7sMxVZnh+FilCQv2mXn+K5EJ/decP3dTWrgvPYa5r6MtRbieNSCE708Da4J0u1UGfQIw==}
+  music-metadata@11.14.0:
+    resolution: {integrity: sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==}
     engines: {node: '>=18'}
 
   mute-stream@3.0.0:
@@ -5323,7 +5323,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  music-metadata@11.13.0:
+  music-metadata@11.14.0:
     dependencies:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0


### PR DESCRIPTION
One change since v0.9.8:

- Bump music-metadata 11.13.0 -> 11.14.0: the upstream v1-tkhd fix (Borewit/music-metadata#2657, our issue #2672) restores native MP4 duration/codec/chapter-track parsing for multi-track version-1 m4bs. Validated against the live library: all 19 ffprobe-fallback-class books now parse with music-metadata matching ffprobe to the decimal; 716 other MP4-family files unchanged, zero regressions.

Will be tagged v0.9.9.