### PR TITLE
Release: develop -> main (v0.9.12)

### DIFF
--- a/src/client/components/held-review/toConfirmItem.test.ts
+++ b/src/client/components/held-review/toConfirmItem.test.ts
@@ -45,3 +45,39 @@ describe('toConfirmItem forceImport derivation', () => {
     expect(item.forceImport).toBe(true);
   });
 });
+
+// #1927 AC5 — two-state, pair-locked series mapping. A non-empty edited series emits
+// seriesName (original, untrimmed) + its paired seriesPosition; empty/whitespace omits
+// BOTH (defer). An untouched seeded row carries the provider primary (item-first no-op).
+describe('toConfirmItem series mapping', () => {
+  it('user-set series → payload carries seriesName + paired seriesPosition', () => {
+    const item = toConfirmItem(row({ edited: { title: 'Book', author: 'Author', series: 'The Dresden Files', seriesPosition: 10 } }), false);
+    expect(item.seriesName).toBe('The Dresden Files');
+    expect(item.seriesPosition).toBe(10);
+  });
+
+  it('user-set series with no position → seriesName present, seriesPosition omitted (pair-lock)', () => {
+    const item = toConfirmItem(row({ edited: { title: 'Book', author: 'Author', series: 'Custom Saga' } }), false);
+    expect(item.seriesName).toBe('Custom Saga');
+    expect(item).not.toHaveProperty('seriesPosition');
+  });
+
+  it('empty edited.series → BOTH seriesName and seriesPosition omitted (defer)', () => {
+    const item = toConfirmItem(row({ edited: { title: 'Book', author: 'Author', series: '', seriesPosition: 15 } }), false);
+    expect(item).not.toHaveProperty('seriesName');
+    expect(item).not.toHaveProperty('seriesPosition');
+  });
+
+  it('whitespace-only edited.series → BOTH omitted (defer, non-React-caller parity)', () => {
+    const item = toConfirmItem(row({ edited: { title: 'Book', author: 'Author', series: '   ', seriesPosition: 15 } }), false);
+    expect(item).not.toHaveProperty('seriesName');
+    expect(item).not.toHaveProperty('seriesPosition');
+  });
+
+  it('untouched seeded row (edited.series = provider primary) → seriesName carries that value verbatim (AC4 item-first no-op)', () => {
+    // The padded value proves trim classifies but does NOT rewrite — the original string ships.
+    const item = toConfirmItem(row({ edited: { title: 'Book', author: 'Author', series: ' Provider Saga ', seriesPosition: 2 } }), false);
+    expect(item.seriesName).toBe(' Provider Saga ');
+    expect(item.seriesPosition).toBe(2);
+  });
+});

--- a/src/client/components/held-review/toConfirmItem.test.ts
+++ b/src/client/components/held-review/toConfirmItem.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { toConfirmItem } from './toConfirmItem.js';
+import type { ImportRow } from '@/components/manual-import';
+import type { DiscoveredBook } from '@/lib/api';
+
+function book(overrides: Partial<DiscoveredBook> = {}): DiscoveredBook {
+  return {
+    path: '/audiobooks/Author/Book',
+    parsedTitle: 'Book',
+    parsedAuthor: 'Author',
+    parsedSeries: null,
+    fileCount: 3,
+    totalSize: 100000,
+    isDuplicate: false,
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<ImportRow> = {}): ImportRow {
+  return {
+    book: book(),
+    selected: true,
+    userEdited: false,
+    edited: { title: 'Book', author: 'Author', series: '' },
+    ...overrides,
+  };
+}
+
+describe('toConfirmItem forceImport derivation', () => {
+  // #1925: a former within-scan row is a NORMAL candidate (isDuplicate: false). With
+  // force=false it must submit WITHOUT forceImport so `classifyConfirmItem` runs the
+  // confirm-time recording ladder instead of the row bypassing it.
+  it('isDuplicate=false + force=false → no forceImport (former within-scan row flows through the ladder)', () => {
+    const item = toConfirmItem(row({ book: book({ isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' }) }), false);
+    expect(item).not.toHaveProperty('forceImport');
+  });
+
+  it('force=true → forceImport true (held-review re-confirm still bypasses the safety net)', () => {
+    const item = toConfirmItem(row({ book: book({ isDuplicate: false }) }), true);
+    expect(item.forceImport).toBe(true);
+  });
+
+  it('isDuplicate=true (a DB duplicate) + force=false → forceImport true (manual-import trust boundary unchanged)', () => {
+    const item = toConfirmItem(row({ book: book({ isDuplicate: true, duplicateReason: 'slug' }) }), false);
+    expect(item.forceImport).toBe(true);
+  });
+});

--- a/src/client/components/held-review/toConfirmItem.ts
+++ b/src/client/components/held-review/toConfirmItem.ts
@@ -7,13 +7,20 @@ import type { ImportRow } from '@/components/manual-import';
  * used both for user-selected duplicates and for re-confirming a held-review item.
  */
 export function toConfirmItem(r: ImportRow, force: boolean): ImportConfirmItem {
+  // Two-state, pair-locked series mapping (#1927 AC5): classify by trim, but emit
+  // the ORIGINAL (untrimmed) series value. A non-empty edited series emits
+  // `seriesName` plus its paired `seriesPosition`; an empty/whitespace-only series
+  // OMITS BOTH so the server defers to the matched metadata's primary (narrator
+  // parity). Position never ships without a series. This mirrors the authoritative
+  // server-side resolver — here it is an early UX safeguard for a clean wire payload.
+  const seriesPresent = r.edited.series.trim().length > 0;
   return {
     path: r.book.path,
     title: r.edited.title,
     ...(r.edited.author && { authorName: r.edited.author }),
-    ...(r.edited.series && { seriesName: r.edited.series }),
+    ...(seriesPresent && { seriesName: r.edited.series }),
     ...(r.edited.narrators?.length && { narrators: r.edited.narrators }),
-    ...(r.edited.seriesPosition !== undefined && { seriesPosition: r.edited.seriesPosition }),
+    ...(seriesPresent && r.edited.seriesPosition !== undefined && { seriesPosition: r.edited.seriesPosition }),
     ...(r.edited.coverUrl !== undefined && { coverUrl: r.edited.coverUrl }),
     ...(r.edited.asin !== undefined && { asin: r.edited.asin }),
     ...(r.edited.metadata !== undefined && { metadata: r.edited.metadata }),

--- a/src/client/components/manual-import/BookEditModal.test.tsx
+++ b/src/client/components/manual-import/BookEditModal.test.tsx
@@ -185,6 +185,59 @@ describe('BookEditModal', () => {
     });
   });
 
+  // #1927 Defect 2 — the Series Position field must not trap a stale value. Emptying
+  // the Series input CLEARS the position value in the UI (not merely disables it), and
+  // handleSave keeps series/position paired (position omitted when series is empty).
+  describe('series position field (#1927 Defect 2)', () => {
+    it('clearing the Series input clears the Series Position value (not just disables it)', async () => {
+      renderModal({ initial: makeEditState({ series: 'Series Name', seriesPosition: 15 }) });
+      const positionInput = screen.getByLabelText('Series Position') as HTMLInputElement;
+      expect(positionInput.value).toBe('15');
+
+      await userEvent.clear(screen.getByLabelText('Series'));
+      await waitFor(() => {
+        expect(positionInput.value).toBe('');
+      });
+      expect(positionInput).toBeDisabled();
+    });
+
+    it('reopening after a cleared save shows a blank, disabled position (no stale value)', () => {
+      renderModal({ initial: makeEditState({ series: '' }) });
+      const positionInput = screen.getByLabelText('Series Position') as HTMLInputElement;
+      expect(positionInput.value).toBe('');
+      expect(positionInput).toBeDisabled();
+    });
+
+    it('handleSave omits seriesPosition when the series is cleared', async () => {
+      const onSave = vi.fn();
+      renderModal({ onSave, initial: makeEditState({ series: 'Series Name', seriesPosition: 15 }) });
+
+      await userEvent.clear(screen.getByLabelText('Series'));
+      await userEvent.click(screen.getByText('Save'));
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalled();
+      });
+      const saved = onSave.mock.calls[0]![0];
+      expect(saved.series).toBe('');
+      expect(saved).not.toHaveProperty('seriesPosition');
+    });
+
+    it('handleSave includes the edited series and position when both are set', async () => {
+      const onSave = vi.fn();
+      renderModal({ onSave, initial: makeEditState({ series: '' }) });
+
+      await userEvent.type(screen.getByLabelText('Series'), 'The Dresden Files');
+      await userEvent.type(screen.getByLabelText('Series Position'), '10');
+      await userEvent.click(screen.getByText('Save'));
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalled();
+      });
+      const saved = onSave.mock.calls[0]![0];
+      expect(saved.series).toBe('The Dresden Files');
+      expect(saved.seriesPosition).toBe(10);
+    });
+  });
+
   describe('save behavior', () => {
     it('calls onSave with current field values', async () => {
       const onSave = vi.fn();

--- a/src/client/components/manual-import/BookEditModal.tsx
+++ b/src/client/components/manual-import/BookEditModal.tsx
@@ -200,7 +200,14 @@ export function BookEditModal({ book, initial, confidence, alternatives, onSave,
                   id="edit-series"
                   type="text"
                   value={series}
-                  onChange={(e) => setSeries(e.target.value)}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    setSeries(next);
+                    // Position without a series is meaningless (#1927 Defect 2): emptying
+                    // the series CLEARS the position value in the UI rather than leaving a
+                    // stale grayed-out number trapped in the disabled field.
+                    if (!next.trim()) setSeriesPosition('');
+                  }}
                   className="w-full px-3 py-2 glass-card rounded-xl text-sm focus-ring"
                 />
               </div>

--- a/src/client/components/manual-import/ImportCard.test.tsx
+++ b/src/client/components/manual-import/ImportCard.test.tsx
@@ -665,41 +665,44 @@ describe('ImportCard — relativePath prop (#133)', () => {
     expect(screen.getByText('audiobooks/Author/Book')).toBeInTheDocument();
   });
 
-  describe('within-scan duplicates (#342)', () => {
-    it('within-scan duplicate shows Duplicate in scan badge instead of Already owned', () => {
+  describe('former within-scan rows (#1925)', () => {
+    // A within-scan title collision is no longer hard-flagged: it arrives as a normal
+    // candidate (isDuplicate=false) carrying a display-only review hint.
+    const WITHIN_SCAN_HINT = 'Possible duplicate folder in this scan';
+
+    it('renders the review-reason indicator and no "Duplicate in scan" badge', () => {
       const row = makeRow({
-        book: makeBook({ isDuplicate: true, duplicateReason: 'within-scan' as 'path' | 'slug' }),
+        book: makeBook({ isDuplicate: false, reviewReason: WITHIN_SCAN_HINT }),
       });
       render(<ImportCard row={row} onToggle={vi.fn()} onEdit={vi.fn()} lockDuplicates />);
-      expect(screen.getByText('Duplicate in scan')).toBeInTheDocument();
-      expect(screen.queryByText('Already owned')).not.toBeInTheDocument();
+      expect(screen.queryByText('Duplicate in scan')).not.toBeInTheDocument();
+      const indicator = screen.getByTestId('review-reason-indicator');
+      expect(indicator).toBeInTheDocument();
+      expect(indicator).toHaveAttribute('title', WITHIN_SCAN_HINT);
     });
 
-    // #1895 F9 — within-scan precedence: paused does NOT re-badge a result-less within-scan
-    // row (it never reaches ConfidenceBadge), so it keeps "Duplicate in scan", not "Paused".
-    it('paused=true: a result-less within-scan duplicate keeps "Duplicate in scan" (not "Paused")', () => {
+    // #1925: a former within-scan row is a normal candidate, so a result-less paused run
+    // renders the ordinary "Paused" badge (it no longer has a special within-scan badge).
+    it('paused=true: a result-less former within-scan row shows the normal "Paused" badge', () => {
       const row = makeRow({
-        book: makeBook({ isDuplicate: true, duplicateReason: 'within-scan' as 'path' | 'slug' }),
+        book: makeBook({ isDuplicate: false, reviewReason: WITHIN_SCAN_HINT }),
       });
       render(<ImportCard row={row} onToggle={vi.fn()} onEdit={vi.fn()} lockDuplicates paused />);
-      expect(screen.getByText('Duplicate in scan')).toBeInTheDocument();
-      expect(screen.queryByText('Paused')).not.toBeInTheDocument();
-      expect(screen.queryByText('Matching')).not.toBeInTheDocument();
+      expect(screen.getByText('Paused')).toBeInTheDocument();
+      expect(screen.queryByText('Duplicate in scan')).not.toBeInTheDocument();
     });
 
-    it('within-scan duplicate has checkbox shown (selectable) when lockDuplicates is true', () => {
-      const onToggle = vi.fn();
+    it('has a visible checkbox (selectable) even when lockDuplicates is true', () => {
       const row = makeRow({
-        book: makeBook({ isDuplicate: true, duplicateReason: 'within-scan' as 'path' | 'slug' }),
+        book: makeBook({ isDuplicate: false, reviewReason: WITHIN_SCAN_HINT }),
       });
-      render(<ImportCard row={row} onToggle={onToggle} onEdit={vi.fn()} lockDuplicates />);
-      const selectBtn = screen.getByRole('button', { name: /select|deselect/i });
-      expect(selectBtn).toBeInTheDocument();
+      render(<ImportCard row={row} onToggle={vi.fn()} onEdit={vi.fn()} lockDuplicates />);
+      expect(screen.getByRole('button', { name: /select|deselect/i })).toBeInTheDocument();
     });
 
-    it('within-scan duplicate has edit button shown when lockDuplicates is true', () => {
+    it('has an edit button shown even when lockDuplicates is true', () => {
       const row = makeRow({
-        book: makeBook({ isDuplicate: true, duplicateReason: 'within-scan' as 'path' | 'slug' }),
+        book: makeBook({ isDuplicate: false, reviewReason: WITHIN_SCAN_HINT }),
       });
       render(<ImportCard row={row} onToggle={vi.fn()} onEdit={vi.fn()} lockDuplicates />);
       expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();

--- a/src/client/components/manual-import/ImportCard.test.tsx
+++ b/src/client/components/manual-import/ImportCard.test.tsx
@@ -155,33 +155,51 @@ describe('ImportCard', () => {
     });
   });
 
-  // T1 — the matched series + #position on the review row, so same-titled series
-  // entries (Fablehaven) are distinguishable at a glance. Sourced from the RESOLVED
-  // match metadata, never from the folder-parsed edited.series.
+  // #1927 AC6 — the row reads series/#position EDITED-FIRST, then falls back to the
+  // matched metadata's primary series (mirroring displayNarrator, #1660). The row
+  // always shows the EFFECTIVE value that will be imported, so row/modal/server agree.
   describe('series / #position display', () => {
-    it('shows the matched series name and #position from edited.metadata', () => {
+    it('renders the EDITED series/#position when a non-empty edited series differs from metadata (#1927 AC6)', () => {
       render(<ImportCard
         {...defaultProps}
         row={makeRow({
           matchResult: makeMatchResult(),
-          edited: { title: 'Book Title', author: 'Author Name', series: 'Series Name', metadata: { title: 'Book Title', authors: [{ name: 'Author Name' }], seriesPrimary: { name: 'Children of Time', position: 3 } } },
+          // User edited the series to a value that differs from the matched metadata primary — the
+          // row must show the EDITED value (what imports item-first), not the metadata primary.
+          edited: { title: 'Book Title', author: 'Author Name', series: 'The Dresden Files', seriesPosition: 10, metadata: { title: 'Book Title', authors: [{ name: 'Author Name' }], seriesPrimary: { name: 'Children of Time', position: 3 } } },
+        })}
+      />);
+      expect(screen.getByText('The Dresden Files #10')).toBeInTheDocument();
+      expect(screen.queryByText('Children of Time #3')).not.toBeInTheDocument();
+    });
+
+    it('renders an untouched matched row from its metadata-seeded edited series (#1927 AC4 no-op)', () => {
+      // buildEditedFromBestMatch seeds edited.series from the metadata primary, so an untouched
+      // matched row's edited series already equals the primary — the row shows that value.
+      render(<ImportCard
+        {...defaultProps}
+        row={makeRow({
+          matchResult: makeMatchResult(),
+          edited: { title: 'Book Title', author: 'Author Name', series: 'Children of Time', seriesPosition: 3, metadata: { title: 'Book Title', authors: [{ name: 'Author Name' }], seriesPrimary: { name: 'Children of Time', position: 3 } } },
         })}
       />);
       expect(screen.getByText('Children of Time #3')).toBeInTheDocument();
     });
 
-    it('sources from matched metadata, NOT the folder-parsed edited.series (unmatched row shows no series line)', () => {
+    it('CLEARED matched row (edited.series === "") falls back to the metadata primary — the deferred value that imports, NOT blank (#1927 AC6)', () => {
       render(<ImportCard
         {...defaultProps}
         row={makeRow({
-          // No metadata → no match yet. edited.series carries the folder guess, which must NOT render here.
-          edited: { title: 'Book Title', author: 'Author Name', series: 'Only In Edited Not Metadata' },
+          matchResult: makeMatchResult(),
+          // Series cleared in the modal → edited.series is empty. The row shows the metadata
+          // primary (what the server imports on the defer path), identical to cleared-narrators.
+          edited: { title: 'Book Title', author: 'Author Name', series: '', metadata: { title: 'Book Title', authors: [{ name: 'Author Name' }], seriesPrimary: { name: 'Children of Time', position: 3 } } },
         })}
       />);
-      expect(screen.queryByText('Only In Edited Not Metadata')).not.toBeInTheDocument();
+      expect(screen.getByText('Children of Time #3')).toBeInTheDocument();
     });
 
-    it('shows the series name alone when the matched series has no position', () => {
+    it('cleared row shows the metadata series name alone when the primary has no position', () => {
       render(<ImportCard
         {...defaultProps}
         row={makeRow({
@@ -192,7 +210,26 @@ describe('ImportCard', () => {
       expect(screen.getByText('Standalone Saga')).toBeInTheDocument();
     });
 
-    it('renders a series position of 0 as #0 (not swallowed — #1028 guard)', () => {
+    it('renders a padded edited series name VERBATIM (no trim) so the row matches the mapper/DB record (#1927 AC5/AC6/F12)', () => {
+      const paddedName = ' Padded Saga ';
+      render(<ImportCard
+        {...defaultProps}
+        row={makeRow({
+          matchResult: makeMatchResult(),
+          // Padded edited series with a DIFFERENT metadata primary — the row must render the item's
+          // ORIGINAL padded value (edited.series is trimmed only to classify present-vs-absent, never
+          // rewritten), matching what toConfirmItem ships and the DB stores. A `.trim()` in the render
+          // path would drop the surrounding whitespace and re-introduce row/server disagreement.
+          edited: { title: 'Book Title', author: 'Author Name', series: paddedName, seriesPosition: 5, metadata: { title: 'Book Title', authors: [{ name: 'Author Name' }], seriesPrimary: { name: 'Different Primary', position: 9 } } },
+        })}
+      />);
+      // getByText normalizes for the lookup; textContent is the raw, un-normalized render.
+      const seriesLine = screen.getByText(/Padded Saga/);
+      expect(seriesLine.textContent).toBe(`${paddedName} #5`);
+      expect(screen.queryByText('Different Primary #9')).not.toBeInTheDocument();
+    });
+
+    it('renders a series position of 0 as #0 on the defer path (not swallowed — #1028 guard)', () => {
       render(<ImportCard
         {...defaultProps}
         row={makeRow({

--- a/src/client/components/manual-import/ImportCard.tsx
+++ b/src/client/components/manual-import/ImportCard.tsx
@@ -26,7 +26,7 @@ interface ImportCardProps {
    * When true (paused match run, #1895), a genuinely-new pending row renders the static
    * `Paused` badge instead of the spinning `Matching` one. Defaults to false so the
    * non-paused path — and Manual Import — stay byte-identical. Does NOT affect the
-   * within-scan `Duplicate in scan` branch, which precedes the confidence badge.
+   * ownership badge, which precedes the confidence badge.
    */
   paused?: boolean | undefined;
 }
@@ -118,12 +118,10 @@ export function ImportCard({ row, onToggle, onEdit, lockDuplicates, relativePath
   const shortPath = relativePath ?? pathParts.slice(-3).join('/') ?? row.book.path;
 
   // When lockDuplicates=true: path-duplicates are fully locked; slug-duplicates show edit but no checkbox.
-  // Within-scan duplicates are always selectable/editable (they're not in the DB yet).
-  const isWithinScanDuplicate = isDuplicate && row.book.duplicateReason === 'within-scan';
   const isPathDuplicate = lockDuplicates && isDuplicate && row.book.duplicateReason === 'path';
   const isSlugDuplicate = lockDuplicates && isDuplicate && row.book.duplicateReason === 'slug';
   const showCheckbox = !isPathDuplicate && !isSlugDuplicate;
-  const showEditButton = !isDuplicate || isSlugDuplicate || isWithinScanDuplicate;
+  const showEditButton = !isDuplicate || isSlugDuplicate;
   const ownership = ownershipBadge(row.book);
 
   // Left border: amber for no-match, matches LibraryPage's status border pattern
@@ -188,11 +186,9 @@ export function ImportCard({ row, onToggle, onEdit, lockDuplicates, relativePath
       </div>
 
       {/* Badge: three-way recording-review ladder (#1712) for owned/new-version/review,
-          "Duplicate in scan" for within-scan, confidence badge for a genuinely new book. */}
+          confidence badge for a genuinely new book. */}
       <div className="w-32 shrink-0 flex justify-center">
-        {isWithinScanDuplicate ? (
-          <Badge variant="muted">Duplicate in scan</Badge>
-        ) : ownership ? (
+        {ownership ? (
           <Badge variant={ownership.variant}>{ownership.label}</Badge>
         ) : (
           <ConfidenceBadge confidence={confidence} reason={row.matchResult?.reason} paused={paused} />

--- a/src/client/components/manual-import/ImportCard.tsx
+++ b/src/client/components/manual-import/ImportCard.tsx
@@ -107,12 +107,15 @@ export function ImportCard({ row, onToggle, onEdit, lockDuplicates, relativePath
   const displayNarrator = row.edited.narrators?.length
     ? row.edited.narrators.join(', ')
     : row.edited.metadata?.narrators?.join(', ');
-  // Matched series/#position — from the RESOLVED match metadata (auto-match bestMatch or a user
-  // Fix-Match pick), NOT edited.series (which is folder-parsed at scan time and would show the
-  // parsed series before any match). Only present once matched, so an unmatched row shows nothing
-  // here; the parsed series still shows in the left path. Disambiguates same-titled series entries
-  // (e.g. Fablehaven) at a glance.
-  const matchedSeries = pickPrimarySeries(row.edited.metadata);
+  // Series/#position — edited-first, then metadata fallback (#1927 AC6), mirroring
+  // `displayNarrator` (#1660) and the item-first server resolver so the row shows the
+  // EFFECTIVE value that will be imported. A non-empty edited series (user edit, or the
+  // provider primary seeded onto an untouched matched row) wins and renders verbatim; a
+  // cleared/absent edited series defers to the matched metadata's primary series — the
+  // deferred value the server imports. `edited.series` is trimmed only to classify.
+  const matchedSeries = row.edited.series?.trim()
+    ? { name: row.edited.series, position: row.edited.seriesPosition }
+    : pickPrimarySeries(row.edited.metadata);
   // Show pre-computed relative path if provided, otherwise last 3 path segments
   const pathParts = row.book.path.split(/[\\/]/).filter(Boolean);
   const shortPath = relativePath ?? pathParts.slice(-3).join('/') ?? row.book.path;

--- a/src/client/components/manual-import/mergeMatchIntoRow.test.ts
+++ b/src/client/components/manual-import/mergeMatchIntoRow.test.ts
@@ -48,6 +48,16 @@ describe('mergeMatchIntoRow', () => {
     expect(mergeMatchIntoRow(makeRow({ userEdited: true, selected: true }), makeMatch({ confidence: 'none', bestMatch: null })).selected).toBe(true);
   });
 
+  it('threads scannedSeconds + reasonKind through onto row.matchResult (#1929)', () => {
+    const merged = mergeMatchIntoRow(
+      makeRow(),
+      makeMatch({ confidence: 'medium', reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m', reasonKind: 'duration-mismatch', scannedSeconds: 53580 }),
+    );
+    expect(merged.matchResult?.scannedSeconds).toBe(53580);
+    expect(merged.matchResult?.reasonKind).toBe('duration-mismatch');
+    expect(merged.matchResult?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+  });
+
   it('auto-populates edited fields only when the row has no prior metadata', () => {
     const fresh = mergeMatchIntoRow(makeRow(), makeMatch({ confidence: 'high' }));
     expect(fresh.edited.title).toBe('Official');

--- a/src/client/components/manual-import/mergeMatchIntoRow.test.ts
+++ b/src/client/components/manual-import/mergeMatchIntoRow.test.ts
@@ -78,6 +78,26 @@ describe('mergeMatchIntoRow', () => {
     expect(merged.selected).toBe(true);
   });
 
+  it('a late match does NOT clobber a userEdited row\'s explicit series/position edit (#1927 AC8)', () => {
+    // The user edited Series to `The Dresden Files #10` BEFORE the (long-running) match arrived.
+    // The late bestMatch carries a DIFFERENT primary series; the userEdited guard must leave the
+    // user's series/position untouched so the edit is not silently discarded by the race.
+    const userEdited = makeRow({
+      userEdited: true,
+      selected: true,
+      edited: { title: 'Book Title', author: 'Author Name', series: 'The Dresden Files', seriesPosition: 10 },
+    });
+    const merged = mergeMatchIntoRow(
+      userEdited,
+      makeMatch({ confidence: 'high', bestMatch: { title: 'Book Title', authors: [{ name: 'Author Name' }], seriesPrimary: { name: 'Wax and Wayne', position: 1 } } }),
+    );
+    expect(merged.edited.series).toBe('The Dresden Files');
+    expect(merged.edited.seriesPosition).toBe(10);
+    expect(merged.edited.metadata).toBeUndefined();
+    expect(merged.matchResult?.confidence).toBe('high');
+    expect(merged.selected).toBe(true);
+  });
+
   it('post-match duplicate deselects a selected high-confidence row and flags row.book (#1662 F8)', () => {
     const result = mergeMatchIntoRow(
       makeRow({ selected: true }),

--- a/src/client/hooks/useMatchJob.test.ts
+++ b/src/client/hooks/useMatchJob.test.ts
@@ -574,6 +574,36 @@ describe('useMatchJob', () => {
     expect(result.current.recovering).toBe(true);
   });
 
+  // #1929 — a restart re-issues a fresh job; the server recomputes scannedSeconds +
+  // reasonKind (they are derived, not persisted). Those fields must survive the
+  // MatchEngine ingest of the restart-produced status unchanged.
+  it('restart-produced result carrying scannedSeconds/reasonKind survives MatchEngine ingest (#1929)', async () => {
+    const enriched: MatchResult = {
+      path: '/b',
+      confidence: 'medium',
+      bestMatch: null,
+      alternatives: [],
+      reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+      reasonKind: 'duration-mismatch',
+      scannedSeconds: 53580,
+    };
+    mockStartMatchJob.mockResolvedValueOnce({ jobId: 'job-1' }).mockResolvedValueOnce({ jobId: 'job-2' });
+    mockGetMatchJob
+      .mockResolvedValueOnce(completed('job-1', [R('/a')]))
+      .mockResolvedValue(completed('job-2', [enriched]));
+    const { result } = renderHook(() => useMatchJob());
+
+    await act(async () => { result.current.startMatching([{ path: '/a', title: 'A' }]); });
+    await advance(POLL);
+    await act(async () => { result.current.restart([{ path: '/b', title: 'B' }]); });
+    await advance(POLL);
+
+    const merged = result.current.results.find(r => r.path === '/b');
+    expect(merged?.scannedSeconds).toBe(53580);
+    expect(merged?.reasonKind).toBe('duration-mismatch');
+    expect(merged?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+  });
+
   // #1864 F1 — automatic recovery activates the fail-closed `recovering` gate.
   describe('recovering gate during automatic recovery (F1)', () => {
     it('is false during a healthy initial poll (keeps the selective-CTA #1102 behavior)', async () => {

--- a/src/client/lib/api/library-scan.ts
+++ b/src/client/lib/api/library-scan.ts
@@ -4,6 +4,7 @@ import type { BookMetadata } from './books.js';
 export type { DiscoveredBook, DuplicateReason, ImportMode, HeldReviewItem } from '../../../shared/schemas/library-scan.js';
 import type { DiscoveredBook, DuplicateReason } from '../../../shared/schemas/library-scan.js';
 import type { RecordingVerdict } from '../../../shared/schemas/recording-verdict.js';
+import type { MatchReasonKind } from '../../../shared/match-reason-kind.js';
 
 export interface ImportConfirmItem {
   path: string;
@@ -48,6 +49,21 @@ export interface MatchResult {
   alternatives: BookMetadata[];
   error?: string;
   reason?: string;
+  /**
+   * Structured discriminator for the duration-confidence Review reason (#1929).
+   * Mirrors the server `MatchResult`. Paired with `reason` (never parsed from it);
+   * `upgradeMatchConfidence` branches on it to decide whether an explicit re-pick
+   * re-evaluates the duration evidence (`duration-mismatch`/`missing-duration`) or
+   * clears to high as today (`no-duration-data` / `undefined` legacy).
+   */
+  reasonKind?: MatchReasonKind;
+  /**
+   * Raw unrounded scanner runtime in SECONDS (#1929). Mirrors the server
+   * `MatchResult`. Threaded onto every result the scanner gave a positive runtime,
+   * so `upgradeMatchConfidence` can re-check a picked edition's `duration * 60`
+   * against it on a medium re-pick. Absent when the scan found no positive runtime.
+   */
+  scannedSeconds?: number;
   /**
    * Post-match library-duplicate flags (#1662). Mirrors the server `MatchResult`.
    * `mergeMatchIntoRow` propagates these onto `row.book` so the existing

--- a/src/client/lib/upgrade-match-confidence.test.ts
+++ b/src/client/lib/upgrade-match-confidence.test.ts
@@ -17,6 +17,9 @@ const baseMetadata = (overrides?: Partial<BookMetadata>): BookMetadata => ({
   ...overrides,
 });
 
+// The real UAT case: 14h53m of files (Δ300s vs a 14h58m edition, out of band). #1929.
+const SCANNED_14H53M = 53580; // 14h 53m in seconds
+
 describe('upgradeMatchConfidence', () => {
   describe('none → medium', () => {
     it('upgrades confidence from none to medium when newMetadata is provided', () => {
@@ -114,6 +117,329 @@ describe('upgradeMatchConfidence', () => {
       const result = upgradeMatchConfidence(matchResult, undefined, baseMetadata());
 
       expect(result).toBe(matchResult);
+    });
+  });
+
+  // #1929 — a medium row whose Review is duration EVIDENCE (duration-mismatch /
+  // missing-duration) must re-check the picked edition against the scanned runtime
+  // on an explicit re-pick, never blanket-clear to green.
+  describe('medium re-pick — duration re-evaluation (#1929)', () => {
+    it('duration-mismatch → re-pick to an in-band edition clears to high, drops reason+reasonKind, preserves scannedSeconds', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      // A DIFFERENT edition that fits: 894min (14h54m) → Δ60s, inside the 240s band.
+      const newMetadata = baseMetadata({ duration: 894 });
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('high');
+      expect(result?.reason).toBeUndefined();
+      expect(result?.reasonKind).toBeUndefined();
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
+    });
+
+    it('duration-mismatch → re-pick still out of band stays medium with the reason re-rendered against the PICKED edition', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 20h 0m', // original row's numbers
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      // Re-pick to 898min (14h58m) → Δ300s, still out of band.
+      const newMetadata = baseMetadata({ duration: 898 });
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('duration-mismatch');
+      // Re-rendered against the PICKED edition's numbers, not the original row's.
+      expect(result?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
+    });
+
+    it('missing-duration → re-pick to a duration-less edition stays medium with the best-match-missing string', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Best match missing duration — cannot verify',
+        reasonKind: 'missing-duration',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const newMetadata = baseMetadata({ duration: undefined });
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('missing-duration');
+      expect(result?.reason).toBe('Best match missing duration — cannot verify');
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
+    });
+
+    // F2 — a picked edition duration of ZERO (not undefined) is a non-positive runtime
+    // and must classify as cannot-verify, NOT a mismatch against 0h 0m. Pins the
+    // `pickedMinutes <= 0` half of the precedence-2 guard (dropping it would render a
+    // false "Duration mismatch — scanned 14h 53m vs expected 0h 0m").
+    it('missing-duration → re-pick to an edition whose duration is 0 stays medium with the best-match-missing string', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Best match missing duration — cannot verify',
+        reasonKind: 'missing-duration',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const newMetadata = baseMetadata({ duration: 0 }); // zero, not undefined
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('missing-duration');
+      expect(result?.reason).toBe('Best match missing duration — cannot verify');
+      expect(result?.reason).not.toContain('0h 0m');
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
+    });
+
+    it('missing-duration → re-pick to an in-band edition clears to high', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Best match missing duration — cannot verify',
+        reasonKind: 'missing-duration',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const newMetadata = baseMetadata({ duration: 894 }); // 14h54m → Δ60s, in band
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('high');
+      expect(result?.reason).toBeUndefined();
+      expect(result?.reasonKind).toBeUndefined();
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
+    });
+
+    // F8 — the distinct missing-duration → duration-mismatch transition: a positive,
+    // out-of-band picked edition flips the kind and re-renders against its numbers.
+    it('missing-duration → re-pick to a positive out-of-band edition flips to duration-mismatch with re-rendered reason', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Best match missing duration — cannot verify',
+        reasonKind: 'missing-duration',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const newMetadata = baseMetadata({ duration: 898 }); // 14h58m → Δ300s, out of band
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('duration-mismatch');
+      expect(result?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
+    });
+
+    // F3 (defensive) — scanned runtime missing on an evidence-bearing row: blaming
+    // the best match would be false, so the SCAN side gets the truthful string.
+    it('duration-mismatch but scannedSeconds absent, picked HAS a duration → stays medium with the scanned-missing string', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+        reasonKind: 'duration-mismatch',
+        // scannedSeconds intentionally absent (missing/corrupt transport)
+      });
+      const newMetadata = baseMetadata({ duration: 898 }); // positive duration
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('missing-duration');
+      expect(result?.reason).toBe('Scanned duration unavailable — cannot verify');
+    });
+
+    it('duration-mismatch with scannedSeconds === 0 also routes to the scanned-missing string', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 0h 0m vs expected 14h 58m',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: 0,
+      });
+      const newMetadata = baseMetadata({ duration: 898 });
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('missing-duration');
+      expect(result?.reason).toBe('Scanned duration unavailable — cannot verify');
+    });
+
+    // F3 — when BOTH runtimes are missing, scanner-first precedence (precedence 1
+    // before 2) must select the scanner-side message. If the two guards were reversed
+    // the row would blame the best match instead of the unavailable scan; the other
+    // cases (scanner-missing+picked-present, picked-missing+scanner-present) can't
+    // distinguish the order, so this both-absent case is the one that pins it.
+    it('duration-mismatch with BOTH scannedSeconds and picked duration missing → scanner-side string (scanner-first precedence)', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+        reasonKind: 'duration-mismatch',
+        // scannedSeconds absent (missing/corrupt transport)
+      });
+      const newMetadata = baseMetadata({ duration: undefined }); // picked runtime also absent
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('missing-duration');
+      // Scanner-side message, NOT the best-match-missing string — scanner is checked first.
+      expect(result?.reason).toBe('Scanned duration unavailable — cannot verify');
+    });
+
+    // Boundary — the shared band is inclusive at 240s (#1850).
+    it('Δ exactly 240s is within the band → high', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned x vs expected y',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: 3600, // 60m
+      });
+      const newMetadata = baseMetadata({ duration: 64 }); // 64m → 3840s, Δ240s
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('high');
+    });
+
+    it('Δ 241s is outside the band → stays Review', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned x vs expected y',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: 3599, // Δ241s vs 3840s
+      });
+      const newMetadata = baseMetadata({ duration: 64 }); // 64m → 3840s
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reasonKind).toBe('duration-mismatch');
+    });
+
+    // Units guard — a missing `* 60` on the picked edition would compare 893 vs 53580
+    // (a giant gap → medium); the correct minutes→seconds conversion lands in-band → high.
+    it('applies the minutes→seconds conversion on the picked edition (893min in-band, not 60× too loose)', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 20h 0m',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: 53580, // 14h53m — exactly 893min in seconds
+      });
+      const newMetadata = baseMetadata({ duration: 893 }); // 893min → 53580s, Δ0
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('high');
+    });
+  });
+
+  describe('medium re-pick — ambiguity/legacy classes clear to high (#1929)', () => {
+    it('no-duration-data → explicit re-pick clears to high and removes BOTH reason and reasonKind', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Multiple results — no duration data to disambiguate',
+        reasonKind: 'no-duration-data',
+        // scannedSeconds absent (no scanned runtime) — the ambiguity class.
+      });
+      const newMetadata = baseMetadata();
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('high');
+      expect(result?.reason).toBeUndefined();
+      expect('reasonKind' in (result ?? {})).toBe(false);
+    });
+
+    it('undefined reasonKind (attempt-cap / narrator-cap / legacy medium) → explicit re-pick clears to high, preserving scannedSeconds', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Low confidence match. Please verify.',
+        scannedSeconds: 3600,
+      });
+      const newMetadata = baseMetadata({ duration: 700 }); // would be out of band, but no reasonKind → not re-evaluated
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result?.confidence).toBe('high');
+      expect(result?.reason).toBeUndefined();
+      expect(result?.reasonKind).toBeUndefined();
+      expect(result?.scannedSeconds).toBe(3600);
+    });
+  });
+
+  describe('scope + no-op contract (#1929)', () => {
+    // F1 — high (already-Matched) rows are out of scope: an explicit re-pick never
+    // demotes, in-band or out.
+    it('high row + explicit re-pick (out of band) stays high, unchanged', () => {
+      const matchResult = baseMatchResult({ confidence: 'high', scannedSeconds: 3600 });
+      const newMetadata = baseMetadata({ duration: 700 }); // 42000s — wildly out of band
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result).toBe(matchResult);
+    });
+
+    it('high row + explicit re-pick (in band) stays high, unchanged', () => {
+      const matchResult = baseMatchResult({ confidence: 'high', scannedSeconds: 3600 });
+      const newMetadata = baseMetadata({ duration: 60 }); // in band, still no change
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, baseMetadata());
+
+      expect(result).toBe(matchResult);
+    });
+
+    it('by-reference no-op on a duration-mismatch row keeps confidence, reason and reasonKind', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const shared = baseMetadata({ duration: 60 });
+
+      const result = upgradeMatchConfidence(matchResult, shared, shared);
+
+      expect(result).toBe(matchResult);
+      expect(result?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+      expect(result?.reasonKind).toBe('duration-mismatch');
+    });
+
+    it('by-reference no-op on a missing-duration row keeps confidence, reason and reasonKind', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'medium',
+        reason: 'Best match missing duration — cannot verify',
+        reasonKind: 'missing-duration',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const shared = baseMetadata();
+
+      const result = upgradeMatchConfidence(matchResult, shared, shared);
+
+      expect(result).toBe(matchResult);
+      expect(result?.reasonKind).toBe('missing-duration');
+    });
+
+    it('none → medium still upgrades and preserves reason + reasonKind', () => {
+      const matchResult = baseMatchResult({
+        confidence: 'none',
+        reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+        reasonKind: 'duration-mismatch',
+        scannedSeconds: SCANNED_14H53M,
+      });
+      const newMetadata = baseMetadata({ duration: 894 });
+
+      const result = upgradeMatchConfidence(matchResult, newMetadata, undefined);
+
+      expect(result?.confidence).toBe('medium');
+      expect(result?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+      expect(result?.reasonKind).toBe('duration-mismatch');
+      expect(result?.scannedSeconds).toBe(SCANNED_14H53M);
     });
   });
 });

--- a/src/client/lib/upgrade-match-confidence.ts
+++ b/src/client/lib/upgrade-match-confidence.ts
@@ -1,18 +1,38 @@
 import type { MatchResult } from './api/library-scan.js';
 import type { BookMetadata } from './api/books.js';
+import { withinDurationTolerance } from '../../shared/duration-tolerance.js';
+import { formatDurationSeconds } from '../../shared/format-duration.js';
 
 /**
  * Upgrade a row's match confidence when the user selects provider metadata in the import editor.
  *
  * none → medium: user provided metadata on an unmatched row (no reference check — a fresh
- *   selection on an unmatched row always signals intent).
- * medium → high: user re-selected on a review row. Keyed on reference identity, not deep
- *   equality — the pre-populated bestMatch is passed back by-reference when the user saves
- *   without touching the picker, and that must NOT upgrade to high. The modal spreads into
- *   a fresh object on explicit re-selection, which is what triggers the upgrade.
+ *   selection on an unmatched row always signals intent). `reason`/`reasonKind` are left
+ *   untouched.
  *
- * `reason` is cleared only on medium → high (user has overridden the suggested match);
- * none → medium leaves `reason` untouched.
+ * medium → (re-evaluate): user re-selected on a Review row. Keyed on reference identity, NOT
+ *   deep equality — the pre-populated `bestMatch` is passed back by-reference when the user
+ *   saves without touching the picker, and that must NOT upgrade (#1929, the by-reference
+ *   no-op contract). The modal spreads into a fresh object on explicit re-selection, which is
+ *   what fires this branch. What happens next depends on the Review's evidence class:
+ *
+ *   - `duration-mismatch` / `missing-duration` (#1929): re-evaluate the DURATION evidence
+ *     against the newly picked edition instead of blanket-clearing — re-picking the same
+ *     edition on a file-vs-edition duration disagreement resolves nothing, so a false green
+ *     would read as "the system validated this version" when it only means "you touched the
+ *     picker". Precedence: (1) scanned runtime missing → stay Review, truthful
+ *     "Scanned duration unavailable" cannot-verify; (2) picked edition has no runtime → stay
+ *     Review, "Best match missing duration" cannot-verify; (3) picked `duration * 60` within
+ *     the shared band of `scannedSeconds` → clear to high (legitimate, incl. a DIFFERENT
+ *     edition that fits); (4) out of band → stay Review with the reason re-rendered against
+ *     the PICKED edition's numbers.
+ *   - `no-duration-data` / `undefined` (attempt-cap, narrator-cap, legacy medium): pure
+ *     match-identity ambiguity — an explicit re-pick legitimately resolves it, so clear to
+ *     high and drop BOTH `reason` and `reasonKind` (no stale discriminator survives onto a
+ *     high result).
+ *
+ * `scannedSeconds` is a file property, never stripped on any outcome. `high` rows are out of
+ * scope: an explicit re-pick on an already-Matched row stays `high`, unchanged (#1929).
  */
 export function upgradeMatchConfidence(
   matchResult: MatchResult | undefined,
@@ -24,8 +44,50 @@ export function upgradeMatchConfidence(
     return { ...matchResult, confidence: 'medium' };
   }
   if (matchResult.confidence === 'medium' && newMetadata !== currentEditedMetadata) {
-    const { reason: _reason, ...rest } = matchResult;
-    return { ...rest, confidence: 'high' };
+    if (matchResult.reasonKind === 'duration-mismatch' || matchResult.reasonKind === 'missing-duration') {
+      return reevaluateDurationRepick(matchResult, newMetadata);
+    }
+    // `no-duration-data` / undefined legacy: explicit re-pick clears the ambiguity.
+    return clearToHigh(matchResult);
   }
   return matchResult;
+}
+
+/** Clear a medium Review row to high, dropping BOTH `reason` and `reasonKind` (#1929 F4 —
+ *  no stale discriminator survives onto a high result) while preserving `scannedSeconds`. */
+function clearToHigh(matchResult: MatchResult): MatchResult {
+  const { reason: _reason, reasonKind: _reasonKind, ...rest } = matchResult;
+  return { ...rest, confidence: 'high' };
+}
+
+/**
+ * Re-evaluate the duration evidence of a `duration-mismatch`/`missing-duration` Review row
+ * against the freshly picked edition. The MINUTES→SECONDS `* 60` on the picked edition's
+ * `duration` is mandatory (learning `book-duration-minutes-vs-quality-seconds`: a raw-minutes
+ * argument makes the band 60× too loose). Reuses the shared band + formatter — no new band.
+ */
+function reevaluateDurationRepick(matchResult: MatchResult, picked: BookMetadata): MatchResult {
+  const scanned = matchResult.scannedSeconds;
+  const pickedMinutes = picked.duration;
+  // (1) Scanner runtime missing/non-positive → cannot verify. Defensive: the server only
+  // emits these reasonKinds when scannedSeconds > 0, so reaching here implies missing/corrupt
+  // transport — blaming the best match would be false, the SCAN side is what's missing.
+  if (scanned == null || scanned <= 0) {
+    return { ...matchResult, confidence: 'medium', reason: 'Scanned duration unavailable — cannot verify', reasonKind: 'missing-duration' };
+  }
+  // (2) Picked edition has no positive runtime → cannot verify (the existing best-match string).
+  if (pickedMinutes == null || pickedMinutes <= 0) {
+    return { ...matchResult, confidence: 'medium', reason: 'Best match missing duration — cannot verify', reasonKind: 'missing-duration' };
+  }
+  // (3) Within the shared band → clear to high (legitimate, incl. a different edition that fits).
+  if (withinDurationTolerance(pickedMinutes * 60, scanned)) {
+    return clearToHigh(matchResult);
+  }
+  // (4) Out of band → stay Review, reason re-rendered against the PICKED edition's numbers.
+  return {
+    ...matchResult,
+    confidence: 'medium',
+    reason: `Duration mismatch — scanned ${formatDurationSeconds(scanned)} vs expected ${formatDurationSeconds(pickedMinutes * 60)}`,
+    reasonKind: 'duration-mismatch',
+  };
 }

--- a/src/client/pages/library-import/LibraryImportPage.test.tsx
+++ b/src/client/pages/library-import/LibraryImportPage.test.tsx
@@ -352,21 +352,21 @@ describe('LibraryImportPage (#133)', () => {
       await waitFor(() => { expect(screen.queryByRole('button', { name: /deselect \d+ pending/i })).not.toBeInTheDocument(); });
     });
 
-    it('F5: affordance clears the actionable within-scan pending row, leaving the DB duplicate (canonical helper)', async () => {
-      // Matched B1 + a result-less WITHIN-SCAN duplicate (actionable, selected) + a DB slug dup
-      // (not selectable). A bare `!r.book.isDuplicate` handler would skip the within-scan row.
+    it('F5: affordance clears the actionable former within-scan pending row, leaving the DB duplicate (canonical helper)', async () => {
+      // Matched B1 + a result-less FORMER WITHIN-SCAN row (a normal candidate, auto-selected) + a
+      // DB slug dup (not selectable). The canonical helper keeps the DB dup out of the "new"
+      // denominator while treating the former within-scan row as actionable (#1925).
       await renderPaused([
-        disc('/audiobooks/A/WS', 'WS', { isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/A/B1' }),
+        disc('/audiobooks/A/WS', 'WS', { isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' }),
         disc('/audiobooks/A/DB', 'DB', { isDuplicate: true, duplicateReason: 'slug' }),
       ]);
 
-      // A within-scan dup starts UNSELECTED (isDuplicate=true) — select it so it's a selected
-      // pending row. DB dup is excluded from the "new" denominator, so selecting WS → "2 of 2".
-      await userEvent.click(screen.getByLabelText('Select'));
+      // WS is a normal candidate now → auto-selected; B1 matched+selected; DB dup excluded from
+      // the "new" denominator → "2 of 2 new selected" from the start.
       await waitFor(() => { expect(screen.getByText(/2 of 2 new selected/i)).toBeInTheDocument(); });
       await userEvent.click(screen.getByRole('button', { name: /deselect 1 pending/i }));
 
-      // WS cleared (helper treats within-scan as actionable); matched B1 kept → Import enabled.
+      // WS cleared (result-less pending row); matched B1 kept → Import enabled.
       await waitFor(() => { expect(screen.getByText(/1 of 2 new selected/i)).toBeInTheDocument(); });
       expect(screen.getByRole('button', { name: /import 1 book$/i })).toBeEnabled();
     });
@@ -385,13 +385,15 @@ describe('LibraryImportPage (#133)', () => {
       expect(segment.querySelector('svg')).toBeNull();
     });
 
-    it('F9: a paused result-less within-scan row keeps "Duplicate in scan" (not "Paused")', async () => {
-      await renderPaused([disc('/audiobooks/A/WS', 'WS', { isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/A/B1' })]);
+    it('F9: a paused result-less former within-scan row shows the normal "Paused" badge + review hint (#1925)', async () => {
+      await renderPaused([disc('/audiobooks/A/WS', 'WS', { isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' })]);
 
-      // The within-scan badge precedes ConfidenceBadge, so paused does not re-badge it.
-      expect(screen.getByText('Duplicate in scan')).toBeInTheDocument();
-      expect(screen.queryByText('Paused')).not.toBeInTheDocument();
-      // …but selection-wise WS is still a pending row, so the summary count reads "1 paused".
+      // No special "Duplicate in scan" badge — it's a normal candidate that renders the shared
+      // review-reason indicator and, while paused + result-less, the ordinary "Paused" badge.
+      expect(screen.queryByText('Duplicate in scan')).not.toBeInTheDocument();
+      expect(screen.getByTestId('review-reason-indicator')).toBeInTheDocument();
+      expect(screen.getByText('Paused')).toBeInTheDocument();
+      // …and selection-wise WS is a pending row, so the summary count reads "1 paused".
       expect(screen.getByText('1 paused')).toBeInTheDocument();
     });
 
@@ -1219,24 +1221,24 @@ describe('LibraryImportPage (#133)', () => {
     });
   });
 
-  describe('within-scan duplicates — visibility and toggle (#342)', () => {
+  describe('former within-scan rows — visibility and toggle (#1925)', () => {
     const scanResultWithWithinScan = {
       discoveries: [
         { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
-        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/Author/Book' },
+        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
         { path: '/audiobooks/DbDup/DbBook', parsedTitle: 'DbBook', parsedAuthor: 'DbAuthor', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: true, duplicateReason: 'slug' },
       ],
       totalFolders: 3,
     };
 
-    it('within-scan duplicates are visible by default (not hidden by showExisting toggle)', async () => {
+    it('former within-scan rows are visible by default (not hidden by showExisting toggle)', async () => {
       mockApi.scanDirectory!.mockResolvedValue(scanResultWithWithinScan);
       mockApi.startMatchJob!.mockResolvedValue({ jobId: 'job-1' });
       mockApi.getMatchJob!.mockResolvedValue({ id: 'job-1', status: 'complete', total: 2, matched: 2, results: [] });
 
       renderWithProviders(<LibraryImportPage />);
 
-      // Within-scan duplicate should be visible by default
+      // Former within-scan row should be visible by default
       await waitFor(() => {
         expect(screen.getByText(/Copy\/Author\/Book/)).toBeInTheDocument();
       });
@@ -1257,7 +1259,7 @@ describe('LibraryImportPage (#133)', () => {
       expect(screen.queryByText(/DbDup\/DbBook/)).not.toBeInTheDocument();
     });
 
-    it('show existing toggle count reflects only DB duplicates, not within-scan', async () => {
+    it('show existing toggle count reflects only DB duplicates, not former within-scan rows', async () => {
       mockApi.scanDirectory!.mockResolvedValue(scanResultWithWithinScan);
       mockApi.startMatchJob!.mockResolvedValue({ jobId: 'job-1' });
       mockApi.getMatchJob!.mockResolvedValue({ id: 'job-1', status: 'complete', total: 2, matched: 2, results: [] });
@@ -1270,7 +1272,7 @@ describe('LibraryImportPage (#133)', () => {
       });
     });
 
-    it('N of M new selected denominator includes within-scan duplicates', async () => {
+    it('N of M new selected denominator counts a former within-scan row as new and default-selected', async () => {
       mockApi.scanDirectory!.mockResolvedValue(scanResultWithWithinScan);
       mockApi.startMatchJob!.mockResolvedValue({ jobId: 'job-1' });
       mockApi.getMatchJob!.mockResolvedValue({ id: 'job-1', status: 'complete', total: 2, matched: 2, results: [] });
@@ -1278,8 +1280,8 @@ describe('LibraryImportPage (#133)', () => {
       renderWithProviders(<LibraryImportPage />);
 
       await waitFor(() => {
-        // 1 non-dup selected out of 2 actionable (non-dup + within-scan dup)
-        expect(screen.getByText(/1 of 2 new selected/)).toBeInTheDocument();
+        // Both actionable rows (non-dup + former within-scan) are default-selected (#1925 AC4).
+        expect(screen.getByText(/2 of 2 new selected/)).toBeInTheDocument();
       });
     });
   });

--- a/src/client/pages/library-import/isLibraryDbDuplicate.test.ts
+++ b/src/client/pages/library-import/isLibraryDbDuplicate.test.ts
@@ -17,13 +17,13 @@ function book(overrides: Partial<DiscoveredBook>): DiscoveredBook {
   };
 }
 
-describe('isLibraryDbDuplicate (#1833)', () => {
+describe('isLibraryDbDuplicate (#1833/#1925)', () => {
   // Exhaustive over every DuplicateReason value so the hook and page — which both import this
-  // one predicate — provably agree about DB-duplicate status no matter how the enum grows.
+  // one predicate — provably agree about DB-duplicate status. As of #1925 both remaining
+  // reasons (path/slug) are DB-backed, so the predicate is simply `isDuplicate`.
   const cases: Array<{ reason: DuplicateReason | undefined; isDuplicate: boolean; expected: boolean }> = [
     { reason: 'path', isDuplicate: true, expected: true },
     { reason: 'slug', isDuplicate: true, expected: true },
-    { reason: 'within-scan', isDuplicate: true, expected: false },
     { reason: undefined, isDuplicate: false, expected: false },
   ];
 
@@ -33,7 +33,7 @@ describe('isLibraryDbDuplicate (#1833)', () => {
     });
   }
 
-  it('a within-scan collision is never a DB duplicate even though isDuplicate is true', () => {
-    expect(isLibraryDbDuplicate(book({ isDuplicate: true, duplicateReason: 'within-scan' }))).toBe(false);
+  it('a former within-scan row (isDuplicate=false, no duplicateReason) is not a DB duplicate (#1925)', () => {
+    expect(isLibraryDbDuplicate(book({ isDuplicate: false }))).toBe(false);
   });
 });

--- a/src/client/pages/library-import/isLibraryDbDuplicate.ts
+++ b/src/client/pages/library-import/isLibraryDbDuplicate.ts
@@ -2,9 +2,11 @@ import type { DiscoveredBook } from '@/lib/api';
 
 /**
  * The single library-import DB-duplicate decision (#1833). A book is a DB-backed
- * duplicate (already in the library by path or slug) when it is flagged `isDuplicate`
- * for a reason OTHER than `within-scan` — a within-scan collision is two folders in the
- * same scan, not something already owned, so it stays actionable.
+ * duplicate (already in the library by path or slug) exactly when it is flagged
+ * `isDuplicate` — both remaining duplicate reasons (`path`/`slug`) are DB-backed.
+ * (Within-scan title collisions are no longer hard-flagged as of #1925: they flow
+ * through as normal candidates and the confirm-time recording ladder decides
+ * identity, so there is no longer a non-DB `isDuplicate` reason to special-case.)
  *
  * This decision drives BOTH selection/counts/pending/retry-match eligibility (the hook)
  * AND row visibility/the "N new" denominator (the page). They MUST agree or the UI lies
@@ -15,5 +17,5 @@ import type { DiscoveredBook } from '@/lib/api';
  * directly) — a different trust boundary — and must NOT be unified with this.
  */
 export function isLibraryDbDuplicate(book: DiscoveredBook): boolean {
-  return book.isDuplicate && book.duplicateReason !== 'within-scan';
+  return book.isDuplicate;
 }

--- a/src/client/pages/library-import/useLibraryImport.test.ts
+++ b/src/client/pages/library-import/useLibraryImport.test.ts
@@ -1385,36 +1385,40 @@ describe('empty result edge case', () => {
     expect(result.current.state.scanError).toBeNull();
   });
 
-  describe('within-scan duplicates — visibility and selection (#342)', () => {
+  describe('former within-scan rows — visibility and selection (#1925)', () => {
     const scanResultWithWithinScan: ScanResult = {
       discoveries: [
         { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
-        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/Author/Book' },
+        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
         { path: '/audiobooks/DbDup/Book', parsedTitle: 'DbBook', parsedAuthor: 'DbAuthor', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: true, duplicateReason: 'slug' },
       ],
       totalFolders: 3,
     };
 
-    it('within-scan duplicates are auto-deselected on initial load', async () => {
+    it('a former within-scan row is default-selected on initial load (#1925 AC4)', async () => {
       mockScanDirectory.mockResolvedValue(scanResultWithWithinScan);
       const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      const withinScanRow = result.current.state.rows.find(r => r.book.duplicateReason === 'within-scan');
-      expect(withinScanRow?.selected).toBe(false);
+      const withinScanRow = result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
+      expect(withinScanRow?.selected).toBe(true);
     });
 
-    it('within-scan duplicates are included in select-all toggling', async () => {
+    it('former within-scan rows participate in select-all toggling', async () => {
       mockScanDirectory.mockResolvedValue(scanResultWithWithinScan);
       const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
+      const findWs = () => result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
+      // Starts selected (#1925 AC4). All actionable rows already selected → select-all toggles OFF.
+      expect(findWs()?.selected).toBe(true);
       act(() => { result.current.actions.handleSelectAll(); });
-
-      const withinScanRow = result.current.state.rows.find(r => r.book.duplicateReason === 'within-scan');
-      expect(withinScanRow?.selected).toBe(true);
+      expect(findWs()?.selected).toBe(false);
+      // …and back ON — proving it is part of the toggled actionable set.
+      act(() => { result.current.actions.handleSelectAll(); });
+      expect(findWs()?.selected).toBe(true);
     });
 
     it('DB duplicates (path/slug) are excluded from select-all toggling', async () => {
@@ -1430,17 +1434,17 @@ describe('empty result edge case', () => {
     });
   });
 
-  describe('within-scan duplicates — match flow (#342)', () => {
+  describe('former within-scan rows — match flow (#1925)', () => {
     const scanResultMatchFlow: ScanResult = {
       discoveries: [
         { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
-        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/Author/Book' },
+        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
         { path: '/audiobooks/DbDup/Book', parsedTitle: 'DbBook', parsedAuthor: 'DbAuthor', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: true, duplicateReason: 'path' },
       ],
       totalFolders: 3,
     };
 
-    it('initial matcher candidates include within-scan duplicates but exclude DB duplicates', async () => {
+    it('initial matcher candidates include former within-scan rows but exclude DB duplicates', async () => {
       // Must set before hook mounts (auto-scan fires on mount)
       mockScanDirectory.mockReset().mockResolvedValue(scanResultMatchFlow);
       mockStartMatchJob.mockClear().mockResolvedValue({ jobId: 'job-1' });
@@ -1479,7 +1483,7 @@ describe('empty result edge case', () => {
       expect(byPath('/audiobooks/Standalone')).not.toHaveProperty('seriesPosition');
     });
 
-    it('mergeMatchResults applies match data to within-scan row and seeds edited metadata', async () => {
+    it('mergeMatchResults applies match data to a former within-scan row and seeds edited metadata', async () => {
       mockScanDirectory.mockReset().mockResolvedValue(scanResultMatchFlow);
       mockStartMatchJob.mockClear().mockResolvedValue({ jobId: 'job-1' });
       // Poll returns a high-confidence match for the within-scan duplicate row
@@ -1504,17 +1508,17 @@ describe('empty result edge case', () => {
 
       // After poll merges match results, within-scan row should have matchResult and edited metadata
       await waitFor(() => {
-        const withinScanRow = result.current.state.rows.find(r => r.book.duplicateReason === 'within-scan');
+        const withinScanRow = result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
         expect(withinScanRow?.matchResult?.confidence).toBe('high');
       }, { timeout: 5000 });
 
-      const withinScanRow = result.current.state.rows.find(r => r.book.duplicateReason === 'within-scan');
+      const withinScanRow = result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
       expect(withinScanRow?.edited.title).toBe('Matched Title');
       expect(withinScanRow?.edited.author).toBe('Matched Author');
       expect(withinScanRow?.edited.asin).toBe('B999');
     });
 
-    it('mergeMatchResults with confidence=none deselects within-scan row', async () => {
+    it('mergeMatchResults with confidence=none deselects a former within-scan row', async () => {
       mockScanDirectory.mockReset().mockResolvedValue(scanResultMatchFlow);
       mockStartMatchJob.mockClear().mockResolvedValue({ jobId: 'job-1' });
       mockGetMatchJob.mockResolvedValue({
@@ -1531,19 +1535,19 @@ describe('empty result edge case', () => {
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      // Select the within-scan row first
-      const withinScanIdx = result.current.state.rows.findIndex(r => r.book.duplicateReason === 'within-scan');
-      act(() => { result.current.actions.handleToggle(withinScanIdx); });
+      // The row is a normal candidate now, so it starts SELECTED (#1925 AC4).
+      const initial = result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
+      expect(initial?.selected).toBe(true);
 
-      // After poll merges confidence=none, the row should be deselected
+      // After poll merges confidence=none, a no-match row is auto-deselected.
       await waitFor(() => {
-        const row = result.current.state.rows.find(r => r.book.duplicateReason === 'within-scan');
+        const row = result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
         expect(row?.matchResult?.confidence).toBe('none');
         expect(row?.selected).toBe(false);
       }, { timeout: 5000 });
     });
 
-    it('handleRestartMatch includes within-scan rows and excludes DB duplicates', async () => {
+    it('handleRestartMatch includes former within-scan rows and excludes DB duplicates', async () => {
       // Initial match attempt fails at start (paused) so we can trigger Restart
       mockScanDirectory.mockReset().mockResolvedValue(scanResultMatchFlow);
       mockStartMatchJob
@@ -1571,17 +1575,17 @@ describe('empty result edge case', () => {
     });
   });
 
-  describe('within-scan duplicates — derived state (#342)', () => {
+  describe('former within-scan rows — derived state (#1925)', () => {
     const scanResultMixed: ScanResult = {
       discoveries: [
         { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
-        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/Author/Book' },
+        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
         { path: '/audiobooks/DbDup/Book', parsedTitle: 'DbBook', parsedAuthor: 'DbAuthor', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: true, duplicateReason: 'slug' },
       ],
       totalFolders: 3,
     };
 
-    it('readyCount includes selected within-scan duplicates with high-confidence matches', async () => {
+    it('readyCount includes selected former within-scan rows with high-confidence matches', async () => {
       mockScanDirectory.mockReset().mockResolvedValue(scanResultMixed);
       mockStartMatchJob.mockClear().mockResolvedValue({ jobId: 'job-1' });
       // Poll returns high-confidence match for both the non-dup and within-scan dup
@@ -1600,25 +1604,23 @@ describe('empty result edge case', () => {
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      // Select all actionable rows (including within-scan dup)
-      act(() => { result.current.actions.handleSelectAll(); });
-
-      // Wait for match results to merge
+      // Both actionable rows are default-selected (#1925 AC4) — no select-all needed. Wait for
+      // the high-confidence matches to merge; both selected + high → readyCount 2.
       await waitFor(() => {
-        expect(result.current.counts.readyCount).toBe(2); // non-dup + within-scan dup, both selected + high confidence
+        expect(result.current.counts.readyCount).toBe(2); // non-dup + former within-scan row
       }, { timeout: 5000 });
     });
 
-    it('pendingCount includes within-scan duplicates awaiting match results', async () => {
+    it('pendingCount includes former within-scan rows awaiting match results', async () => {
       mockScanDirectory.mockResolvedValue(scanResultMixed);
       const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      // Within-scan dup has no matchResult yet → should count as pending
+      // Former within-scan row has no matchResult yet → should count as pending
       // DB dup should NOT count as pending
       // Non-dup has no matchResult yet → should count as pending
-      expect(result.current.counts.pendingCount).toBe(2); // non-dup + within-scan dup
+      expect(result.current.counts.pendingCount).toBe(2); // non-dup + former within-scan row
     });
 
     // #1102 — selectedPendingCount is scoped to selection, excludes DB duplicates
@@ -1628,12 +1630,9 @@ describe('empty result edge case', () => {
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      // Non-dup row is auto-selected; within-scan dup is auto-deselected.
+      // Both the non-dup and the former within-scan row are auto-selected (#1925 AC4), so both
+      // pending rows are selected from the start; the DB slug dup is excluded.
       expect(result.current.counts.pendingCount).toBe(2);
-      expect(result.current.counts.selectedPendingCount).toBe(1);
-
-      // Selecting all actionable rows includes the within-scan dup → 2 pending selected.
-      act(() => { result.current.actions.handleSelectAll(); });
       expect(result.current.counts.selectedPendingCount).toBe(2);
     });
 
@@ -1645,14 +1644,15 @@ describe('empty result edge case', () => {
 
       // Locate the DB-dup row index (slug duplicate) and force-select it via handleToggle.
       const dbDupIndex = result.current.state.rows.findIndex(r =>
-        r.book.isDuplicate && r.book.duplicateReason !== 'within-scan',
+        r.book.isDuplicate && r.book.duplicateReason === 'slug',
       );
       expect(dbDupIndex).toBeGreaterThanOrEqual(0);
       act(() => { result.current.actions.handleToggle(dbDupIndex); });
       expect(result.current.state.rows[dbDupIndex]!.selected).toBe(true);
 
       // DB dup must NOT contribute to selectedPendingCount (matches pendingCount semantics).
-      expect(result.current.counts.selectedPendingCount).toBe(1);
+      // Non-dup + former within-scan row remain the only two selected pending rows.
+      expect(result.current.counts.selectedPendingCount).toBe(2);
     });
 
     it('duplicateCount counts only DB duplicates', async () => {
@@ -1664,28 +1664,34 @@ describe('empty result edge case', () => {
       expect(result.current.counts.duplicateCount).toBe(1); // only DB slug dup
     });
 
-    it('allSelected treats within-scan duplicates as actionable', async () => {
+    it('allSelected treats former within-scan rows as actionable', async () => {
       mockScanDirectory.mockResolvedValue(scanResultMixed);
       const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      // Not all selected yet (within-scan dup is auto-deselected)
+      // Both actionable rows (non-dup + former within-scan) are auto-selected, so allSelected
+      // is true from the start; the DB slug dup is excluded from the "all actionable" set.
+      expect(result.current.counts.allSelected).toBe(true);
+
+      // Deselecting the former within-scan row breaks allSelected — proving it is counted
+      // among the actionable rows.
+      const withinScanIdx = result.current.state.rows.findIndex(r => r.book.path === '/audiobooks/Copy/Author/Book');
+      act(() => { result.current.actions.handleToggle(withinScanIdx); });
       expect(result.current.counts.allSelected).toBe(false);
 
-      // Select all actionable rows
+      // Reselecting all restores it.
       act(() => { result.current.actions.handleSelectAll(); });
-
       expect(result.current.counts.allSelected).toBe(true);
     });
   });
 
-  describe('within-scan duplicates — registration (#342)', () => {
-    it('handleRegister sends forceImport: true for selected duplicate rows', async () => {
+  describe('former within-scan rows — registration (#1925)', () => {
+    it('handleRegister omits forceImport for a selected former within-scan row (#1925 AC5)', async () => {
       const scanResult: ScanResult = {
         discoveries: [
           { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
-          { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/Author/Book' },
+          { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
         ],
         totalFolders: 2,
       };
@@ -1698,17 +1704,18 @@ describe('empty result edge case', () => {
 
       await waitFor(() => { expect(result.current.state.step).toBe('review'); });
 
-      // Select all (including within-scan dup)
-      act(() => { result.current.actions.handleSelectAll(); });
+      // Both rows are normal candidates, default-selected (#1925 AC4) — register directly.
       act(() => { result.current.actions.handleRegister(); });
 
       await waitFor(() => { expect(mockCreateSubmission).toHaveBeenCalled(); });
 
+      // #1925 AC5: a former within-scan row flows through the confirm-time recording ladder
+      // rather than bypassing it — so neither row submits with forceImport.
       const items = submittedItems() as Array<{ path: string; forceImport?: boolean }>;
       const nonDup = items.find(i => i.path === '/audiobooks/Author/Book');
-      const withinScanDup = items.find(i => i.path === '/audiobooks/Copy/Author/Book');
+      const withinScanRow = items.find(i => i.path === '/audiobooks/Copy/Author/Book');
       expect(nonDup?.forceImport).toBeUndefined();
-      expect(withinScanDup?.forceImport).toBe(true);
+      expect(withinScanRow?.forceImport).toBeUndefined();
     });
 
     it('scan with only DB duplicates still shows All caught up', async () => {
@@ -1725,11 +1732,11 @@ describe('empty result edge case', () => {
       await waitFor(() => { expect(result.current.state.emptyResult).toBe(true); });
     });
 
-    it('scan with mix of new + within-scan duplicates does NOT show All caught up', async () => {
+    it('scan with mix of new + former within-scan rows does NOT show All caught up', async () => {
       const mixedResult: ScanResult = {
         discoveries: [
           { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
-          { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/audiobooks/Author/Book' },
+          { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
         ],
         totalFolders: 2,
       };

--- a/src/client/pages/library-import/useLibraryImport.test.ts
+++ b/src/client/pages/library-import/useLibraryImport.test.ts
@@ -1841,4 +1841,70 @@ describe('empty result edge case', () => {
       expect(result.current.state.rows[0]!.edited).not.toHaveProperty('seriesPosition');
     });
   });
+
+  // #1929 — re-picking a match on a duration-mismatch Review row must re-check the
+  // picked edition against the scanned runtime, never blanket-clear to green.
+  describe('#1929 re-pick re-evaluates duration evidence (library surface)', () => {
+    const scanWithSingleNew: ScanResult = {
+      discoveries: [
+        { path: '/audiobooks/AuthorA/Book1', parsedTitle: 'Book One', parsedAuthor: 'Author A', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
+      ],
+      totalFolders: 1,
+    };
+    // scanned 14h53m vs the seeded 14h58m edition (Δ300s, out of band).
+    const durationMismatchResult = {
+      path: '/audiobooks/AuthorA/Book1',
+      confidence: 'medium' as const,
+      bestMatch: { title: 'Official', authors: [{ name: 'Author A' }], duration: 898 },
+      alternatives: [],
+      reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+      reasonKind: 'duration-mismatch' as const,
+      scannedSeconds: 53580,
+    };
+
+    async function seedMismatchRow() {
+      mockScanDirectory.mockReset().mockResolvedValue(scanWithSingleNew);
+      mockStartMatchJob.mockClear().mockResolvedValue({ jobId: 'job-1' });
+      mockGetMatchJob.mockResolvedValue({ id: 'job-1', status: 'completed', total: 1, matched: 1, results: [durationMismatchResult] });
+      const { result } = renderHook(() => useLibraryImport(), { wrapper: createWrapper() });
+      await waitFor(() => { expect(result.current.state.step).toBe('review'); });
+      await waitFor(() => { expect(result.current.state.rows[0]!.matchResult?.reasonKind).toBe('duration-mismatch'); }, { timeout: 5000 });
+      return result;
+    }
+
+    it('re-picking the SAME (out-of-band) edition keeps the row in Review, not green', async () => {
+      const result = await seedMismatchRow();
+
+      // BookEditModal spreads the pick into a FRESH object — same values, new reference.
+      act(() => {
+        result.current.actions.handleEdit(0, {
+          title: 'Official', author: 'Author A', series: '',
+          metadata: { title: 'Official', authors: [{ name: 'Author A' }], duration: 898 },
+        });
+      });
+
+      const match = result.current.state.rows[0]!.matchResult;
+      expect(match?.confidence).toBe('medium');
+      expect(match?.reasonKind).toBe('duration-mismatch');
+      expect(match?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+      expect(match?.scannedSeconds).toBe(53580);
+    });
+
+    it('re-picking an in-band edition legitimately clears the row to Matched', async () => {
+      const result = await seedMismatchRow();
+
+      act(() => {
+        result.current.actions.handleEdit(0, {
+          title: 'Official', author: 'Author A', series: '',
+          metadata: { title: 'Official', authors: [{ name: 'Author A' }], duration: 894 }, // 14h54m → Δ60s
+        });
+      });
+
+      const match = result.current.state.rows[0]!.matchResult;
+      expect(match?.confidence).toBe('high');
+      expect(match?.reason).toBeUndefined();
+      expect(match?.reasonKind).toBeUndefined();
+      expect(match?.scannedSeconds).toBe(53580);
+    });
+  });
 });

--- a/src/client/pages/library-import/useLibraryImport.ts
+++ b/src/client/pages/library-import/useLibraryImport.ts
@@ -214,8 +214,8 @@ export function useLibraryImport() {
   // Deselect-pending affordance (#1895): while paused, clear `selected` on every pending row
   // — result-less and NOT a DB duplicate — so the remaining matched selection can import. The
   // predicate mirrors `selectedPendingCount` exactly (the canonical `isLibraryDbDuplicate`
-  // helper, not a bare `!isDuplicate`): a within-scan duplicate is actionable and gets cleared,
-  // a path/slug DB duplicate isn't selectable to begin with. Matched selections stay intact.
+  // helper): a path/slug DB duplicate isn't selectable to begin with, so it never needs
+  // clearing. Matched selections stay intact.
   const handleDeselectPending = useCallback(() => {
     setRows(prev => prev.map(r => (!r.matchResult && !isLibraryDbDuplicate(r.book)) ? { ...r, selected: false } : r));
   }, []);

--- a/src/client/pages/manual-import/useManualImport.test.ts
+++ b/src/client/pages/manual-import/useManualImport.test.ts
@@ -2012,6 +2012,49 @@ describe('match merge — boundary values (#185)', () => {
     }
   });
 
+  // #1929 — re-picking the same duration-mismatch edition on the manual surface must
+  // NOT turn the row green; it re-checks the picked edition against the scanned runtime.
+  it('re-picking the same out-of-band edition on a duration-mismatch row keeps it in Review (#1929)', async () => {
+    try {
+      vi.mocked(api.scanDirectory).mockResolvedValue(SCAN_RESULT);
+      vi.mocked(api.getMatchJob).mockResolvedValue({
+        id: 'job-123', status: 'completed', matched: 1, total: 1,
+        results: [{
+          path: '/audiobooks/Book A',
+          confidence: 'medium',
+          bestMatch: { title: 'Official Title', authors: [{ name: 'Author A' }], duration: 898 }, // 14h58m
+          alternatives: [],
+          reason: 'Duration mismatch — scanned 14h 53m vs expected 14h 58m',
+          reasonKind: 'duration-mismatch',
+          scannedSeconds: 53580, // 14h53m — Δ300s, out of band
+        }],
+      });
+
+      const { result } = renderHook(() => useManualImport(), { wrapper: createWrapper() });
+      act(() => { result.current.state.setScanPath('/audiobooks'); });
+      await act(async () => { result.current.actions.handleScan(); });
+      await waitFor(() => { expect(result.current.state.rows).toHaveLength(2); });
+      await tickPoll();
+      await waitFor(() => { expect(result.current.state.rows[0]!.matchResult?.reasonKind).toBe('duration-mismatch'); });
+
+      // BookEditModal spreads the pick into a fresh object — same edition, new reference.
+      act(() => {
+        result.current.actions.handleEdit(0, {
+          title: 'Official Title', author: 'Author A', series: '',
+          metadata: { title: 'Official Title', authors: [{ name: 'Author A' }], duration: 898 },
+        });
+      });
+
+      const match = result.current.state.rows[0]!.matchResult;
+      expect(match?.confidence).toBe('medium');
+      expect(match?.reasonKind).toBe('duration-mismatch');
+      expect(match?.reason).toBe('Duration mismatch — scanned 14h 53m vs expected 14h 58m');
+      expect(match?.scannedSeconds).toBe(53580);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('high confidence does NOT re-select a row the user had deselected (#1318 parity)', async () => {
     try {
       vi.mocked(api.scanDirectory).mockResolvedValue(SCAN_RESULT);

--- a/src/client/pages/manual-import/useManualImport.test.ts
+++ b/src/client/pages/manual-import/useManualImport.test.ts
@@ -2738,4 +2738,62 @@ describe('grouped return shape (REACT-1 refactor)', () => {
       expect(result.current.state.paused).toBe(false);
     });
   });
+
+  // #1925 AC10 / F5: Manual Import consumes the SAME shared scan result as Library Import. A
+  // former within-scan title collision now arrives as a normal candidate (isDuplicate: false)
+  // carrying a display-only review hint, so on this surface it must ALSO become default-selected,
+  // match-eligible, and submit WITHOUT forceImport — flowing through the confirm-time ladder.
+  describe('former within-scan rows on the Manual Import surface (#1925 AC10)', () => {
+    const SCAN_WITH_FORMER_WITHIN_SCAN: ScanResult = {
+      discoveries: [
+        { path: '/audiobooks/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false },
+        { path: '/audiobooks/Copy/Author/Book', parsedTitle: 'Book', parsedAuthor: 'Author', parsedSeries: null, fileCount: 3, totalSize: 100000, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
+        { path: '/audiobooks/DbDup/Book', parsedTitle: 'DbBook', parsedAuthor: 'DbAuthor', parsedSeries: null, fileCount: 1, totalSize: 50000, isDuplicate: true, duplicateReason: 'slug' },
+      ],
+      totalFolders: 3,
+    };
+
+    it('is default-selected on load and match-eligible; the DB duplicate is neither', async () => {
+      vi.mocked(api.scanDirectory).mockResolvedValue(SCAN_WITH_FORMER_WITHIN_SCAN);
+      vi.mocked(api.startMatchJob).mockClear().mockResolvedValue({ jobId: 'job-123' });
+
+      const { result } = renderHook(() => useManualImport(), { wrapper: createWrapper() });
+      act(() => { result.current.state.setScanPath('/audiobooks'); });
+      await act(async () => { result.current.actions.handleScan(); });
+      await waitFor(() => { expect(result.current.state.rows).toHaveLength(3); });
+
+      const wsRow = result.current.state.rows.find(r => r.book.path === '/audiobooks/Copy/Author/Book');
+      const dbRow = result.current.state.rows.find(r => r.book.path === '/audiobooks/DbDup/Book');
+      expect(wsRow?.selected).toBe(true);   // selected: !isDuplicate
+      expect(dbRow?.selected).toBe(false);  // DB duplicate stays unchecked
+
+      // Match candidates derive off `!book.isDuplicate` → include the former within-scan row, exclude the DB dup.
+      await waitFor(() => { expect(vi.mocked(api.startMatchJob)).toHaveBeenCalled(); });
+      const candidatePaths = (vi.mocked(api.startMatchJob).mock.calls[0]![0] as Array<{ path: string }>).map(c => c.path);
+      expect(candidatePaths).toContain('/audiobooks/Author/Book');
+      expect(candidatePaths).toContain('/audiobooks/Copy/Author/Book');
+      expect(candidatePaths).not.toContain('/audiobooks/DbDup/Book');
+    });
+
+    it('submits via toConfirmItem WITHOUT forceImport (flows through the confirm ladder)', async () => {
+      vi.mocked(api.scanDirectory).mockResolvedValue(SCAN_WITH_FORMER_WITHIN_SCAN);
+      wireStagedComplete(stagedMocks, {
+        source: 'manual', mode: 'copy',
+        items: [acceptedRow(0, '/audiobooks/Author/Book', 'Book'), acceptedRow(1, '/audiobooks/Copy/Author/Book', 'Book')],
+      });
+
+      const { result } = renderHook(() => useManualImport(), { wrapper: createWrapper() });
+      act(() => { result.current.state.setScanPath('/audiobooks'); });
+      await act(async () => { result.current.actions.handleScan(); });
+      await waitFor(() => { expect(result.current.state.rows).toHaveLength(3); });
+
+      await act(async () => { result.current.actions.handleImport(); });
+      await waitFor(() => { expect(vi.mocked(api.createImportSubmission)).toHaveBeenCalled(); });
+
+      const items = submittedItems();
+      const wsItem = items.find(i => i.path === '/audiobooks/Copy/Author/Book');
+      expect(wsItem).toBeDefined();
+      expect(wsItem).not.toHaveProperty('forceImport');
+    });
+  });
 });

--- a/src/core/utils/path-order.ts
+++ b/src/core/utils/path-order.ts
@@ -1,7 +1,7 @@
 /**
  * Total, cross-platform-stable ordering over filesystem paths (#1891). Scan
- * dispositions (`duplicateFirstPath`, `isDuplicate` in the library scan) are
- * order-dependent under the non-transitive title predicate, so identical trees MUST
+ * dispositions (`isDuplicate` and the within-scan review hint in the library scan)
+ * are order-dependent under the non-transitive title predicate, so identical trees MUST
  * order identically regardless of `readdir` order, separator style, or folded-key
  * collisions. `discoverBooks` sorts its results with this before returning.
  *

--- a/src/server/jobs/enrichment.test.ts
+++ b/src/server/jobs/enrichment.test.ts
@@ -802,19 +802,54 @@ describe('enrichment job', () => {
       expect(setCall).toHaveProperty('seriesPosition', 1);
     });
 
-    it('does NOT overwrite existing seriesName', async () => {
-      setupEnrichment({ seriesName: 'Existing Series', seriesPosition: 3 }, { series: [{ name: 'New Series', position: 1 }] });
+    // #1927 AC10 — a stored series name is authoritative: enrichment writes NEITHER field,
+    // so a metadata position is never grafted onto a user's stored series (the pair stays
+    // single-sourced). Covers name-present × { position present, position null }.
+    it('stored seriesName present + position present → writes NEITHER field (#1927 AC10)', async () => {
+      setupEnrichment({ seriesName: 'Custom Saga', seriesPosition: 3 }, { series: [{ name: 'Provider Saga', position: 15 }] });
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
       const setCall = db.update.mock.results[0]!.value.set.mock.calls[0][0];
       expect(setCall).not.toHaveProperty('seriesName');
+      expect(setCall).not.toHaveProperty('seriesPosition');
     });
 
-    it('fills seriesPosition independently when seriesName exists but seriesPosition is null', async () => {
-      setupEnrichment({ seriesName: 'The Stormlight Archive', seriesPosition: null }, { series: [{ name: 'The Stormlight Archive', position: 1 }] });
+    it('stored seriesName present + position null → position NOT back-filled (#1927 AC10 reverses the old independent fill)', async () => {
+      // Pre-#1927 this back-filled seriesPosition beside the stored name (crossing sources).
+      // AC10: a stored name is authoritative; a missing position is corrected via Fix Match /
+      // the metadata editor, never grafted by enrichment.
+      setupEnrichment({ seriesName: 'Custom Saga', seriesPosition: null }, { series: [{ name: 'Provider Saga', position: 15 }] });
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
       const setCall = db.update.mock.results[0]!.value.set.mock.calls[0][0];
       expect(setCall).not.toHaveProperty('seriesName');
-      expect(setCall).toHaveProperty('seriesPosition', 1);
+      expect(setCall).not.toHaveProperty('seriesPosition');
+    });
+
+    it('orphan { seriesName: null, seriesPosition: 5 } → BOTH written atomically, stale position overwritten (#1927 AC10/F11)', async () => {
+      // The name is absent, so the metadata pair is written atomically — the orphan `5` is
+      // overwritten by the metadata position (15), never surviving as `Provider Saga #5`.
+      setupEnrichment({ seriesName: null, seriesPosition: 5 }, { series: [{ name: 'Provider Saga', position: 15 }] });
+      await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
+      const setCall = db.update.mock.results[0]!.value.set.mock.calls[0][0];
+      expect(setCall).toHaveProperty('seriesName', 'Provider Saga');
+      expect(setCall).toHaveProperty('seriesPosition', 15);
+    });
+
+    it('orphan { seriesName: null, seriesPosition: 5 } vs metadata with NO position → position CLEARED to null (#1927 AC10)', async () => {
+      // Absent name + metadata name without a position → seriesName set, orphan position cleared
+      // to null (not retained), so the written pair is single-sourced.
+      setupEnrichment({ seriesName: null, seriesPosition: 5 }, { series: [{ name: 'Provider Saga' }] });
+      await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
+      const setCall = db.update.mock.results[0]!.value.set.mock.calls[0][0];
+      expect(setCall).toHaveProperty('seriesName', 'Provider Saga');
+      expect(setCall).toHaveProperty('seriesPosition', null);
+    });
+
+    it('absent name + metadata primary position 0 → seriesPosition 0 written (not dropped) (#1927 AC10)', async () => {
+      setupEnrichment({ seriesName: null, seriesPosition: null }, { series: [{ name: 'Prequels', position: 0 }] });
+      await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
+      const setCall = db.update.mock.results[0]!.value.set.mock.calls[0][0];
+      expect(setCall).toHaveProperty('seriesName', 'Prequels');
+      expect(setCall).toHaveProperty('seriesPosition', 0);
     });
 
     it('does not change series when enrichment returns empty series array', async () => {

--- a/src/server/jobs/enrichment.ts
+++ b/src/server/jobs/enrichment.ts
@@ -172,11 +172,24 @@ function fillEmptyFields(book: ExistingBookFields, result: Record<string, unknow
 }
 
 /**
- * Fill series fields independently (matching library-scan.service.ts:432-433).
- * Prefers the Audnexus-derived `seriesPrimary` canonical ref, falling back to
- * `series[0]` only when `seriesPrimary` is absent — `series[0]` on Audible can
- * be a broader universe ref (e.g. Cosmere) rather than the real book series
- * (Stormlight Archive). (#1088 / #1097)
+ * Fill series fields as one atomic single-source pair (#1927 AC10). The `(name,
+ * position)` pair must always share ONE source, so enrichment never crosses a
+ * stored user series with a metadata position:
+ *
+ * - Stored `seriesName` present (any position) → write NEITHER field. The stored
+ *   pair is authoritative; a missing position on a named series is corrected via
+ *   Fix Match / the metadata editor, not by grafting a metadata position on.
+ * - Stored `seriesName` absent + metadata has a primary name → write BOTH
+ *   atomically: `seriesName = primary.name` and `seriesPosition = primary.position
+ *   ?? null`. NOT gated on the stored position, so a reachable orphan
+ *   `{ seriesName: null, seriesPosition: 5 }` (Manual Add / independent writes) has
+ *   its stale position overwritten or cleared to match the metadata name rather
+ *   than surviving as `Provider Saga #5`. Position 0 survives (`?? null` keeps 0).
+ * - No usable primary name → write nothing.
+ *
+ * Prefers the Audnexus-derived `seriesPrimary` canonical ref over `series[0]`
+ * (#1088 / #1097) — `series[0]` on Audible can be a broader universe ref (Cosmere)
+ * rather than the real book series (Stormlight Archive).
  */
 function fillSeriesFields(
   book: ExistingBookFields,
@@ -187,9 +200,9 @@ function fillSeriesFields(
 ): Record<string, unknown> {
   const updates: Record<string, unknown> = {};
   const primary = pickPrimarySeries(result);
-  if (!primary) return updates;
-  if (primary.name && !book.seriesName) updates.seriesName = primary.name;
-  if (primary.position != null && book.seriesPosition == null) updates.seriesPosition = primary.position;
+  if (!primary?.name || book.seriesName) return updates;
+  updates.seriesName = primary.name;
+  updates.seriesPosition = primary.position ?? null;
   return updates;
 }
 

--- a/src/server/routes/library-scan.test.ts
+++ b/src/server/routes/library-scan.test.ts
@@ -551,13 +551,13 @@ describe('library-scan routes', () => {
     });
   });
 
-  describe('POST /api/library/import/scan — within-scan duplicates (#342)', () => {
-    it('response includes duplicateReason=within-scan and duplicateFirstPath for within-scan duplicates', async () => {
+  describe('POST /api/library/import/scan — within-scan title collisions (#1925)', () => {
+    it('serializes a former within-scan row as a normal candidate + review hint, no duplicate fields', async () => {
       (services.libraryScan.scanDirectory as ReturnType<typeof vi.fn>)
         .mockResolvedValue({
           discoveries: [
             { path: '/a/Author/Title', parsedTitle: 'Title', parsedAuthor: 'Author', parsedSeries: null, fileCount: 1, totalSize: 100, isDuplicate: false },
-            { path: '/a/Copy/Author/Title', parsedTitle: 'Title', parsedAuthor: 'Author', parsedSeries: null, fileCount: 1, totalSize: 100, isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: '/a/Author/Title' },
+            { path: '/a/Copy/Author/Title', parsedTitle: 'Title', parsedAuthor: 'Author', parsedSeries: null, fileCount: 1, totalSize: 100, isDuplicate: false, reviewReason: 'Possible duplicate folder in this scan' },
           ],
           totalFolders: 2,
         });
@@ -565,11 +565,13 @@ describe('library-scan routes', () => {
       const res = await app.inject({ method: 'POST', url: '/api/library/import/scan', payload: { path: '/a' } });
       expect(res.statusCode).toBe(200);
       const body = JSON.parse(res.payload);
+      // Both rows flow through as normal candidates — the recording ladder decides identity at confirm time.
       expect(body.discoveries[0].isDuplicate).toBe(false);
-      expect(body.discoveries[0]).not.toHaveProperty('duplicateFirstPath');
-      expect(body.discoveries[1].isDuplicate).toBe(true);
-      expect(body.discoveries[1].duplicateReason).toBe('within-scan');
-      expect(body.discoveries[1].duplicateFirstPath).toBe('/a/Author/Title');
+      expect(body.discoveries[1].isDuplicate).toBe(false);
+      expect(body.discoveries[1].reviewReason).toBe('Possible duplicate folder in this scan');
+      // The within-scan hard-flag machinery is gone — no duplicate reason/first-path survives serialization.
+      expect(body.discoveries[1]).not.toHaveProperty('duplicateReason');
+      expect(body.discoveries[1]).not.toHaveProperty('duplicateFirstPath');
     });
   });
 

--- a/src/server/services/enrichment-orchestration.helpers.test.ts
+++ b/src/server/services/enrichment-orchestration.helpers.test.ts
@@ -561,31 +561,77 @@ describe('buildBookCreatePayload (#1028)', () => {
     expect(payload.publisher).toBeUndefined();
   });
 
-  it('meta.series[0].position: 0 wins over item.seriesPosition (provider-truth, regression guard for falsy)', async () => {
+  // #1927 — item-first, two-state, pair-locked series resolution (was #1071 metadata-first).
+  it('item supplies series + position → payload uses the ITEM values, not metadata (#1927 AC1)', async () => {
     const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
     const payload = buildBookCreatePayload(
-      { path: '/x', title: 'T', seriesPosition: 99 },
-      { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'S', position: 0 }] },
-      'importing',
-    );
-    expect(payload.seriesPosition).toBe(0);
-  });
-
-  it('meta.series[0].position wins over item.seriesPosition (#1071 provider-truth precedence)', async () => {
-    const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
-    const payload = buildBookCreatePayload(
-      { path: '/x', title: 'T', seriesPosition: 99 },
+      { path: '/x', title: 'T', seriesName: 'The Dresden Files', seriesPosition: 10 },
       { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'Wax and Wayne', position: 1 }] },
       'importing',
     );
-    expect(payload.seriesPosition).toBe(1);
-    expect(payload.seriesName).toBe('Wax and Wayne');
+    expect(payload.seriesName).toBe('The Dresden Files');
+    expect(payload.seriesPosition).toBe(10);
   });
 
-  it('item.seriesPosition: 1.5 falls through when meta has no series', async () => {
+  it('item supplies series but NO position → item series with NO position, metadata position NOT grafted (#1927 AC3 pair-lock)', async () => {
     const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
     const payload = buildBookCreatePayload(
-      { path: '/x', title: 'T', seriesPosition: 1.5 },
+      { path: '/x', title: 'T', seriesName: 'Custom Saga' },
+      { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'Provider Saga', position: 15 }] },
+      'importing',
+    );
+    expect(payload.seriesName).toBe('Custom Saga');
+    expect(payload.seriesPosition).toBeUndefined();
+  });
+
+  it('item supplies series + position 0 → item position 0 survives (#1927 AC3 falsy guard)', async () => {
+    const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
+    const payload = buildBookCreatePayload(
+      { path: '/x', title: 'T', seriesName: 'Prequels', seriesPosition: 0 },
+      { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'Provider Saga', position: 15 }] },
+      'importing',
+    );
+    expect(payload.seriesName).toBe('Prequels');
+    expect(payload.seriesPosition).toBe(0);
+  });
+
+  it('item OMITS series → defers to metadata primary, position 0 preserved (#1927 AC3/AC4 defer path)', async () => {
+    const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
+    const payload = buildBookCreatePayload(
+      { path: '/x', title: 'T' },
+      { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'S', position: 0 }] },
+      'importing',
+    );
+    expect(payload.seriesName).toBe('S');
+    expect(payload.seriesPosition).toBe(0);
+  });
+
+  it('item seriesName "   " (whitespace) → treated as absent, defers to metadata (#1927 AC5)', async () => {
+    const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
+    const payload = buildBookCreatePayload(
+      { path: '/x', title: 'T', seriesName: '   ', seriesPosition: 99 },
+      { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'Wax and Wayne', position: 1 }] },
+      'importing',
+    );
+    expect(payload.seriesName).toBe('Wax and Wayne');
+    expect(payload.seriesPosition).toBe(1);
+  });
+
+  it('item padded non-empty series " Saga " → item wins, name preserved VERBATIM (trim classifies only, #1927 AC5/F12)', async () => {
+    const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
+    const payload = buildBookCreatePayload(
+      { path: '/x', title: 'T', seriesName: ' Saga ', seriesPosition: 3 },
+      { title: 'T', authors: [{ name: 'A' }], series: [{ name: 'Provider Saga', position: 15 }] },
+      'importing',
+    );
+    expect(payload.seriesName).toBe(' Saga ');
+    expect(payload.seriesPosition).toBe(3);
+  });
+
+  it('item.seriesPosition: 1.5 with a series falls through when meta has no series (#1927 item-first)', async () => {
+    const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
+    const payload = buildBookCreatePayload(
+      { path: '/x', title: 'T', seriesName: 'Some Series', seriesPosition: 1.5 },
       { title: 'T', authors: [{ name: 'A' }] },
       'importing',
     );

--- a/src/server/services/enrichment-orchestration.helpers.ts
+++ b/src/server/services/enrichment-orchestration.helpers.ts
@@ -14,6 +14,7 @@ import { RateLimitError } from '../../core/index.js';
 import type { EnrichmentStatus } from '../../shared/schemas/enrichment.js';
 import { canonicalizeAsin } from '../../shared/asin.js';
 import { pickPrimarySeries } from '../../shared/pick-primary-series.js';
+import { resolveImportSeries } from './resolve-import-series.js';
 import { serializeError } from '../utils/serialize-error.js';
 
 
@@ -311,7 +312,12 @@ export function buildBookCreatePayload(
   meta: BookMetadata | null,
   status: 'imported' | 'importing',
 ) {
-  const primary = pickPrimarySeries(meta);
+  // Item-first, two-state, pair-locked series resolution (#1927) — shared with
+  // `copyToLibrary`'s `targetBook` so the DB record and the physical folder agree.
+  // A user's explicit series edit wins over the matched metadata's primary series;
+  // an absent (empty/whitespace) item series defers to metadata. `pickPrimarySeries`
+  // (`seriesPrimary` over `series[0]`, #1088/#1097) still selects the defer-path ref.
+  const series = resolveImportSeries(item, pickPrimarySeries(meta));
   return {
     title: item.title,
     // When metadata provides multiple authors (co-authored books), preserve the full array.
@@ -320,12 +326,8 @@ export function buildBookCreatePayload(
       ? meta.authors
       : (item.authorName ? [{ name: item.authorName }] : (meta?.authors?.length ? meta.authors : [])),
     narrators: item.narrators?.length ? item.narrators : meta?.narrators,
-    // Provider-truth precedence: accepted provider metadata wins over raw item/tag fields.
-    // Prefer the canonical primary-series ref over `series[0]` (#1088 / #1097) —
-    // `series[0]` on Audible can be a broader universe entry rather than the
-    // real book series. When `meta` is null (no provider match accepted), fall back to item-derived values.
-    seriesName: primary?.name ?? item.seriesName ?? undefined,
-    seriesPosition: primary?.position ?? (item.seriesPosition !== undefined ? item.seriesPosition : undefined),
+    seriesName: series.name,
+    seriesPosition: series.position,
     coverUrl: item.coverUrl || meta?.coverUrl,
     asin: item.asin || meta?.asin,
     isbn: meta?.isbn,

--- a/src/server/services/import-adapters/manual.test.ts
+++ b/src/server/services/import-adapters/manual.test.ts
@@ -1319,6 +1319,68 @@ describe('ManualImportAdapter', () => {
       }));
     });
 
+    it('worker rehydration: a non-empty user series + paired position survives the strict schema round-trip and WINS over matched metadata in the copy target (#1927 F6/AC2)', async () => {
+      // Full live chain: JSON → strict manualImportJobPayloadSchema parse → toImportConfirmItem →
+      // copyToLibrary. The user's `Custom Saga #7` must reach the folder target, NOT the matched
+      // metadata's `Provider Saga #2` — the item-first resolver runs at the persisted boundary.
+      const settingsSvc = createMockSettingsService({
+        library: { path: '/library', folderFormat: '{author}/{series} #{seriesPosition}/{title}', fileFormat: '' },
+      });
+      deps.settingsService = inject<SettingsService>(settingsSvc);
+      adapter = new ManualImportAdapter(deps);
+
+      const { copyToLibrary: stageSourceAudio } = await import('../../utils/import-steps.js');
+
+      const payload: ManualImportJobPayload = {
+        path: '/audiobooks/Author/Custom Saga 7/Test Book',
+        title: 'Test Book',
+        authorName: 'Author',
+        seriesName: 'Custom Saga',
+        seriesPosition: 7,
+        metadata: { title: 'Test Book', authors: [{ name: 'Author' }], seriesPrimary: { name: 'Provider Saga', position: 2 } },
+        mode: 'copy',
+      };
+      const job = makeJob({ metadata: JSON.stringify(payload) });
+      await adapter.process(job, ctx);
+
+      const expectedTarget = '/library/Author/Custom Saga #7/Test Book';
+      expect(vi.mocked(stageSourceAudio)).toHaveBeenCalledWith(expect.objectContaining({
+        sourcePath: payload.path,
+        targetPath: expectedTarget,
+      }));
+    });
+
+    it('worker rehydration: a whitespace-only seriesName defers to the matched metadata pair — no whitespace third state (#1927 F4/F10/AC5)', async () => {
+      // A non-React/persisted caller can submit `seriesName: "   "` (the schema accepts any string).
+      // The authoritative server resolver classifies it absent, so the copy target defers to the
+      // metadata pair (Provider Saga #2), NOT a whitespace folder or the item's orphan position 99.
+      const settingsSvc = createMockSettingsService({
+        library: { path: '/library', folderFormat: '{author}/{series} #{seriesPosition}/{title}', fileFormat: '' },
+      });
+      deps.settingsService = inject<SettingsService>(settingsSvc);
+      adapter = new ManualImportAdapter(deps);
+
+      const { copyToLibrary: stageSourceAudio } = await import('../../utils/import-steps.js');
+
+      const payload: ManualImportJobPayload = {
+        path: '/audiobooks/Author/Whitespace/Test Book',
+        title: 'Test Book',
+        authorName: 'Author',
+        seriesName: '   ',
+        seriesPosition: 99,
+        metadata: { title: 'Test Book', authors: [{ name: 'Author' }], seriesPrimary: { name: 'Provider Saga', position: 2 } },
+        mode: 'copy',
+      };
+      const job = makeJob({ metadata: JSON.stringify(payload) });
+      await adapter.process(job, ctx);
+
+      const expectedTarget = '/library/Author/Provider Saga #2/Test Book';
+      expect(vi.mocked(stageSourceAudio)).toHaveBeenCalledWith(expect.objectContaining({
+        sourcePath: payload.path,
+        targetPath: expectedTarget,
+      }));
+    });
+
     it('failure path: payload.narrators wins over payload.metadata.narrators[0] (F11/#1028)', async () => {
       const { copyToLibrary: stageSourceAudio } = await import('../../utils/import-steps.js');
       vi.mocked(stageSourceAudio).mockRejectedValueOnce(new Error('Disk full'));

--- a/src/server/services/import-orchestration.helpers.test.ts
+++ b/src/server/services/import-orchestration.helpers.test.ts
@@ -74,12 +74,13 @@ describe('copyToLibrary — token precedence (#1028)', () => {
     };
   }
 
-  it('meta.series[0] wins over item series fields (#1071 provider-truth precedence)', async () => {
+  it('item series fields win over meta.series[0] in the folder path (#1927 AC2 item-first)', async () => {
     const deps = buildDeps('{author}/{series} #{seriesPosition}/{title}');
-    // Item tags say `Mistborn #5`; provider match says `Wax and Wayne #1` — provider wins.
-    const targetPath = '/library/Author/Wax and Wayne #1/Title';
+    // The user edited Series to `The Dresden Files #10`; provider match says `Wax and Wayne #1`.
+    // Item-first (#1927): the physical folder must match the user's edit, not the metadata.
+    const targetPath = '/library/Author/The Dresden Files #10/Title';
     const path = await copyToLibrary(
-      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: 'Mistborn', seriesPosition: 5 },
+      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: 'The Dresden Files', seriesPosition: 10 },
       { title: 'Title', authors: [{ name: 'Author' }], series: [{ name: 'Wax and Wayne', position: 1 }] },
       'copy',
       deps,
@@ -99,12 +100,30 @@ describe('copyToLibrary — token precedence (#1028)', () => {
     expect(path.targetPath).toBe(targetPath);
   });
 
-  it('meta.series[0].position: 0 wins over item (#1071 falsy regression guard)', async () => {
+  it('item series with NO position → folder path uses item series, metadata position NOT grafted (#1927 AC3 pair-lock)', async () => {
     const deps = buildDeps('{author}/{series} #{seriesPosition}/{title}');
-    // Provider says position 0 (prequel); item tags say 5; provider wins, position 0 preserved.
+    // The user edited Series to `Custom Saga` with no position; provider match says `Provider Saga #15`.
+    // Pair-lock: the folder token must carry the item series with NO position — the metadata position
+    // must NOT be borrowed at this boundary (mirrors the DB-create case). The renderer emits a bare
+    // `#` for the empty position token; the assertion is that `#15` (and `Provider Saga`) never appear.
+    const targetPath = '/library/Author/Custom Saga #/Title';
+    const path = await copyToLibrary(
+      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: 'Custom Saga' },
+      { title: 'Title', authors: [{ name: 'Author' }], series: [{ name: 'Provider Saga', position: 15 }] },
+      'copy',
+      deps,
+    );
+    expect(path.targetPath).toBe(targetPath);
+    expect(path.targetPath).not.toContain('#15');
+    expect(path.targetPath).not.toContain('Provider Saga');
+  });
+
+  it('item OMITS series → folder path defers to meta.series[0], position 0 preserved (#1927 AC3 defer path)', async () => {
+    const deps = buildDeps('{author}/{series} #{seriesPosition}/{title}');
+    // No user series edit; provider says position 0 (prequel). Defer → metadata pair, 0 preserved.
     const targetPath = '/library/Author/Prequels #0/Title';
     const path = await copyToLibrary(
-      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: 'Prequels', seriesPosition: 5 },
+      { path: targetPath, title: 'Title', authorName: 'Author' },
       { title: 'Title', authors: [{ name: 'Author' }], series: [{ name: 'Prequels', position: 0 }] },
       'copy',
       deps,
@@ -112,12 +131,30 @@ describe('copyToLibrary — token precedence (#1028)', () => {
     expect(path.targetPath).toBe(targetPath);
   });
 
-  it('falls back to meta.series[0].position when item.seriesPosition is undefined', async () => {
+  it('item seriesName "   " (whitespace) → folder path defers to metadata (#1927 AC5 non-React-caller guard)', async () => {
     const deps = buildDeps('{author}/{series} #{seriesPosition}/{title}');
-    const targetPath = '/library/Author/Discworld #99/Title';
+    // A whitespace-only seriesName (a non-React/persisted caller can submit one) classifies as
+    // absent at the shared resolver, so the folder path defers to the matched metadata pair.
+    const targetPath = '/library/Author/Wax and Wayne #1/Title';
     const path = await copyToLibrary(
-      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: 'Discworld' },
-      { title: 'Title', authors: [{ name: 'Author' }], series: [{ name: 'Discworld', position: 99 }] },
+      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: '   ', seriesPosition: 99 },
+      { title: 'Title', authors: [{ name: 'Author' }], series: [{ name: 'Wax and Wayne', position: 1 }] },
+      'copy',
+      deps,
+    );
+    expect(path.targetPath).toBe(targetPath);
+  });
+
+  it('padded item series " Saga " wins over a DIFFERENT metadata primary; renderer sanitizes to "Saga" (#1927 AC5/F12)', async () => {
+    const deps = buildDeps('{author}/{series} #{seriesPosition}/{title}');
+    // Item ` Saga ` #3 vs metadata `Other` #2 — the sanitized `Saga #3` segment can ONLY come
+    // from the item, proving item-first won. The renderer's existing sanitizePath trims the
+    // padding to `Saga` on disk (parity with the pre-change metadata-first path output);
+    // this change adds NO new canonicalization (F13, out of scope).
+    const targetPath = '/library/Author/Saga #3/Title';
+    const path = await copyToLibrary(
+      { path: targetPath, title: 'Title', authorName: 'Author', seriesName: ' Saga ', seriesPosition: 3 },
+      { title: 'Title', authors: [{ name: 'Author' }], series: [{ name: 'Other', position: 2 }] },
       'copy',
       deps,
     );

--- a/src/server/services/import-orchestration.helpers.ts
+++ b/src/server/services/import-orchestration.helpers.ts
@@ -26,6 +26,7 @@ import type { ConnectorService } from './connector.service.js';
 import type { ImportConfirmItem, ImportMode } from './library-scan.service.js';
 import { serializeError } from '../utils/serialize-error.js';
 import { pickPrimarySeries } from '../../shared/pick-primary-series.js';
+import { resolveImportSeries } from './resolve-import-series.js';
 
 
 export interface ImportPipelineDeps {
@@ -243,15 +244,18 @@ export async function copyToLibrary(
 
   const librarySettings = await settingsService.get('library');
   const namingOptions = toNamingOptions(librarySettings);
-  // Provider-truth precedence: accepted provider metadata wins over raw item/tag fields.
-  // Prefer canonical `seriesPrimary` over `series[0]` (#1088 / #1097) — `series[0]`
-  // on Audible can be a broader universe entry rather than the real book series.
-  // When `meta` is null (no provider match accepted), fall back to item-derived values.
-  const metaPrimarySeries = pickPrimarySeries(meta);
+  // Item-first, two-state, pair-locked series resolution (#1927) — the SAME shared
+  // resolver `buildBookCreatePayload` uses, so the physical library folder and the
+  // stored DB record resolve the series identically. A user's explicit series edit
+  // wins; an absent (empty/whitespace) item series defers to the matched metadata's
+  // primary (`pickPrimarySeries`: `seriesPrimary` over `series[0]`, #1088/#1097). The
+  // resolver preserves a padded name verbatim; `buildTargetPath`/`sanitizePath` below
+  // is the sole on-disk normalizer, unchanged by this work.
+  const series = resolveImportSeries(item, pickPrimarySeries(meta));
   const targetBook = {
     title: item.title,
-    seriesName: metaPrimarySeries?.name ?? item.seriesName ?? undefined,
-    seriesPosition: metaPrimarySeries?.position ?? (item.seriesPosition !== undefined ? item.seriesPosition : undefined),
+    seriesName: series.name,
+    seriesPosition: series.position,
     narrators: item.narrators?.length
       ? item.narrators.map(name => ({ name }))
       : (meta?.narrators?.length ? meta.narrators.map(n => ({ name: n })) : undefined),

--- a/src/server/services/import-submission-runner.integration.test.ts
+++ b/src/server/services/import-submission-runner.integration.test.ts
@@ -824,4 +824,111 @@ describe('ImportSubmissionRunner (DB-backed, #1893)', () => {
       expect(hB!.status).toBe('complete');
     });
   });
+
+  // #1925: within-scan title collisions no longer hard-flag at scan time — both folders flow
+  // through as NON-forced confirm items in ONE submission. The runner processes them in ascending
+  // ordinal, committing the first before classifying the second, so the SECOND item's
+  // classifyConfirmItem → findDuplicate → resolveRecordingIdentity runs over the matched metadata
+  // both rows carry (persisted onto the first's placeholder via buildBookCreatePayload). These pin
+  // the three confirm-ladder outcomes; none uses forceImport (the decision must reach the ladder).
+  describe('within-scan sibling confirm-ladder outcomes (#1925 AC6/AC7)', () => {
+    /** A NON-forced staged item whose matched metadata carries the identity signals the ladder reads. */
+    function ladderItem(
+      path: string,
+      title: string,
+      opts: { author?: string; narrators?: string[]; asin?: string; duration?: number } = {},
+    ): StagedImportItem {
+      const author = opts.author ?? 'J.K. Rowling';
+      return {
+        path,
+        title,
+        authorName: author,
+        ...(opts.narrators ? { narrators: opts.narrators } : {}),
+        ...(opts.asin ? { asin: opts.asin } : {}),
+        metadata: {
+          title,
+          authors: [{ name: author }],
+          ...(opts.narrators ? { narrators: opts.narrators } : {}),
+          ...(opts.asin ? { asin: opts.asin } : {}),
+          ...(opts.duration !== undefined ? { duration: opts.duration } : {}),
+        },
+      };
+    }
+
+    async function orderedItems(subId: number) {
+      return db.select().from(importSubmissionItems)
+        .where(eq(importSubmissionItems.submissionId, subId))
+        .orderBy(asc(importSubmissionItems.ordinal));
+    }
+
+    it('AC6 same-edition decisive signal (equal canonical ASIN): first imports, second → same-recording skip; ONE book', async () => {
+      const subId = await seedProcessing([
+        ladderItem('/hp/a', 'Harry Potter', { narrators: ['Jim Dale'], asin: 'B0EQUALASIN' }),
+        ladderItem('/hp/b', 'Harry Potter', { narrators: ['Jim Dale'], asin: 'B0EQUALASIN' }),
+      ]);
+
+      await drainAll();
+
+      const rows = await orderedItems(subId);
+      expect(rows[0]!.disposition).toBe('accepted');
+      expect(rows[1]!.disposition).toBe('skipped');
+      expect(rows[1]!.reason).toBe('already-in-library');
+      // The skip carries the incumbent id+title → surfaced as "already in your library as '{title}'".
+      expect(rows[1]!.existingBookId).toBe(rows[0]!.bookId);
+      expect(rows[1]!.existingTitle).toBe('Harry Potter');
+      // Never two identical books — one imported, one skipped-with-report.
+      expect(await db.select().from(books)).toHaveLength(1);
+    });
+
+    it('AC6 no usable identity signal (title+author only, no narrator/ASIN): first imports, second → review held; ONE book, ONE held', async () => {
+      const subId = await seedProcessing([
+        ladderItem('/hp/a', 'Harry Potter', { narrators: ['Jim Dale'] }),
+        ladderItem('/hp/b', 'Harry Potter'), // no narrator or ASIN signal on the comparison
+      ]);
+
+      await drainAll();
+
+      const rows = await orderedItems(subId);
+      expect(rows[0]!.disposition).toBe('accepted');
+      expect(rows[1]!.disposition).toBe('held');
+      expect(rows[1]!.reason).toBe('recording-review-required');
+      // One imported, one held (NOT skipped, NOT a second import).
+      expect(await db.select().from(books)).toHaveLength(1);
+      const [h] = await db.select().from(importSubmissions).where(eq(importSubmissions.id, subId));
+      expect(h!.acceptedCount).toBe(1);
+      expect(h!.heldCount).toBe(1);
+    });
+
+    it('AC7 distinct editions (single narrator vs NAMED full-cast, unequal ASINs): both import; TWO books', async () => {
+      const subId = await seedProcessing([
+        ladderItem('/hp/a', 'Harry Potter', { narrators: ['Jim Dale'], asin: 'B0JIMDALE' }),
+        // Named full-cast members — NOT the literal "Full Cast" placeholder — so the sets compare not-equal.
+        ladderItem('/hp/b', 'Harry Potter', { narrators: ['Hugh Laurie', 'Cush Jumbo'], asin: 'B0FULLCAST' }),
+      ]);
+
+      await drainAll();
+
+      const rows = await orderedItems(subId);
+      expect(rows.every((r) => r.disposition === 'accepted')).toBe(true);
+      // different-recording for the second row → both import as distinct editions (#1712).
+      expect(await db.select().from(books)).toHaveLength(2);
+    });
+
+    it('AC7 negative control (Tehanu shape — different ASIN, EQUAL narrator): second → same-recording skip; ONE book', async () => {
+      // A distinct matched ASIN ALONE does not yield two books: unequal ASINs defer to the narrator
+      // ladder, and an equal narrator (with agreeing duration) resolves same-recording → skip.
+      const subId = await seedProcessing([
+        ladderItem('/te/a', 'Tehanu', { author: 'Ursula K. Le Guin', narrators: ['Jenny Sterlin'], asin: 'B0OLDTEHANU', duration: 420 }),
+        ladderItem('/te/b', 'Tehanu', { author: 'Ursula K. Le Guin', narrators: ['Jenny Sterlin'], asin: 'B0NEWTEHANU', duration: 420 }),
+      ]);
+
+      await drainAll();
+
+      const rows = await orderedItems(subId);
+      expect(rows[0]!.disposition).toBe('accepted');
+      expect(rows[1]!.disposition).toBe('skipped');
+      expect(rows[1]!.reason).toBe('already-in-library');
+      expect(await db.select().from(books)).toHaveLength(1);
+    });
+  });
 });

--- a/src/server/services/library-scan.helpers.test.ts
+++ b/src/server/services/library-scan.helpers.test.ts
@@ -7,6 +7,7 @@ import { inject } from '../__tests__/helpers.js';
 import {
   buildDiscoveredBook,
   getAudioStats,
+  type BuildDiscoveredBookOptions,
 } from './library-scan.helpers.js';
 
 function createMockLog() {
@@ -53,7 +54,6 @@ describe('buildDiscoveredBook', () => {
         isDuplicate: true,
         existingBookId: 42,
         duplicateReason: 'slug',
-        duplicateFirstPath: '/audiobooks/Author/Book Original',
       },
     );
 
@@ -61,7 +61,6 @@ describe('buildDiscoveredBook', () => {
       isDuplicate: true,
       existingBookId: 42,
       duplicateReason: 'slug',
-      duplicateFirstPath: '/audiobooks/Author/Book Original',
     });
   });
 
@@ -75,8 +74,32 @@ describe('buildDiscoveredBook', () => {
 
     expect(result).not.toHaveProperty('existingBookId');
     expect(result).not.toHaveProperty('duplicateReason');
-    expect(result).not.toHaveProperty('duplicateFirstPath');
     expect(result).not.toHaveProperty('reviewReason');
+  });
+
+  it('never emits duplicateFirstPath even when a legacy caller passes it (removal is load-bearing, #1925 F1)', () => {
+    // The scan-only first-path field was removed with the within-scan hard-flag. This is a
+    // deletion-heuristic guard: a legacy caller supplying it (cast past the now-narrowed options
+    // type) must NOT round-trip it. Reintroducing the destructure/spread in buildDiscoveredBook
+    // would make this fail — without it, the field could silently return while the suite stays green.
+    const legacyOptions = {
+      isDuplicate: true,
+      duplicateReason: 'slug',
+      duplicateFirstPath: '/audiobooks/Author/Original',
+    } as unknown as BuildDiscoveredBookOptions;
+
+    const result = buildDiscoveredBook(
+      '/audiobooks/Author/Book',
+      { title: 'Book', author: 'Author', series: null },
+      3,
+      100,
+      legacyOptions,
+    );
+
+    expect(result).not.toHaveProperty('duplicateFirstPath');
+    // Sanity: the still-supported fields DO round-trip, so the assertion above isn't vacuously green.
+    expect(result.isDuplicate).toBe(true);
+    expect(result.duplicateReason).toBe('slug');
   });
 
   describe('parsedSeriesPosition (#1042)', () => {
@@ -134,7 +157,6 @@ describe('buildDiscoveredBook', () => {
       expect(r.isDuplicate).toBe(true);
       expect(r).not.toHaveProperty('existingBookId');
       expect(r).not.toHaveProperty('duplicateReason');
-      expect(r).not.toHaveProperty('duplicateFirstPath');
       expect(r).not.toHaveProperty('reviewReason');
     });
 
@@ -147,11 +169,6 @@ describe('buildDiscoveredBook', () => {
     it('duplicateReason alone', () => {
       const r = buildDiscoveredBook(...baseArgs, { duplicateReason: 'path' });
       expect(r.duplicateReason).toBe('path');
-    });
-
-    it('duplicateFirstPath alone', () => {
-      const r = buildDiscoveredBook(...baseArgs, { duplicateFirstPath: '/orig' });
-      expect(r.duplicateFirstPath).toBe('/orig');
     });
 
     it('reviewReason alone', () => {

--- a/src/server/services/library-scan.helpers.ts
+++ b/src/server/services/library-scan.helpers.ts
@@ -54,8 +54,7 @@ export async function getAudioStats(path: string, log: FastifyBaseLogger): Promi
 export interface BuildDiscoveredBookOptions {
   isDuplicate?: boolean | undefined;
   existingBookId?: number | undefined;
-  duplicateReason?: 'path' | 'slug' | 'within-scan' | undefined;
-  duplicateFirstPath?: string | undefined;
+  duplicateReason?: 'path' | 'slug' | undefined;
   reviewReason?: string | undefined;
 }
 
@@ -67,7 +66,7 @@ export function buildDiscoveredBook(
   totalSize: number,
   options: BuildDiscoveredBookOptions = {},
 ): DiscoveredBook {
-  const { isDuplicate = false, existingBookId, duplicateReason, duplicateFirstPath, reviewReason } = options;
+  const { isDuplicate = false, existingBookId, duplicateReason, reviewReason } = options;
   return {
     path,
     parsedTitle: parsed.title,
@@ -79,7 +78,6 @@ export function buildDiscoveredBook(
     isDuplicate,
     ...(existingBookId !== undefined && { existingBookId }),
     ...(duplicateReason !== undefined && { duplicateReason }),
-    ...(duplicateFirstPath !== undefined && { duplicateFirstPath }),
     ...(reviewReason !== undefined && { reviewReason }),
   };
 }

--- a/src/server/services/library-scan.service.test.ts
+++ b/src/server/services/library-scan.service.test.ts
@@ -7,7 +7,7 @@ import type { BookImportService } from './book-import.service.js';
 import type { MetadataService } from './metadata.service.js';
 import type { SettingsService } from './settings.service.js';
 import type { EventHistoryService } from './event-history.service.js';
-import { parseFolderStructure, extractYear, LibraryScanService } from './library-scan.service.js';
+import { parseFolderStructure, extractYear, LibraryScanService, SCAN_WITHIN_SCAN_REVIEW_HINT, SCAN_RECORDING_REVIEW_HINT } from './library-scan.service.js';
 import { books } from '../../db/schema.js';
 import { buildTitleShape } from '../../shared/dedup.js';
 
@@ -636,7 +636,7 @@ describe('LibraryScanService', () => {
         expect(result.discoveries[0]!.reviewReason).toBeDefined();
       });
 
-      it('within-scan duplicate check is case-insensitive on title', async () => {
+      it('within-scan title collision is case-insensitive on title (second carries the hint, not a hard flag) (#1925)', async () => {
         vi.mocked(discoverBooks).mockResolvedValue([
           { path: '/audiobooks/Author/the way of kings', folderParts: ['Author', 'the way of kings'], audioFileCount: 1, totalSize: 100 },
           { path: '/audiobooks/Author/The Way Of Kings', folderParts: ['Author', 'The Way Of Kings'], audioFileCount: 2, totalSize: 200 },
@@ -645,9 +645,11 @@ describe('LibraryScanService', () => {
 
         const result = await service.scanDirectory('/audiobooks');
 
-        const dups = result.discoveries.filter(d => d.isDuplicate);
-        expect(dups).toHaveLength(1);
-        expect(dups[0]!.duplicateReason).toBe('within-scan');
+        // Neither folder is hard-flagged — both flow through to the match/confirm ladder.
+        expect(result.discoveries.filter(d => d.isDuplicate)).toHaveLength(0);
+        expect(result.discoveries[0]!.reviewReason).toBeUndefined();
+        expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
+        expect(result.discoveries[1]).not.toHaveProperty('duplicateReason');
       });
 
       it('does not check title+author duplicate when parsed title is empty; folder is not marked isDuplicate', async () => {
@@ -1149,7 +1151,7 @@ describe('scanDirectory() — duplicateReason field (#133)', () => {
       expect(result.discoveries[0]!.reviewReason).toBe(REVIEW_REASON);
     });
 
-    it('within-scan duplicate branch preserves reviewReason', async () => {
+    it('within-scan collision branch preserves an existing reviewReason over the within-scan hint (#1925)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { ...folder, path: '/audiobooks/a/Author/Title' },
         { ...folder, path: '/audiobooks/b/Author/Title' },
@@ -1158,7 +1160,10 @@ describe('scanDirectory() — duplicateReason field (#133)', () => {
 
       const result = await service.scanDirectory('/audiobooks');
 
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
+      // No hard flag; the upstream reviewReason wins over SCAN_WITHIN_SCAN_REVIEW_HINT
+      // via the `reviewReason ?? hint` fallback (mirrors branch 3).
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]).not.toHaveProperty('duplicateReason');
       expect(result.discoveries[1]!.reviewReason).toBe(REVIEW_REASON);
     });
 
@@ -1693,7 +1698,7 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
   }
 
   describe('happy path', () => {
-    it('two folders with same title+author slug → second flagged isDuplicate with duplicateReason=within-scan', async () => {
+    it('two folders with same title+author slug → second flows through as a normal candidate carrying the within-scan hint (#1925)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Copy/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1703,11 +1708,45 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const result = await service.scanDirectory('/audiobooks');
 
       expect(result.discoveries).toHaveLength(2);
-      expect(result.discoveries[1]!.isDuplicate).toBe(true);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
+      // No hard flag — the recording ladder decides identity at confirm time.
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
+      expect(result.discoveries[1]).not.toHaveProperty('duplicateReason');
     });
 
-    it('first folder of a within-scan duplicate pair remains isDuplicate=false', async () => {
+    it('clean-slate pair with DIFFERENT bracketed folder ASINs, same title+author → both normal candidates; second carries the within-scan hint (#1925 F3, motivating case)', async () => {
+      // The motivating scenario from the issue: two editions of one title (Jim Dale vs Full-Cast)
+      // distinguished ONLY by their bracketed folder ASIN — which is parsed but intentionally NOT
+      // threaded to the match job. With an EMPTY library the ASIN is never decisive (branch 2 needs
+      // an incumbent), so both folders take the normal-candidate branch-4 path; the recording ladder
+      // (not scan-time title-pairing) decides identity later.
+      // Precondition: the parser extracts DISTINCT ASINs yet the SAME title — so the ASIN is the sole discriminator.
+      const parsedA = parseFolderStructure(['J.K. Rowling', 'Harry Potter and the Goblet of Fire [B0JIMDALE1]']);
+      const parsedB = parseFolderStructure(['J.K. Rowling', 'Harry Potter and the Goblet of Fire (Full-Cast Edition) [B0F14PB6WN]']);
+      expect(parsedA.asin).toBe('B0JIMDALE1');
+      expect(parsedB.asin).toBe('B0F14PB6WN');
+      expect(parsedA.title).toBe(parsedB.title);
+
+      vi.mocked(discoverBooks).mockResolvedValue([
+        { path: '/audiobooks/J.K. Rowling/04 - Goblet (Jim Dale)', folderParts: ['J.K. Rowling', 'Harry Potter and the Goblet of Fire [B0JIMDALE1]'], audioFileCount: 3, totalSize: 100 },
+        { path: '/audiobooks/J.K. Rowling/Goblet (Full-Cast) [B0F14PB6WN]', folderParts: ['J.K. Rowling', 'Harry Potter and the Goblet of Fire (Full-Cast Edition) [B0F14PB6WN]'], audioFileCount: 3, totalSize: 100 },
+      ]);
+      mockPreFetch([], []); // clean-slate: empty DB
+
+      const result = await service.scanDirectory('/audiobooks');
+
+      expect(result.discoveries[0]!.isDuplicate).toBe(false);
+      expect(result.discoveries[0]).not.toHaveProperty('reviewReason');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
+      // Neither carries the removed duplicate fields — both flow through to the match/confirm ladder.
+      for (const d of result.discoveries) {
+        expect(d).not.toHaveProperty('duplicateReason');
+        expect(d).not.toHaveProperty('duplicateFirstPath');
+      }
+    });
+
+    it('first folder of a within-scan collision pair is a plain candidate — no flag, no hint', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Copy/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1718,9 +1757,10 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
       expect(result.discoveries[0]).not.toHaveProperty('duplicateReason');
+      expect(result.discoveries[0]).not.toHaveProperty('reviewReason');
     });
 
-    it('within-scan duplicate has duplicateFirstPath set to first discovery path', async () => {
+    it('within-scan second folder carries the display hint, not a first-path pointer (#1925)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Copy/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1729,10 +1769,10 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       const result = await service.scanDirectory('/audiobooks');
 
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/Title');
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
-    it('within-scan duplicate has no existingBookId', async () => {
+    it('within-scan hinted row has no existingBookId', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Copy/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1746,7 +1786,7 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
   });
 
   describe('boundary values', () => {
-    it('three+ folders with same title+author → second and third both flagged as within-scan duplicates referencing first path', async () => {
+    it('three+ folders with same title+author → the second and later each carry the hint; the first does not (#1925)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/a/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/b/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1756,16 +1796,14 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       const result = await service.scanDirectory('/audiobooks');
 
-      expect(result.discoveries[0]!.isDuplicate).toBe(false);
-      expect(result.discoveries[1]!.isDuplicate).toBe(true);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/a/Author/Title');
-      expect(result.discoveries[2]!.isDuplicate).toBe(true);
-      expect(result.discoveries[2]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[2]!.duplicateFirstPath).toBe('/audiobooks/a/Author/Title');
+      // None hard-flagged; all flow through to the match/confirm ladder.
+      expect(result.discoveries.every(d => !d.isDuplicate)).toBe(true);
+      expect(result.discoveries[0]).not.toHaveProperty('reviewReason');
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
+      expect(result.discoveries[2]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
-    it('single folder with no duplicate → isDuplicate=false, no duplicateReason, no duplicateFirstPath', async () => {
+    it('single folder with no collision → isDuplicate=false, no duplicateReason, no hint', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
       ]);
@@ -1776,10 +1814,10 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       expect(result.discoveries).toHaveLength(1);
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
       expect(result.discoveries[0]).not.toHaveProperty('duplicateReason');
-      expect(result.discoveries[0]).not.toHaveProperty('duplicateFirstPath');
+      expect(result.discoveries[0]).not.toHaveProperty('reviewReason');
     });
 
-    it('slug case normalization — different casing of same author produces same slug and triggers within-scan dedup', async () => {
+    it('slug case normalization — different casing of same author produces same slug and hints the second folder', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Brandon Sanderson/Title', folderParts: ['Brandon Sanderson', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/brandon sanderson/Title', folderParts: ['brandon sanderson', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1788,8 +1826,8 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       const result = await service.scanDirectory('/audiobooks');
 
-      expect(result.discoveries[1]!.isDuplicate).toBe(true);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
   });
 
@@ -1803,8 +1841,10 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       const result = await service.scanDirectory('/audiobooks');
 
+      // No author → no title+author shape → no collision → no within-scan hint on the second.
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
       expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]).not.toHaveProperty('reviewReason');
     });
 
     it('two folders with empty/falsy title → not deduplicated within scan', async () => {
@@ -1818,6 +1858,7 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
       expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]).not.toHaveProperty('reviewReason');
     });
   });
 
@@ -1832,7 +1873,7 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       expect(result.discoveries[0]!.isDuplicate).toBe(true);
       expect(result.discoveries[0]!.duplicateReason).toBe('path');
-      expect(result.discoveries[0]).not.toHaveProperty('duplicateFirstPath');
+      expect(result.discoveries[0]).not.toHaveProperty('reviewReason');
     });
 
     it('folder matching DB by slug → review-hint candidate, not checked for within-scan (#1711 F6)', async () => {
@@ -1847,7 +1888,7 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
       expect(result.discoveries[0]!.reviewReason).toBeDefined();
-      expect(result.discoveries[0]).not.toHaveProperty('duplicateFirstPath');
+      expect(result.discoveries[0]!.existingBookId).toBe(99);
     });
 
     it('mixed scan: DB path dup + DB slug dup + within-scan dup + new folder → each has correct flag and reason', async () => {
@@ -1867,17 +1908,42 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       expect(result.discoveries[0]!.duplicateReason).toBe('path');
       // Second: DB title+author match → review-hint candidate, NOT a hard duplicate (#1711 F6).
       expect(result.discoveries[1]!.isDuplicate).toBe(false);
-      expect(result.discoveries[1]!.reviewReason).toBeDefined();
       expect(result.discoveries[1]!.existingBookId).toBe(42);
-      // Third: same title+author → also a review-hint candidate (the title+author branch
-      // continues before the within-scan map is populated, so it is never a within-scan dup).
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_RECORDING_REVIEW_HINT);
+      // Third: matches DB BookB (id 42) AND the registered sibling (discovery[1]). Branch 3
+      // precedes branch 4, so it MUST carry the existing-library hint + existingBookId — NOT the
+      // within-scan hint. Asserting both distinguishes branch 3 from branch 4 (which would drop
+      // existingBookId and substitute SCAN_WITHIN_SCAN_REVIEW_HINT) — the vacuity F2 flagged.
       expect(result.discoveries[2]!.isDuplicate).toBe(false);
-      expect(result.discoveries[2]!.reviewReason).toBeDefined();
+      expect(result.discoveries[2]!.existingBookId).toBe(42);
+      expect(result.discoveries[2]!.reviewReason).toBe(SCAN_RECORDING_REVIEW_HINT);
+      expect(result.discoveries[2]!.reviewReason).not.toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
       // Fourth: new discovery
       expect(result.discoveries[3]!.isDuplicate).toBe(false);
     });
 
-    it('first occurrence is DB path duplicate → still registers, so second occurrence is a within-scan dup (#1891)', async () => {
+    it('branch-3-over-branch-4 precedence: a folder matching an existing library book AND a sibling scan row gets the existing-library hint + existingBookId, NOT the within-scan hint (#1925 F2)', async () => {
+      // Two same-title+author folders where the DB already owns that title. The FIRST folder
+      // already matches the DB (branch 3). The SECOND matches BOTH the DB row AND the registered
+      // first sibling — branch 3 must win over branch 4.
+      vi.mocked(discoverBooks).mockResolvedValue([
+        { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
+        { path: '/audiobooks/Copy/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
+      ]);
+      mockDb.select
+        .mockReturnValueOnce(mockDbChain([]))
+        .mockReturnValueOnce(mockDbChain([{ id: 77, title: 'Title', slug: 'author' }]));
+
+      const result = await service.scanDirectory('/audiobooks');
+
+      // The second folder takes branch-3 treatment, not the within-scan hint.
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.existingBookId).toBe(77);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_RECORDING_REVIEW_HINT);
+      expect(result.discoveries[1]!.reviewReason).not.toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
+    });
+
+    it('first occurrence is DB path duplicate → still registers, so second occurrence gets the within-scan hint (#1891/#1925)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Copy/Author/Title', folderParts: ['Author', 'Title'], audioFileCount: 3, totalSize: 100 },
@@ -1893,18 +1959,18 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       // which branch emitted it, so the path-dup row IS added to the within-scan bucket.
       expect(result.discoveries[0]!.duplicateReason).toBe('path');
       // Second: not in DB by path/title, but pairwise-matches the registered first row →
-      // within-scan duplicate of it.
-      expect(result.discoveries[1]!.isDuplicate).toBe(true);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/Title');
+      // a normal candidate carrying the within-scan hint (proving the path-dup row registered).
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
   });
 
   describe('pairwise non-transitive title matching (#1891)', () => {
-    it('non-transitive chain: a within-scan-dup row still registers, so a later row matches IT not the first (branch 4)', async () => {
-      // Series: A (row1, normal) — Series (row2, within-scan dup of row1) — Series: B
-      // (row3). row3 ≁ row1 (distinct subtitles) but ~ row2 (bare bridges) → row3's
-      // first-match is row2, proving the within-scan-dup row2 registered.
+    it('non-transitive chain: a hinted within-scan row still registers, so a later row matches IT not the first (branch 4)', async () => {
+      // Series: A (row1, normal) — Series (row2, within-scan collision of row1) — Series: B
+      // (row3). row3 ≁ row1 (distinct subtitles) but ~ row2 (bare bridges). row3 gets the
+      // hint ONLY because row2 registered — row1 alone does not match row3 — so the hint on
+      // row3 proves the within-scan-hinted row2 registered into the bucket.
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/SeriesA', folderParts: ['Author', 'Series: A'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Author/Series', folderParts: ['Author', 'Series'], audioFileCount: 3, totalSize: 100 },
@@ -1915,13 +1981,12 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const result = await service.scanDirectory('/audiobooks');
 
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/SeriesA');
-      expect(result.discoveries[2]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[2]!.duplicateFirstPath).toBe('/audiobooks/Author/Series');
+      expect(result.discoveries[0]).not.toHaveProperty('reviewReason');
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT); // matched row1
+      expect(result.discoveries[2]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT); // matched row2 (proves it registered)
     });
 
-    it('existing-library review-hint row registers, so a non-transitive later row is a within-scan dup of it (branch 3)', async () => {
+    it('existing-library review-hint row registers, so a non-transitive later row is a within-scan collision of it (branch 3)', async () => {
       // DB owns "Series: A". row1 bare "Series" bridges to it → existing-title hint
       // AND registers. row2 "Series: B" ≁ DB "Series: A" but ~ row1 "Series".
       vi.mocked(discoverBooks).mockResolvedValue([
@@ -1935,11 +2000,11 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
       expect(result.discoveries[0]!.existingBookId).toBe(50);
       expect(result.discoveries[0]!.reviewReason).toBeDefined();
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/Series');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
-    it('decisive-ASIN row registers, so a later same-base row is a within-scan dup of it (branch 2)', async () => {
+    it('decisive-ASIN row registers, so a later same-base row is a within-scan collision of it (branch 2)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/SeriesAsin', folderParts: ['Author', 'Series [B01ABC0001]'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Author/Series', folderParts: ['Author', 'Series'], audioFileCount: 3, totalSize: 100 },
@@ -1952,8 +2017,8 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const result = await service.scanDirectory('/audiobooks');
 
       expect(result.discoveries[0]!.duplicateReason).toBe('slug'); // decisive ASIN
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/SeriesAsin');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
     it('retrieval invariant: existing "Dune (Edition: Deluxe)" and scanned "Dune" share the colonBase bucket', async () => {
@@ -1982,7 +2047,7 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       expect(result.discoveries[0]).not.toHaveProperty('existingBookId');
     });
 
-    it('distinct-subtitle siblings are NOT within-scan duplicates', async () => {
+    it('distinct-subtitle siblings are NOT within-scan collisions (no hint)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Beyond', folderParts: ['Author', 'WoW: Beyond'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Author/Tides', folderParts: ['Author', 'WoW: Tides'], audioFileCount: 3, totalSize: 100 },
@@ -1992,9 +2057,10 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const result = await service.scanDirectory('/audiobooks');
 
       expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]).not.toHaveProperty('reviewReason');
     });
 
-    it('bare/subtitle bridge still collides within a scan', async () => {
+    it('bare/subtitle bridge still collides within a scan (hints the second)', async () => {
       vi.mocked(discoverBooks).mockResolvedValue([
         { path: '/audiobooks/Author/Series', folderParts: ['Author', 'Series'], audioFileCount: 3, totalSize: 100 },
         { path: '/audiobooks/Author/SeriesA', folderParts: ['Author', 'Series: A'], audioFileCount: 3, totalSize: 100 },
@@ -2003,8 +2069,8 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
 
       const result = await service.scanDirectory('/audiobooks');
 
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/Series');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
     it('existing-library multi-match resolves to the LOWEST matching books.id, and pins the orderBy(books.id) contract (F1)', async () => {
@@ -2053,8 +2119,8 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const result = await service.scanDirectory('/audiobooks');
 
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Frank Herbert/DuneBook1');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
     it('within-scan retrieval invariant across a colon-bearing preserved suffix ("Saga, Book 1: Deluxe" → "Saga") (F7)', async () => {
@@ -2074,8 +2140,8 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const result = await service.scanDirectory('/audiobooks');
 
       expect(result.discoveries[0]!.isDuplicate).toBe(false);
-      expect(result.discoveries[1]!.duplicateReason).toBe('within-scan');
-      expect(result.discoveries[1]!.duplicateFirstPath).toBe('/audiobooks/Author/SagaDeluxe');
+      expect(result.discoveries[1]!.isDuplicate).toBe(false);
+      expect(result.discoveries[1]!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
     });
 
     it('path match outranks a simultaneous decisive-ASIN AND title+author collision (F5)', async () => {
@@ -2126,13 +2192,13 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
     // separator, so the fixture is platform-unconstructible (path.join inside the real
     // discoverBooks re-keys every mocked entry and the collision premise dissolves).
     // The comparator itself stays covered cross-platform by path-order.test.ts.
-    it.skipIf(process.platform === 'win32')('sorted discovery makes duplicateFirstPath stable across readdir permutations, through the REAL discoverBooks (F3)', async () => {
+    it.skipIf(process.platform === 'win32')('sorted discovery makes the within-scan hint placement stable across readdir permutations, through the REAL discoverBooks (F3)', async () => {
       // Cross-boundary regression: delegate the mocked discoverBooks to the ACTUAL
       // implementation so its `results.sort(comparePosixPath)` runs in-path. A
       // folded-key collision pair — nested `/root/a/b` and one literal folder `/root/a\b`
-      // (both parse to author "a" / title "b", so the second is a within-scan dup of the
-      // first) — is served in two readdir permutations. Because discoverBooks sorts,
-      // duplicateFirstPath is identical across both; deleting the sort makes it
+      // (both parse to author "a" / title "b", so the second is a within-scan collision of the
+      // first) — is served in two readdir permutations. Because discoverBooks sorts, the
+      // hint lands on the SAME folder across both; deleting the sort makes it
       // readdir-order dependent and fails this test.
       const actual = await vi.importActual<typeof import('../../core/utils/book-discovery.js')>(
         '../../core/utils/book-discovery.js',
@@ -2177,12 +2243,14 @@ describe('scanDirectory() — within-scan duplicate detection (#342)', () => {
       const permA = await runScan([nested, literal]);
       const permB = await runScan([literal, nested]);
 
-      // '/' (0x2f) sorts before '\\' (0x5c), so `/root/a/b` is always first → the normal
-      // row; `/root/a\b` is always the within-scan dup pointing back at it — in BOTH runs.
+      // '/' (0x2f) sorts before '\\' (0x5c), so `/root/a/b` is always first → the plain
+      // candidate (no hint); `/root/a\b` is always the within-scan collision carrying the
+      // hint — in BOTH runs.
       for (const perm of [permA, permB]) {
         expect(perm.get('/root/a/b')!.isDuplicate).toBe(false);
-        expect(perm.get('/root/a\\b')!.duplicateReason).toBe('within-scan');
-        expect(perm.get('/root/a\\b')!.duplicateFirstPath).toBe('/root/a/b');
+        expect(perm.get('/root/a/b')).not.toHaveProperty('reviewReason');
+        expect(perm.get('/root/a\\b')!.isDuplicate).toBe(false);
+        expect(perm.get('/root/a\\b')!.reviewReason).toBe(SCAN_WITHIN_SCAN_REVIEW_HINT);
       }
     });
   });

--- a/src/server/services/library-scan.service.ts
+++ b/src/server/services/library-scan.service.ts
@@ -34,7 +34,17 @@ export type ImportMode = 'copy' | 'move';
  * existing library book but carries no decisive ASIN. Display-only; the match job
  * later replaces it with the authoritative recording verdict once narrators exist.
  */
-const SCAN_RECORDING_REVIEW_HINT = 'Possible match to an existing book — checking recording';
+export const SCAN_RECORDING_REVIEW_HINT = 'Possible match to an existing book — checking recording';
+
+/**
+ * Display-only within-scan hint (#1925): the second-and-later folder of a
+ * title+author collision *inside one scan* carries this so the user still notices
+ * two folders of the same title during triage. Distinct from
+ * `SCAN_RECORDING_REVIEW_HINT` (an *existing-library* collision) — a within-scan
+ * collision is a different situation and never a decision. Never affects selection,
+ * counts, or submission; the recording ladder decides identity at confirm time.
+ */
+export const SCAN_WITHIN_SCAN_REVIEW_HINT = 'Possible duplicate folder in this scan';
 
 /** An existing-library row in a pairwise dedup bucket (#1891), ordered by `id` asc. */
 interface ExistingTitleEntry {
@@ -42,9 +52,13 @@ interface ExistingTitleEntry {
   shape: TitleShape;
 }
 
-/** A prior scanned row in a within-scan dedup bucket (#1891), in scan order. */
+/**
+ * A prior scanned row in a within-scan dedup bucket (#1891), in scan order. Only the
+ * title `shape` is retained — the second-and-later row needs nothing but a shape to
+ * pairwise-match against for the display hint (#1925); the row's own path is no longer
+ * carried, since the first-path field it used to feed was removed (#1925 F6).
+ */
 interface WithinScanEntry {
-  path: string;
   shape: TitleShape;
 }
 
@@ -287,7 +301,7 @@ export class LibraryScanService {
       // can pairwise-match a row that was itself emitted as a within-scan duplicate.
       if (shape && bucketKey) {
         const arr = withinScanBucket.get(bucketKey) ?? [];
-        arr.push({ path: folder.path, shape });
+        arr.push({ shape });
         withinScanBucket.set(bucketKey, arr);
       }
     }
@@ -306,9 +320,10 @@ export class LibraryScanService {
 
   /**
    * Classify a single scanned folder into a `DiscoveredBook` (#1891). Ordered
-   * precedence, unchanged from the pre-#1891 inline chain: (1) path match, (2)
-   * decisive-ASIN match, (3) existing-library title+author review hint, (4)
-   * within-scan duplicate, (5) normal. The title+author branches now bucket by
+   * precedence: (1) path match, (2) decisive-ASIN match, (3) existing-library
+   * title+author review hint, (4) within-scan title+author collision (#1925 — a
+   * NORMAL candidate carrying a display-only hint, NOT a hard flag; recording
+   * identity is deferred to the confirm ladder), (5) normal. The title+author branches now bucket by
    * author+`colonBase` and pairwise-filter (the predicate is non-transitive), picking
    * the lowest existing `books.id` (bucket is id-ordered) and the first prior scan row
    * (bucket is scan-ordered). Registration into the within-scan bucket is the caller's
@@ -353,12 +368,18 @@ export class LibraryScanService {
         return buildDiscoveredBook(...base, { isDuplicate: false, existingBookId: existingMatch.id, reviewReason: reviewReason ?? SCAN_RECORDING_REVIEW_HINT });
       }
 
-      // (4) Within-scan duplicate (a prior scan row pairwise-matches). First prior row
-      // in sorted scan order wins (bucket is scan-ordered).
+      // (4) Within-scan title+author collision (#1925): a prior scan row pairwise-matches.
+      // NOT a hard duplicate — scan time has no narrators, so "same recording?" cannot be
+      // answered here; deciding it a second time (in disagreement with the confirm-time
+      // recording ladder) is exactly the bug. Emit a NORMAL candidate so both folders flow
+      // through the match job and the sequential confirm runner decides identity where
+      // narrators exist (same-recording → skip, different-recording → edition, unsure →
+      // held). Carry a display-only within-scan hint on the second-and-later folder so the
+      // user still notices the collision during triage; preserve any upstream reviewReason.
       const withinMatch = (maps.withinScanBucket.get(bucketKey) ?? []).find((e) => titlesMatchForDedup(e.shape, shape));
       if (withinMatch) {
-        this.log.debug({ path: folder.path, title: parsed.title, author: parsed.author }, 'Duplicate detected (within-scan title+author match)');
-        return buildDiscoveredBook(...base, { isDuplicate: true, duplicateReason: 'within-scan', duplicateFirstPath: withinMatch.path, reviewReason });
+        this.log.debug({ path: folder.path, title: parsed.title, author: parsed.author }, 'Within-scan title+author match — deferring recording verdict to confirm ladder');
+        return buildDiscoveredBook(...base, { isDuplicate: false, reviewReason: reviewReason ?? SCAN_WITHIN_SCAN_REVIEW_HINT });
       }
     }
 

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -909,7 +909,7 @@ describe('resolveConfidenceFromDuration', () => {
 
   it('returns medium when scanned seconds is undefined', () => {
     const result = resolveConfidenceFromDuration([{ meta: topMeta }], undefined);
-    expect(result).toEqual({ confidence: 'medium', reason: expect.stringContaining('no duration data') });
+    expect(result).toEqual({ confidence: 'medium', reason: expect.stringContaining('no duration data'), reasonKind: 'no-duration-data' });
   });
 
   it('returns medium when scanned seconds is zero', () => {
@@ -920,7 +920,7 @@ describe('resolveConfidenceFromDuration', () => {
   it('returns medium "cannot verify" when top result has no duration', () => {
     const noDuration = makeBook();
     const result = resolveConfidenceFromDuration([{ meta: noDuration }], 3600);
-    expect(result).toEqual({ confidence: 'medium', reason: expect.stringContaining('cannot verify') });
+    expect(result).toEqual({ confidence: 'medium', reason: expect.stringContaining('cannot verify'), reasonKind: 'missing-duration' });
   });
 
   it('returns high when scanned seconds is within the 90s band', () => {
@@ -934,6 +934,7 @@ describe('resolveConfidenceFromDuration', () => {
     const result = resolveConfidenceFromDuration([{ meta: makeBook({ duration: 60 }) }], 3900);
     expect(result.confidence).toBe('medium');
     expect(result.reason).toContain('Duration mismatch');
+    expect(result.reasonKind).toBe('duration-mismatch');
   });
 
   it('does not relax on long books — a 30h book 5min off is medium, no score tier rescues it', () => {
@@ -1023,6 +1024,7 @@ describe('resolveSingleResultConfidence', () => {
     const result = resolveSingleResultConfidence(makeBook({ duration: 807 }), 33360);
     expect(result.confidence).toBe('medium');
     expect(result.reason).toBe('Duration mismatch — scanned 9h 16m vs expected 13h 27m');
+    expect(result.reasonKind).toBe('duration-mismatch');
   });
 
   it('both present + within 90s → high, no reason', () => {
@@ -1030,12 +1032,14 @@ describe('resolveSingleResultConfidence', () => {
     const result = resolveSingleResultConfidence(makeBook({ duration: 60 }), 3650);
     expect(result.confidence).toBe('high');
     expect(result.reason).toBeUndefined();
+    expect(result.reasonKind).toBeUndefined();
   });
 
   it('scanned seconds missing → high, no reason (absent data does not demote)', () => {
     const result = resolveSingleResultConfidence(makeBook({ duration: 60 }), undefined);
     expect(result.confidence).toBe('high');
     expect(result.reason).toBeUndefined();
+    expect(result.reasonKind).toBeUndefined();
   });
 
   it('scanned seconds zero → high, no reason', () => {

--- a/src/server/services/match-job.helpers.ts
+++ b/src/server/services/match-job.helpers.ts
@@ -6,6 +6,7 @@ import { compareNarratorSignals, diceCoefficient, normalizeNarrator, scoreResult
 import { normalizeProductionType } from '../../core/metadata/production-type.js';
 import { cleanTagTitle, extractYear, hasTagSeriesMarker, isPureVolumeMarker } from '../utils/folder-parsing.js';
 import type { Confidence, MatchCandidate, MatchResult } from './match-job.types.js';
+import type { MatchReasonKind } from '../../shared/match-reason-kind.js';
 import type { MatchSource } from './tag-search-planner.js';
 import type { BookService } from './book.service.js';
 import { serializeError } from '../utils/serialize-error.js';
@@ -105,15 +106,29 @@ export function capConfidence(c: Confidence, cap: 'high' | 'medium'): Confidence
 
 // Cap-driven downgrades from a planner attempt need a user-facing tooltip
 // reason; without one the amber Review pill renders with no explanation (#1052).
-export function applyAttemptCap(raw: Confidence, cap: 'high' | 'medium', durationReason: string | undefined): { confidence: Confidence; reason?: string } {
+export function applyAttemptCap(
+  raw: Confidence,
+  cap: 'high' | 'medium',
+  durationReason: string | undefined,
+  durationReasonKind?: MatchReasonKind,
+): { confidence: Confidence; reason?: string; reasonKind?: MatchReasonKind } {
   const confidence = capConfidence(raw, cap);
   const reason = durationReason ?? (confidence === 'medium' ? CAPPED_ATTEMPT_REASON : undefined);
-  return reason !== undefined ? { confidence, reason } : { confidence };
+  const base = reason !== undefined ? { confidence, reason } : { confidence };
+  // `reasonKind` rides only when the DURATION reason survives (it pairs with
+  // `durationReason`). A cap-synthesized `CAPPED_ATTEMPT_REASON` carries no kind,
+  // matching the spec's "attempt-cap rows have no reasonKind" (#1929).
+  return durationReasonKind !== undefined && reason === durationReason
+    ? { ...base, reasonKind: durationReasonKind }
+    : base;
 }
 
 export interface DurationConfidenceResult {
   confidence: Confidence;
   reason?: string;
+  /** Structured discriminator paired with `reason` (#1929) — one of the three
+   * duration-derived kinds, or absent on a `high` result. */
+  reasonKind?: MatchReasonKind;
 }
 
 /**
@@ -159,7 +174,7 @@ export function resolveConfidenceFromDuration(
   scannedSeconds: number | undefined,
 ): DurationConfidenceResult {
   if (!scannedSeconds || scannedSeconds <= 0) {
-    return { confidence: 'medium', reason: 'Multiple results — no duration data to disambiguate' };
+    return { confidence: 'medium', reason: 'Multiple results — no duration data to disambiguate', reasonKind: 'no-duration-data' };
   }
   const topResult = scored[0]!;
   if (topResult.meta.duration && topResult.meta.duration > 0) {
@@ -167,9 +182,10 @@ export function resolveConfidenceFromDuration(
     return {
       confidence: 'medium',
       reason: `Duration mismatch — scanned ${formatDurationSeconds(scannedSeconds)} vs expected ${formatDurationSeconds(topResult.meta.duration * 60)}`,
+      reasonKind: 'duration-mismatch',
     };
   }
-  return { confidence: 'medium', reason: 'Best match missing duration — cannot verify' };
+  return { confidence: 'medium', reason: 'Best match missing duration — cannot verify', reasonKind: 'missing-duration' };
 }
 
 /**
@@ -194,6 +210,7 @@ export function resolveSingleResultConfidence(
     return {
       confidence: 'medium',
       reason: `Duration mismatch — scanned ${formatDurationSeconds(scannedSeconds)} vs expected ${formatDurationSeconds(meta.duration! * 60)}`,
+      reasonKind: 'duration-mismatch',
     };
   }
   return { confidence: 'high' };

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -817,6 +817,108 @@ describe('MatchJobService', () => {
     });
   });
 
+  // #1929 — the raw scanned runtime (seconds) and a structured reasonKind ride the
+  // assembled MatchResult so the client can re-evaluate a medium re-pick without
+  // parsing the display string. scannedSeconds is threaded UNCONDITIONALLY whenever
+  // the scanner produced a positive runtime (F9), regardless of confidence.
+  describe('#1929 scannedSeconds + reasonKind threading (filename path)', () => {
+    it('multi-result duration-mismatch top exposes scannedSeconds + reasonKind:duration-mismatch', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 36000, files: [] });
+      const results = [
+        makeBookMetadata({ title: 'Doctor Sleep: A Novel', authors: [{ name: 'Stephen King' }], providerId: 'p1' }),
+        makeBookMetadata({ title: 'Doctor Sleep (Unabridged)', authors: [{ name: 'Stephen King' }], providerId: 'p2' }),
+      ];
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue(results);
+      (metadataService.getBook as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ asin: 'A1', duration: 650 }) // 39000s vs 36000s → Δ3000 out of band
+        .mockResolvedValueOnce({ asin: 'A2', duration: 700 });
+
+      const id = service.createJob([{ path: '/audiobooks/Doctor Sleep', title: 'Doctor Sleep', author: 'Stephen King' }]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0]!;
+      expect(result.confidence).toBe('medium');
+      expect(result.reasonKind).toBe('duration-mismatch');
+      expect(result.reason).toContain('Duration mismatch');
+      expect(result.scannedSeconds).toBe(36000);
+    });
+
+    it('multi-result duration-verified high exposes scannedSeconds and NO reasonKind', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 36050, files: [] });
+      const results = [
+        makeBookMetadata({ title: 'The Way of Kings', providerId: 'p1' }),
+        makeBookMetadata({ title: 'The Way of Kings (Unabridged)', providerId: 'p2' }),
+      ];
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue(results);
+      (metadataService.getBook as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ asin: 'A1', duration: 600 }) // Δ50s — inside band
+        .mockResolvedValueOnce({ asin: 'A2', duration: 800 });
+
+      const id = service.createJob([sampleCandidate]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0]!;
+      expect(result.confidence).toBe('high');
+      expect(result.scannedSeconds).toBe(36050);
+      expect(result.reasonKind).toBeUndefined();
+    });
+
+    // F9 — scannedSeconds rides even the non-success exits (no results / title-floor /
+    // catch), never only the resolved-match ones.
+    it('no-search-results none result still carries scannedSeconds (no reasonKind)', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 36000, files: [] });
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const id = service.createJob([sampleCandidate]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0]!;
+      expect(result.confidence).toBe('none');
+      expect(result.scannedSeconds).toBe(36000);
+      expect(result.reasonKind).toBeUndefined();
+    });
+
+    it('title-floor none result still carries scannedSeconds', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 36000, files: [] });
+      // A result whose title shares no similarity with the candidate → below the floor.
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        makeBookMetadata({ title: 'The Way of Kings', providerId: 'p1' }),
+      ]);
+      (metadataService.getBook as ReturnType<typeof vi.fn>).mockResolvedValue({ asin: 'A1', duration: 600 });
+
+      const id = service.createJob([{ path: '/audiobooks/xyz', title: 'Zzzqqq Nonsense Title', author: 'Nobody' }]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0]!;
+      expect(result.confidence).toBe('none');
+      expect(result.scannedSeconds).toBe(36000);
+    });
+
+    it('error/catch none result still carries scannedSeconds', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 36000, files: [] });
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('provider exploded'));
+
+      const id = service.createJob([sampleCandidate]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0]!;
+      expect(result.confidence).toBe('none');
+      expect(result.error).toBeDefined();
+      expect(result.scannedSeconds).toBe(36000);
+    });
+
+    it('a scan with no positive runtime leaves scannedSeconds absent', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 0, files: [] });
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+      const id = service.createJob([sampleCandidate]);
+      await waitForJob(service, id);
+
+      const result = service.getJob(id)!.results[0]!;
+      expect(result.scannedSeconds).toBeUndefined();
+    });
+  });
+
   // #1821 — single-result filename path (uncapped): corroborate against runtime.
   // A grossly-off duration demotes high → medium (Review); missing runtime or a
   // within-tolerance runtime stays high. This is the exact path the Fablehaven
@@ -1281,6 +1383,37 @@ describe('MatchJobService', () => {
       // fetchDetails checks cancelled between each iteration, so after first call
       // triggers cancel, subsequent iterations should break
       expect(getBookCalls).toBeLessThanOrEqual(2);
+    });
+
+    // #1929 F1 (carried F9) — the empty-scored/cancellation exit is a SEPARATE result
+    // exit from the no-results/title-floor/catch ones; it must also carry the raw
+    // scanned seconds unconditionally. This fails if `withScanned` is dropped from the
+    // empty-scored return (match-job.service.ts:278) while every other test stays green.
+    it('empty-scored (cancellation) none exit still carries positive scannedSeconds (#1929)', async () => {
+      (scanAudioDirectory as ReturnType<typeof vi.fn>).mockResolvedValue({ totalDuration: 36000, files: [] });
+      const results = Array.from({ length: 5 }, (_, i) =>
+        makeBookMetadata({ title: `Book ${i}`, providerId: `prov-${i}` }),
+      );
+      // Cancel WHILE the search resolves so `fetchDetails` sees `isCancelled` on its very
+      // first iteration and returns an empty `detailed` → `scored` is empty even though the
+      // search returned 5 results → the empty-scored exit (not no-results/title-floor) fires.
+      (metadataService.searchBooks as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        service.cancelJob('test-job-id');
+        return results;
+      });
+
+      const id = service.createJob([sampleCandidate]);
+      await waitForJob(service, id);
+      // The empty-scored result is pushed in the microtask cascade following the cancel;
+      // let it settle before snapshotting.
+      await flushPromises();
+
+      const result = service.getJob(id)!.results[0]!;
+      // The empty-scored none exit — bestMatch null, but getBook was never reached.
+      expect(result.confidence).toBe('none');
+      expect(result.bestMatch).toBeNull();
+      expect(metadataService.getBook).not.toHaveBeenCalled();
+      expect(result.scannedSeconds).toBe(36000);
     });
 
     it('polling mid-job shows incremental progress', async () => {
@@ -2571,6 +2704,54 @@ describe('MatchJobService', () => {
 
         // Pass 2 would issue ANOTHER searchBooks call with filename-derived params
         expect(metadataService.searchBooks).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    // #1929 — the tag assembly path threads the same scannedSeconds + reasonKind as
+    // the filename path, incl. through the attempt cap (a duration-mismatch reason and
+    // its kind survive the cap; a bypass-to-high carries neither).
+    describe('#1929 scannedSeconds + reasonKind threading (tag path)', () => {
+      it('tag-derived duration-mismatch result exposes scannedSeconds + reasonKind:duration-mismatch', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeTaggedScan('Dogs of War', 'Adrian Tchaikovsky', 36000),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], providerId: 'p1' }),
+        ]);
+        vi.mocked(metadataService.getBook).mockResolvedValue(
+          // 700min → 42000s vs 36000s → Δ6000, out of band.
+          makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], providerId: 'p1', asin: 'B1', duration: 700 }),
+        );
+
+        const id = service.createJob([taggedCandidate]);
+        await waitForJob(service, id);
+
+        const result = service.getJob(id)!.results[0]!;
+        expect(result.confidence).toBe('medium');
+        expect(result.reasonKind).toBe('duration-mismatch');
+        expect(result.reason).toContain('Duration mismatch');
+        expect(result.scannedSeconds).toBe(36000);
+      });
+
+      it('tag-derived duration-verified high exposes scannedSeconds and NO reasonKind', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(
+          makeTaggedScan('Dogs of War', 'Adrian Tchaikovsky', 36000),
+        );
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], providerId: 'p1' }),
+        ]);
+        vi.mocked(metadataService.getBook).mockResolvedValue(
+          // 600min → 36000s vs 36000s → Δ0, verified.
+          makeBookMetadata({ title: 'Dogs of War', authors: [{ name: 'Adrian Tchaikovsky' }], providerId: 'p1', asin: 'B1', duration: 600 }),
+        );
+
+        const id = service.createJob([taggedCandidate]);
+        await waitForJob(service, id);
+
+        const result = service.getJob(id)!.results[0]!;
+        expect(result.confidence).toBe('high');
+        expect(result.scannedSeconds).toBe(36000);
+        expect(result.reasonKind).toBeUndefined();
       });
     });
 

--- a/src/server/services/match-job.service.ts
+++ b/src/server/services/match-job.service.ts
@@ -4,6 +4,7 @@ import type { MetadataService } from './metadata.service.js';
 import type { BookService } from './book.service.js';
 import type { BookMetadata } from '../../core/metadata/index.js';
 import type { Confidence, MatchCandidate, MatchResult, MatchJobStatus } from './match-job.types.js';
+import type { MatchReasonKind } from '../../shared/match-reason-kind.js';
 import { scanAudioDirectory, type AudioScanResult } from '../../core/utils/audio-scanner.js';
 import { resolveFfprobePathFromSettings } from '../../core/utils/ffprobe-path.js';
 import { resolveFfmpegPath } from '../../core/utils/audio-processor.js';
@@ -196,6 +197,12 @@ class MatchJob {
 
   // eslint-disable-next-line complexity -- audio-scan + tag-pass + filename-pass + scoring branches with conditional-spread on MatchResult
   async matchSingleBook(book: MatchCandidate): Promise<MatchResult> {
+    // Raw scanner seconds (#1929) threaded onto EVERY assembled result regardless of
+    // confidence (incl. 'none'/title-floor/error exits) so the client can re-evaluate a
+    // medium re-pick. Declared outside the try so the catch's error result honors it too.
+    let scannedSeconds: number | undefined;
+    const withScanned = (result: MatchResult): MatchResult =>
+      scannedSeconds && scannedSeconds > 0 ? { ...result, scannedSeconds } : result;
     try {
       // Scan audio files for duration (used for runtime disambiguation) AND tag fields
       let duration: number | undefined;
@@ -211,6 +218,7 @@ class MatchJob {
         if (audioResult && audioResult.totalDuration > 0) {
           // Convert seconds → minutes to match Audible's runtime_length_min
           duration = Math.round(audioResult.totalDuration / 60);
+          scannedSeconds = audioResult.totalDuration;
           this.log.debug({ path: book.path, duration: `${duration}min` }, 'Audio duration scanned');
         }
       } catch (error: unknown) {
@@ -241,7 +249,7 @@ class MatchJob {
 
         if (trace.results.length === 0) {
           this.log.debug({ path: book.path }, 'No search results returned');
-          return { path: book.path, confidence: 'none', bestMatch: null, alternatives: [] };
+          return withScanned({ path: book.path, confidence: 'none', bestMatch: null, alternatives: [] });
         }
 
         this.log.debug({ path: book.path, resultCount: trace.results.length, swapRetry: trace.swapRetry }, 'Search returned results');
@@ -267,7 +275,7 @@ class MatchJob {
             { path: book.path, cancelled: this.isCancelled, resultCount: trace.results.length },
             'No scored results after ranking — cancelled mid-flight or all filtered',
           );
-          return { path: book.path, confidence: 'none', bestMatch: null, alternatives: [] };
+          return withScanned({ path: book.path, confidence: 'none', bestMatch: null, alternatives: [] });
         }
 
         // Title similarity floor: below 50% → confidence 'none'
@@ -279,12 +287,12 @@ class MatchJob {
             { path: book.path, titleSimilarity: titleSimilarity.toFixed(2), bestTitle: topScored.meta.title },
             'Top result below title similarity floor — none confidence',
           );
-          return {
+          return withScanned({
             path: book.path,
             confidence: 'none',
             bestMatch: topScored.meta,
             alternatives: scored.slice(1).map(s => s.meta),
-          };
+          });
         }
 
         if (scored.length === 1) {
@@ -302,7 +310,7 @@ class MatchJob {
           // (text score, with duration only breaking a score tie, #1882); this
           // step reads confidence off that top candidate's runtime agreement.
           // Unrounded seconds (#1850); `duration` (minutes) below is logging only.
-          const { confidence, reason } = resolveConfidenceFromDuration(scored, audioResult?.totalDuration);
+          const { confidence, reason, reasonKind } = resolveConfidenceFromDuration(scored, audioResult?.totalDuration);
           this.log.debug(
             {
               path: book.path,
@@ -321,6 +329,7 @@ class MatchJob {
             bestMatch: topScored.meta,
             alternatives: scored.slice(1).map(s => s.meta),
             ...(reason !== undefined && { reason }),
+            ...(reasonKind !== undefined && { reasonKind }),
           };
           // `resolveConfidenceFromDuration` returning 'high' IS the duration corroboration.
           capCtx = { log: this.log, matchSource: 'filename-duration-resolved', durationVerified: confidence === 'high' };
@@ -333,16 +342,16 @@ class MatchJob {
 
       // Post-match library-duplicate pass (#1662) — keyed off the MATCHED metadata,
       // so a no-author filename that resolves to an owned book is flagged at review.
-      return await applyLibraryDuplicate(capped, this.bookService, this.log);
+      return withScanned(await applyLibraryDuplicate(capped, this.bookService, this.log));
     } catch (error: unknown) {
       this.log.warn({ error: serializeError(error), path: book.path, title: book.title }, 'Match failed for book');
-      return {
+      return withScanned({
         path: book.path,
         confidence: 'none',
         bestMatch: null,
         alternatives: [],
         error: getErrorMessage(error),
-      };
+      });
     }
   }
 
@@ -377,8 +386,8 @@ class MatchJob {
     const durationVerified = isDurationVerified(top.meta, scannedSeconds);
     // #1266 — when the scanned runtime verifies the top candidate, bypass the strip `medium` cap and keep `high`.
     const capBypassedByDuration = attempt.maxConfidence === 'medium' && durationVerified;
-    const cap = (raw: Confidence, reason: string | undefined): { confidence: Confidence; reason?: string } =>
-      capBypassedByDuration ? { confidence: 'high' } : applyAttemptCap(raw, attempt.maxConfidence, reason);
+    const cap = (raw: Confidence, reason: string | undefined, reasonKind: MatchReasonKind | undefined): { confidence: Confidence; reason?: string; reasonKind?: MatchReasonKind } =>
+      capBypassedByDuration ? { confidence: 'high' } : applyAttemptCap(raw, attempt.maxConfidence, reason, reasonKind);
 
     const single = scored.length === 1;
     // #1821 — corroborate the single tag-result (incl. the ASIN kill-shot) against
@@ -386,8 +395,8 @@ class MatchJob {
     // below: a mismatch → raw `medium` survives (durationVerified false, so
     // capBypassedByDuration false); a missing runtime → raw `high`, clamped to
     // `medium` by a `maxConfidence: 'medium'` attempt exactly as before.
-    const { confidence, reason } = single ? resolveSingleResultConfidence(top.meta, scannedSeconds) : resolveConfidenceFromDuration(scored, scannedSeconds);
-    const result: MatchResult = { path: book.path, ...cap(confidence, reason), bestMatch: top.meta, alternatives: single ? [] : scored.slice(1).map(s => s.meta) };
+    const { confidence, reason, reasonKind } = single ? resolveSingleResultConfidence(top.meta, scannedSeconds) : resolveConfidenceFromDuration(scored, scannedSeconds);
+    const result: MatchResult = { path: book.path, ...cap(confidence, reason, reasonKind), bestMatch: top.meta, alternatives: single ? [] : scored.slice(1).map(s => s.meta) };
     return { result, ctx: { log: this.log, matchSource: attempt.source, durationVerified } };
   }
 

--- a/src/server/services/match-job.types.ts
+++ b/src/server/services/match-job.types.ts
@@ -1,5 +1,6 @@
 import type { BookMetadata } from '../../core/metadata/index.js';
 import type { DuplicateReason, RecordingVerdict } from '../../shared/schemas.js';
+import type { MatchReasonKind } from '../../shared/match-reason-kind.js';
 
 /**
  * Match-job data contracts. Extracted from `match-job.service.ts` (#1864 file-size
@@ -26,6 +27,18 @@ export interface MatchResult {
   alternatives: BookMetadata[];
   error?: string;
   reason?: string;
+  /** Structured discriminator for the duration-confidence Review reason (#1929),
+   * paired with `reason` (never parsed from it). Present only on the three
+   * duration-derived medium reasons; absent on high, attempt-cap, narrator-cap,
+   * and legacy medium rows. The client re-pick logic branches on it. */
+  reasonKind?: MatchReasonKind;
+  /** Raw unrounded scanner runtime in SECONDS (#1929) — the same value the match
+   * job compares against a candidate's `duration * 60`. Threaded unconditionally
+   * onto every assembled result whenever the scanner produced a positive runtime
+   * (it is a file property, not confidence-dependent), so the client can
+   * re-evaluate any medium re-pick against the picked edition. Absent when the
+   * scan found no positive runtime. */
+  scannedSeconds?: number;
   /** Post-match library-duplicate flags (#1662), set from the resolved `bestMatch`
    * (which carries the author/asin a no-author filename lacks). The client merge
    * propagates these onto `row.book` so the badge lights up and the row fails closed. */

--- a/src/server/services/resolve-import-series.test.ts
+++ b/src/server/services/resolve-import-series.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { resolveImportSeries } from './resolve-import-series.js';
+
+// Single shared resolver (#1927 F7) — the authoritative item-first, two-state,
+// pair-locked decision both server sites (buildBookCreatePayload + copyToLibrary)
+// call. Table-driven over { present, absent, whitespace-only, padded-non-empty } ×
+// { position present, absent, 0 } against a FIXED metadata primary, so a drift on
+// any edge (whitespace, position-0, padded name, orphan position) is caught here.
+describe('resolveImportSeries', () => {
+  const META = { name: 'Provider Saga', position: 2 };
+
+  const cases: Array<{
+    name: string;
+    item: { seriesName?: string | null | undefined; seriesPosition?: number | undefined };
+    primary: { name?: string; position?: number } | undefined;
+    expected: { name: string | undefined; position: number | undefined };
+  }> = [
+    // ── Present item name → item wins for BOTH fields (pair-lock) ──
+    { name: 'present name + present position → item pair', item: { seriesName: 'Custom Saga', seriesPosition: 7 }, primary: META, expected: { name: 'Custom Saga', position: 7 } },
+    { name: 'present name + absent position → item name, NO position (never grafts metadata position)', item: { seriesName: 'Custom Saga' }, primary: META, expected: { name: 'Custom Saga', position: undefined } },
+    { name: 'present name + position 0 → item pair, 0 survives', item: { seriesName: 'Custom Saga', seriesPosition: 0 }, primary: META, expected: { name: 'Custom Saga', position: 0 } },
+    // ── Padded-non-empty → classified present, name preserved VERBATIM (trim classifies, does not rewrite) ──
+    { name: 'padded non-empty name → item wins, name kept verbatim (" Saga ", not "Saga")', item: { seriesName: ' Saga ', seriesPosition: 3 }, primary: META, expected: { name: ' Saga ', position: 3 } },
+    // ── Absent item name (omit / empty / whitespace) → defer BOTH to metadata ──
+    { name: 'absent (omitted) name → defer to metadata pair', item: {}, primary: META, expected: { name: 'Provider Saga', position: 2 } },
+    { name: 'empty-string name → treated as absent, defer', item: { seriesName: '' }, primary: META, expected: { name: 'Provider Saga', position: 2 } },
+    { name: 'whitespace-only name → treated as absent, defer', item: { seriesName: '   ' }, primary: META, expected: { name: 'Provider Saga', position: 2 } },
+    { name: 'null name → treated as absent, defer', item: { seriesName: null }, primary: META, expected: { name: 'Provider Saga', position: 2 } },
+    // Absent name + orphan item position → position dropped (pair-lock), metadata pair used.
+    { name: 'absent name + orphan item position → defer, orphan position NOT borrowed onto metadata name', item: { seriesPosition: 9 }, primary: META, expected: { name: 'Provider Saga', position: 2 } },
+    // Defer path preserves position-0 from metadata (?? semantics).
+    { name: 'absent name + metadata position 0 → defer, 0 survives', item: {}, primary: { name: 'Prequels', position: 0 }, expected: { name: 'Prequels', position: 0 } },
+    // Defer path with metadata name but no position → name only.
+    { name: 'absent name + metadata name without position → name only', item: {}, primary: { name: 'Standalone' }, expected: { name: 'Standalone', position: undefined } },
+    // Absent both sides → both undefined.
+    { name: 'absent name + no metadata primary → both undefined', item: {}, primary: undefined, expected: { name: undefined, position: undefined } },
+  ];
+
+  for (const c of cases) {
+    it(c.name, () => {
+      expect(resolveImportSeries(c.item, c.primary)).toEqual(c.expected);
+    });
+  }
+});

--- a/src/server/services/resolve-import-series.ts
+++ b/src/server/services/resolve-import-series.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared item-first series resolver (#1927).
+ *
+ * The confirm item's `(seriesName, seriesPosition)` pair is consumed by TWO
+ * server sites — `buildBookCreatePayload` (DB-create) and `copyToLibrary`'s
+ * `targetBook` (library folder path). Both must resolve the pair IDENTICALLY, so
+ * the physical folder and the stored record never disagree. This is that single
+ * home (the #1088/#1097/#1374/#1660 anti-drift instinct that already produced
+ * `pickPrimarySeries` and `mergeMatchIntoRow`).
+ *
+ * Two-state, pair-locked:
+ * - `seriesName` **present** (non-empty after trimming) → BOTH `name` and
+ *   `position` come from the ITEM. Trimming ONLY classifies present-vs-absent —
+ *   the returned name is the item's original string, unmodified (a padded
+ *   `" Saga "` is preserved verbatim; the folder-path renderer's existing
+ *   `sanitizePath` is the sole normalizer on disk, unchanged by this work). A
+ *   user series with no position gets series-with-no-position — position never
+ *   crosses sources.
+ * - `seriesName` **absent** (omitted / empty / whitespace-only) → BOTH fields
+ *   defer to the matched metadata's primary series. Callers pass
+ *   `pickPrimarySeries(meta)` as `primary`, which prefers `seriesPrimary` over
+ *   `series[0]` (#1088/#1097) and uses `??` so a `position === 0` primary
+ *   survives. An item-supplied position on an absent name is intentionally
+ *   dropped (pair-lock), never borrowed onto the metadata name.
+ *
+ * This is the AUTHORITATIVE classification point (AC5): it holds for every
+ * caller — the staged PUT body and already-persisted payloads accept any string
+ * (`z.string().optional()`), so a non-React caller can submit `seriesName: "   "`;
+ * the resolver classifies it absent before deciding. The client mapper
+ * (`toConfirmItem`) applies the same classification early for a clean wire
+ * payload, but that is a UX safeguard, not the contract boundary.
+ */
+
+interface SeriesRefLike {
+  name?: string | undefined;
+  position?: number | undefined;
+}
+
+interface ImportSeriesFields {
+  seriesName?: string | null | undefined;
+  seriesPosition?: number | undefined;
+}
+
+export interface ResolvedImportSeries {
+  name: string | undefined;
+  position: number | undefined;
+}
+
+export function resolveImportSeries(
+  item: ImportSeriesFields,
+  primary: SeriesRefLike | undefined,
+): ResolvedImportSeries {
+  // Classify by trim (present-vs-absent) but never rewrite a present value.
+  if (item.seriesName?.trim()) {
+    return { name: item.seriesName, position: item.seriesPosition };
+  }
+  return { name: primary?.name, position: primary?.position };
+}

--- a/src/shared/match-reason-kind.ts
+++ b/src/shared/match-reason-kind.ts
@@ -1,0 +1,20 @@
+/**
+ * Structured discriminator for the three duration-confidence Review reasons the
+ * match job emits (#1929). Paired with — never parsed from — the human `reason`
+ * display string, so the client re-pick logic can branch on the *evidence class*
+ * without string-matching the wording:
+ *
+ *  - `duration-mismatch` — scanned runtime present, picked/best-match edition
+ *    runtime present, and the two are out of the shared tolerance band.
+ *  - `missing-duration` — duration evidence is incomplete on ONE side (the
+ *    best-match/picked edition has no positive runtime); cannot verify.
+ *  - `no-duration-data` — no scanned runtime at all; pure match-identity
+ *    ambiguity, resolvable by an explicit operator re-pick.
+ *
+ * Attempt-cap / narrator-cap / legacy medium rows carry NO `reasonKind`
+ * (`undefined`) and route to the legacy re-pick branch. Hand-mirrored between the
+ * server `MatchResult` (`match-job.types.ts`) and the client twin
+ * (`lib/api/library-scan.ts`) — no Zod schema, matching the un-validated
+ * match-job status contract.
+ */
+export type MatchReasonKind = 'duration-mismatch' | 'missing-duration' | 'no-duration-data';

--- a/src/shared/schemas/library-scan.test.ts
+++ b/src/shared/schemas/library-scan.test.ts
@@ -209,11 +209,15 @@ describe('manualImportJobPayloadSchema — narrators and seriesPosition flow thr
   });
 });
 
-describe('duplicateReasonSchema — within-scan variant (#342)', () => {
-  it('accepts within-scan value', () => {
+describe('duplicateReasonSchema — DB-backed reasons only (#1925)', () => {
+  it('accepts path and slug values', () => {
+    expect(duplicateReasonSchema.safeParse('path').success).toBe(true);
+    expect(duplicateReasonSchema.safeParse('slug').success).toBe(true);
+  });
+
+  it('rejects the removed within-scan value (#1925)', () => {
     const result = duplicateReasonSchema.safeParse('within-scan');
-    expect(result.success).toBe(true);
-    if (result.success) expect(result.data).toBe('within-scan');
+    expect(result.success).toBe(false);
   });
 
   it('rejects invalid values like foo', () => {
@@ -257,7 +261,7 @@ describe('discoveredBookSchema — parsedSeriesPosition field (#1042)', () => {
   });
 });
 
-describe('discoveredBookSchema — duplicateFirstPath field (#342)', () => {
+describe('discoveredBookSchema — duplicateFirstPath removed (#1925)', () => {
   const validDiscovery = {
     path: '/audiobooks/Author/Title',
     parsedTitle: 'Title',
@@ -266,22 +270,16 @@ describe('discoveredBookSchema — duplicateFirstPath field (#342)', () => {
     fileCount: 3,
     totalSize: 100,
     isDuplicate: true,
-    duplicateReason: 'within-scan',
+    duplicateReason: 'slug',
   };
 
-  it('validates discovery with duplicateFirstPath present', () => {
+  it('no longer carries duplicateFirstPath — the field is stripped as unknown', () => {
     const result = discoveredBookSchema.safeParse({
       ...validDiscovery,
       duplicateFirstPath: '/audiobooks/Other/Title',
     });
     expect(result.success).toBe(true);
-    if (result.success) expect(result.data.duplicateFirstPath).toBe('/audiobooks/Other/Title');
-  });
-
-  it('validates discovery with duplicateFirstPath absent', () => {
-    const result = discoveredBookSchema.safeParse(validDiscovery);
-    expect(result.success).toBe(true);
-    if (result.success) expect(result.data.duplicateFirstPath).toBeUndefined();
+    if (result.success) expect(result.data).not.toHaveProperty('duplicateFirstPath');
   });
 });
 

--- a/src/shared/schemas/library-scan.ts
+++ b/src/shared/schemas/library-scan.ts
@@ -12,7 +12,7 @@ export const scanDirectoryBodySchema = z.object({
   path: z.string().trim().min(1, 'path is required'),
 });
 
-export const duplicateReasonSchema = z.enum(['path', 'slug', 'within-scan']);
+export const duplicateReasonSchema = z.enum(['path', 'slug']);
 export type DuplicateReason = z.infer<typeof duplicateReasonSchema>;
 
 export const discoveredBookSchema = z.object({
@@ -26,7 +26,6 @@ export const discoveredBookSchema = z.object({
   isDuplicate: z.boolean(),
   existingBookId: z.number().optional(),
   duplicateReason: duplicateReasonSchema.optional(),
-  duplicateFirstPath: z.string().optional(),
   previewUrl: z.string().optional(),
   /**
    * Surfaces a discovery-time heuristic warning to the import UI when content


### PR DESCRIPTION
Brings #1929 (re-pick duration re-check) plus #1925 (within-scan edition deferral) and #1927 (series/position edit semantics) to main for the v0.9.12 tag.