### PR TITLE
Release: develop -> main (v0.9.13)

### DIFF
--- a/src/core/metadata/audnexus.test.ts
+++ b/src/core/metadata/audnexus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { http, HttpResponse, delay } from 'msw';
 import { useMswServer } from '../__tests__/msw/server.js';
 import { AudnexusProvider } from './audnexus.js';
@@ -821,6 +821,327 @@ describe('AudnexusProvider', () => {
       );
       const result = await provider.getBook('B_NO_TITLE');
       expect(result).toBeNull();
+    });
+  });
+
+  // #1942 — chapter-runtime adapter. The Audnexus chapter table is a strictly
+  // more authoritative runtime than the `runtimeLengthMin` scalar; this thin,
+  // never-throw lookup is the corroborating second source. Definitive outcomes
+  // (`ok` on the requested edition's complete record, `not_found` on a documented
+  // 400/404) are the ONLY kinds the service may cache — everything else is transient.
+  describe('getChapterRuntime — chapter-runtime adapter (#1942)', () => {
+    const FABLEHAVEN = 'B00CXXEX8W';
+
+    /** Live-verified Fablehaven Book 1 chapter record (2026-07-25). */
+    function chapterRecord(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        asin: FABLEHAVEN,
+        region: 'us',
+        runtimeLengthMs: 33219490,
+        runtimeLengthSec: 33219,
+        isAccurate: true,
+        chapters: [{ title: 'Opening Credits', startOffsetMs: 0, lengthMs: 21000 }],
+        ...overrides,
+      };
+    }
+
+    function chaptersHandler(responder: Parameters<typeof http.get>[1]) {
+      return http.get('https://api.audnex.us/books/:asin/chapters', responder);
+    }
+
+    describe('definitive — the requested edition\'s complete record', () => {
+      it('200 with matching asin + chapters array → ok carrying runtimeLengthMs and isAccurate', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord())));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+
+        expect(result.kind).toBe('ok');
+        if (result.kind === 'ok') {
+          expect(result.runtimeLengthMs).toBe(33219490);
+          expect(result.isAccurate).toBe(true);
+        }
+      });
+
+      it('a complete record with isAccurate false still parses as ok (the trust gate is the service\'s job)', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord({ isAccurate: false }))));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+
+        expect(result.kind).toBe('ok');
+        if (result.kind === 'ok') expect(result.isAccurate).toBe(false);
+      });
+
+      it('a complete record with null runtime/trust fields still parses as ok (.nullish external fields)', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord({ runtimeLengthMs: null, isAccurate: null }))));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+
+        expect(result.kind).toBe('ok');
+        if (result.kind === 'ok') {
+          expect(result.runtimeLengthMs).toBeNull();
+          expect(result.isAccurate).toBeNull();
+        }
+      });
+
+      it('an empty chapters array still satisfies the shape half of the predicate', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord({ chapters: [] }))));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('ok');
+      });
+
+      it.each([400, 404])('documented HTTP %i → not_found', async (status) => {
+        server.use(chaptersHandler(() => new HttpResponse(null, { status })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('not_found');
+      });
+    });
+
+    describe('transient — a 200 that is NOT the requested edition\'s complete record (F18/F20)', () => {
+      it('chapters array but MISMATCHED asin → invalid_record (a wrong-edition body is never authoritative)', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord({ asin: 'B_OTHER_EDITION' }))));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('chapters array but ABSENT asin → invalid_record', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json({ chapters: [], runtimeLengthMs: 33219490, isAccurate: true })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('matching asin but NO chapters array → invalid_record (partial/error object)', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json({ asin: FABLEHAVEN, message: 'temporarily unavailable' })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('matching asin with a null chapters field → invalid_record', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord({ chapters: null }))));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('fieldless {} envelope → invalid_record', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json({})));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('HTML interstitial body → invalid_record', async () => {
+        server.use(chaptersHandler(() => new HttpResponse('<html><body>Just a moment…</body></html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('empty 200 body → invalid_record', async () => {
+        server.use(chaptersHandler(() => new HttpResponse('', { status: 200 })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('JSON primitive body → invalid_record', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(42)));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+
+      it('schema-invalid body (runtimeLengthMs is a string) → invalid_record', async () => {
+        server.use(chaptersHandler(() => HttpResponse.json(chapterRecord({ runtimeLengthMs: 'oops' }))));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('invalid_record');
+      });
+    });
+
+    describe('transient — incomplete or inconclusive exchanges (F15/F17/F19)', () => {
+      it('post-header body-stream failure → transient_failure, NOT invalid_record', async () => {
+        server.use(chaptersHandler(() => {
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"asin":"B00CX'));
+              controller.error(new Error('stream aborted mid-body'));
+            },
+          });
+          return new HttpResponse(stream, { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('transient_failure');
+      });
+
+      it.each([401, 403, 408, 410, 422])('unexpected non-success HTTP %i → transient_failure (never not_found)', async (status) => {
+        server.use(chaptersHandler(() => new HttpResponse(null, { status })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('transient_failure');
+      });
+
+      it.each([202, 204])('ok-but-non-200 HTTP %i → transient_failure (the definitive branch gates on status === 200)', async (status) => {
+        server.use(chaptersHandler(() => new HttpResponse(null, { status })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('transient_failure');
+      });
+
+      it.each([500, 503])('HTTP %i → transient_failure', async (status) => {
+        server.use(chaptersHandler(() => new HttpResponse(null, { status })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('transient_failure');
+      });
+
+      it('3xx redirect (thrown by fetchWithTimeout after headers) → transient_failure', async () => {
+        server.use(chaptersHandler(() => new HttpResponse(null, { status: 302, headers: { Location: 'https://example.test/login' } })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('transient_failure');
+      });
+
+      it('pre-header network failure → transient_failure', async () => {
+        server.use(chaptersHandler(() => HttpResponse.error()));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('transient_failure');
+      });
+
+      it('never throws on any failure path', async () => {
+        server.use(chaptersHandler(() => new HttpResponse(null, { status: 500 })));
+
+        await expect(provider.getChapterRuntime(FABLEHAVEN)).resolves.toBeDefined();
+      });
+    });
+
+    describe('429 retry-window normalization (F16)', () => {
+      /**
+       * Read the `retryAfterMs` off a 429 chapters response, asserting the
+       * discriminant first so a mis-classified outcome fails loudly here rather
+       * than silently skipping the window assertion.
+       */
+      async function retryAfterMsFor(header?: string): Promise<number> {
+        server.use(chaptersHandler(() => new HttpResponse(null, {
+          status: 429,
+          ...(header !== undefined && { headers: { 'Retry-After': header } }),
+        })));
+
+        const result = await provider.getChapterRuntime(FABLEHAVEN);
+        expect(result.kind).toBe('rate_limited');
+        return (result as Extract<typeof result, { kind: 'rate_limited' }>).retryAfterMs;
+      }
+
+      it('Retry-After delay-seconds → seconds × 1000', async () => {
+        expect(await retryAfterMsFor('30')).toBe(30_000);
+      });
+
+      // The clock is frozen (Date only — `toFake: ['Date']` leaves MSW's and
+      // `AbortSignal.timeout`'s real timers alone) so the HTTP-date arm asserts an
+      // EXACT window instead of a range: production reads `Date.now()` at a
+      // different instant than the test builds the header, and an ambient-clock
+      // range assertion cannot distinguish a correct window from a lucky one.
+      describe('HTTP-date arm, frozen clock', () => {
+        const NOW = Date.parse('2026-07-25T12:00:00.000Z');
+
+        beforeEach(() => {
+          vi.useFakeTimers({ toFake: ['Date'] });
+          vi.setSystemTime(NOW);
+        });
+        afterEach(() => { vi.useRealTimers(); });
+
+        it('a FUTURE HTTP-date → exactly the delta to that instant', async () => {
+          expect(await retryAfterMsFor(new Date(NOW + 120_000).toUTCString())).toBe(120_000);
+        });
+
+        it('an HTTP-date exactly NOW → a finite 0ms window', async () => {
+          expect(await retryAfterMsFor(new Date(NOW).toUTCString())).toBe(0);
+        });
+
+        it('a PAST HTTP-date → the finite 60000ms default, never a negative window', async () => {
+          expect(await retryAfterMsFor(new Date(NOW - 120_000).toUTCString())).toBe(60_000);
+        });
+      });
+
+      it.each([
+        ['absent', undefined],
+        ['empty', ''],
+        ['non-numeric', 'not-a-number'],
+        ['negative', '-30'],
+      ])('Retry-After %s → the finite 60000ms default', async (_label, header) => {
+        const retryAfterMs = await retryAfterMsFor(header);
+        expect(retryAfterMs).toBe(60_000);
+        expect(retryAfterMs).not.toBeNaN();
+      });
+
+      it('Retry-After of 0 seconds → a finite 0ms window', async () => {
+        expect(await retryAfterMsFor('0')).toBe(0);
+      });
+
+      // F1 — the finiteness guard must apply to the PRODUCT, not the operand.
+      // `1e306` is a finite Number written in all digits, so an operand-side
+      // `Number.isFinite` check passes it straight through and `× 1000` overflows
+      // to Infinity. `setRateLimited(Date.now() + Infinity)` is then a deadline
+      // that never expires, permanently suppressing every Audnexus lookup.
+      it.each([
+        ['overflows only after ×1000 (1e306 in digits)', `1${'0'.repeat(306)}`],
+        ['overflows on parse alone (1e400 in digits)', `1${'0'.repeat(400)}`],
+        ['Number.MAX_VALUE in digits', BigInt(Number.MAX_SAFE_INTEGER).toString().repeat(40)],
+      ])('an all-digit Retry-After that %s → the finite 60000ms default', async (_label, header) => {
+        const retryAfterMs = await retryAfterMsFor(header);
+        expect(retryAfterMs).toBe(60_000);
+        expect(Number.isFinite(retryAfterMs)).toBe(true);
+      });
+
+      it('every Retry-After form yields a window MetadataService can honor (finite, non-negative)', async () => {
+        // The contract the provider-wide backoff gate depends on, asserted across
+        // the whole input space in one place.
+        const headers = [undefined, '', '0', '30', '-30', 'not-a-number', `1${'0'.repeat(306)}`];
+        for (const header of headers) {
+          const retryAfterMs = await retryAfterMsFor(header);
+          expect(Number.isFinite(retryAfterMs)).toBe(true);
+          expect(retryAfterMs).toBeGreaterThanOrEqual(0);
+        }
+      });
+    });
+
+    describe('request shape', () => {
+      it('requests /books/{asin}/chapters with the provider\'s configured region', async () => {
+        const ukProvider = new AudnexusProvider({ region: 'uk' });
+        let capturedUrl = '';
+        server.use(chaptersHandler(({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(chapterRecord());
+        }));
+
+        await ukProvider.getChapterRuntime(FABLEHAVEN);
+
+        expect(capturedUrl).toContain(`/books/${FABLEHAVEN}/chapters`);
+        expect(capturedUrl).toContain('region=uk');
+        expect(capturedUrl).not.toContain('region=us');
+      });
+
+      it('defaults to region=us and URL-encodes the ASIN path segment', async () => {
+        let capturedUrl = '';
+        server.use(chaptersHandler(({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json(chapterRecord({ asin: 'B 0030' }));
+        }));
+
+        await provider.getChapterRuntime('B 0030');
+
+        expect(capturedUrl).toContain('/books/B%200030/chapters');
+        expect(capturedUrl).toContain('region=us');
+      });
     });
   });
 });

--- a/src/core/metadata/audnexus.ts
+++ b/src/core/metadata/audnexus.ts
@@ -9,6 +9,7 @@ import type {
   MetadataEnrichmentProvider,
   BookMetadata,
   AuthorMetadata,
+  ChapterRuntimeOutcome,
   ProviderLookupResult,
 } from './types.js';
 
@@ -45,6 +46,56 @@ const audnexusBookSchema = z.object({
   runtimeLengthMin: z.number().nullish(),
   genres: z.array(z.object({ name: z.string().nullish(), type: z.string().nullish() }).passthrough()).nullish(),
 }).passthrough();
+
+/**
+ * Chapter-endpoint raw schema (#1942). Only the top-level fields matter — the
+ * endpoint publishes its own `runtimeLengthMs`, so the chapter entries are never
+ * summed client-side and stay `z.unknown()`. `runtimeLengthMs`/`isAccurate` are
+ * `.nullish()` (external-API convention) so a GENUINE record with a null trust
+ * field still validates and settles as a definitive trust-fail; the identity +
+ * shape predicate below — not these two fields — is what proves authority.
+ */
+const audnexusChaptersSchema = z.object({
+  asin: z.string().nullish(),
+  runtimeLengthMs: z.number().nullish(),
+  isAccurate: z.boolean().nullish(),
+  chapters: z.array(z.unknown()).nullish(),
+}).passthrough();
+
+const DEFAULT_RETRY_AFTER_MS = 60_000;
+
+/**
+ * A backoff window is only usable if it is finite and non-negative — every arm of
+ * `parseRetryAfterMs` funnels its arithmetic RESULT through here so no branch can
+ * return a window the caller cannot honor.
+ *
+ * The finiteness check must be on the product, not the operand: `1e306` written
+ * out in digits is a perfectly finite Number, but `× 1000` overflows to
+ * `Infinity`, and `setRateLimited(Date.now() + Infinity)` is a deadline that never
+ * expires — a malformed-but-numeric upstream header would then suppress every
+ * Audnexus lookup for the life of the process.
+ */
+function finiteWindowMs(candidateMs: number): number {
+  return Number.isFinite(candidateMs) && candidateMs >= 0 ? candidateMs : DEFAULT_RETRY_AFTER_MS;
+}
+
+/**
+ * Normalize a `Retry-After` header to a FINITE, non-negative millisecond window.
+ *
+ * RFC 9110 permits both delay-seconds and an HTTP-date; the book path's
+ * `parseInt(header, 10) * 1000` yields `NaN` for the latter, and a `NaN` window
+ * makes the service's `setRateLimited(Date.now() + NaN)` backoff gate a silent
+ * no-op. Absent, unparseable, negative, and overflowing values all fall back to
+ * the same 60s default the absent-header case has always used.
+ */
+export function parseRetryAfterMs(header: string | null): number {
+  const raw = header?.trim();
+  if (!raw) return DEFAULT_RETRY_AFTER_MS;
+  if (/^[+-]?\d+$/.test(raw)) return finiteWindowMs(Number(raw) * 1000);
+  const dateMs = Date.parse(raw);
+  if (Number.isNaN(dateMs)) return DEFAULT_RETRY_AFTER_MS;
+  return finiteWindowMs(dateMs - Date.now());
+}
 
 const audnexusAuthorSchema = z.object({
   asin: z.string().nullish(),
@@ -105,6 +156,59 @@ export class AudnexusProvider implements MetadataEnrichmentProvider {
       return { kind: 'invalid_record', source: 'mapped', cause: parsed.error, issues: parsed.error.issues };
     }
     return { kind: 'ok', book: parsed.data };
+  }
+
+  /**
+   * Edition chapter-runtime lookup (#1942) — `GET /books/{asin}/chapters`, region
+   * forwarded exactly as the book/author lookups do (the endpoint defaults to `us`,
+   * so a bare path would silently answer with US chapters for a non-US edition).
+   *
+   * Deliberately does NOT reuse `fetchJsonDetailed`: that helper collapses three
+   * distinctions this feature's cache depends on (see {@link ChapterRuntimeOutcome}).
+   *   - It maps every non-OK status to `not_found`, which would settle a temporary
+   *     401/403/408 as a permanent "no runtime" for the service lifetime.
+   *   - It branches on `response.ok`, true for all of 200–299, so a null-body
+   *     202/204 would enter the record parser.
+   *   - It folds every `response.json()` rejection into `transient_failure`, which
+   *     conflates a body-stream abort (the exchange never completed) with a
+   *     completed-but-unparseable body.
+   *
+   * Never throws; owns no cache and no throttle.
+   */
+  async getChapterRuntime(id: string): Promise<ChapterRuntimeOutcome> {
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(
+        `${BASE_URL}/books/${encodeURIComponent(id)}/chapters?region=${encodeURIComponent(this.region)}`,
+        {},
+        REQUEST_TIMEOUT_MS,
+      );
+    } catch (error: unknown) {
+      // Pre-header rejection — network/DNS/TLS/timeout, and the 3xx redirect that
+      // `fetchWithTimeout` throws rather than returning.
+      return { kind: 'transient_failure', message: getErrorMessage(error) };
+    }
+
+    if (response.status === 429) {
+      return { kind: 'rate_limited', retryAfterMs: parseRetryAfterMs(response.headers.get('Retry-After')) };
+    }
+    // The ONLY statuses Audnexus documents as "this ASIN is absent/invalid".
+    if (response.status === 400 || response.status === 404) return { kind: 'not_found' };
+    // Exact-200 gate, not `response.ok`.
+    if (response.status !== 200) {
+      return { kind: 'transient_failure', message: `HTTP ${response.status} ${response.statusText}` };
+    }
+
+    // Split at the body boundary: `fetchWithTimeout` returns the Response with its
+    // timeout signal still attached, so the stream can reject AFTER headers.
+    let body: string;
+    try {
+      body = await response.text();
+    } catch (error: unknown) {
+      return { kind: 'transient_failure', message: getErrorMessage(error) };
+    }
+
+    return classifyChapterBody(body, id);
   }
 
   async getAuthor(id: string): Promise<AuthorMetadata | null> {
@@ -193,6 +297,39 @@ export class AudnexusProvider implements MetadataEnrichmentProvider {
 // ---------------------------------------------------------------------------
 // Mapping helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * The authority predicate (#1942, F18/F20). A fully-read 200 is NOT an
+ * authoritative statement about an edition just because its bytes arrived — this
+ * boundary routinely sees HTML interstitials, rate-limit pages, and upstream shape
+ * changes. A body is the requested edition's COMPLETE chapter record only when
+ * BOTH hold:
+ *
+ *  1. **Identity** — `asin` strictly equals the requested ASIN, and
+ *  2. **Shape** — a `chapters` array is present.
+ *
+ * The AND is load-bearing. An OR would admit a wrong-`asin` chapter record (another
+ * edition, whose runtime could falsely clear a genuine mismatch) and an ASIN-only
+ * error envelope (`{ asin, message: 'temporarily unavailable' }`, which would settle
+ * as a permanent trust-fail). Both are `invalid_record` → transient → never cached.
+ */
+function classifyChapterBody(body: string, requestedAsin: string): ChapterRuntimeOutcome {
+  if (body.trim().length === 0) return { kind: 'invalid_record', reason: 'empty-body' };
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(body);
+  } catch {
+    return { kind: 'invalid_record', reason: 'non-json-body' };
+  }
+
+  const parsed = audnexusChaptersSchema.safeParse(raw);
+  if (!parsed.success) return { kind: 'invalid_record', reason: 'schema-invalid' };
+  if (parsed.data.asin !== requestedAsin) return { kind: 'invalid_record', reason: 'asin-mismatch' };
+  if (!Array.isArray(parsed.data.chapters)) return { kind: 'invalid_record', reason: 'missing-chapters' };
+
+  return { kind: 'ok', runtimeLengthMs: parsed.data.runtimeLengthMs, isAccurate: parsed.data.isAccurate };
+}
 
 function mapAuthor(d: AudnexusAuthorDetail): Record<string, unknown> {
   return {

--- a/src/core/metadata/types.ts
+++ b/src/core/metadata/types.ts
@@ -37,6 +37,34 @@ export type ProviderLookupResult =
   | { kind: 'invalid_record'; source: 'mapped' | 'raw'; cause?: unknown; issues?: ZodIssue[] }
   | { kind: 'transient_failure'; message: string };
 
+/**
+ * Typed outcome union for the chapter-runtime lookup (#1942). The chapter table
+ * is a strictly more authoritative runtime than the `runtimeLengthMin` scalar,
+ * so the owner caches a derived verdict from it — which makes the *classification*
+ * load-bearing, not just the payload:
+ *
+ * - **Definitive** (safe to cache): `ok` — and ONLY when the 200 body is the
+ *   requested edition's COMPLETE chapter record (`asin` strictly equal to the
+ *   requested ASIN AND a present `chapters` array) — plus `not_found`, emitted
+ *   for the documented HTTP 400/404 only.
+ * - **Transient** (never cached; a later call may succeed): everything else —
+ *   `invalid_record` for a 200 that fails the record predicate (empty, non-JSON,
+ *   JSON primitive, schema-invalid, fieldless/error envelope, wrong-`asin`, or no
+ *   chapter array), `rate_limited` for a 429, and `transient_failure` for a
+ *   pre-header fetch rejection (incl. the 3xx redirect throw), a post-header body
+ *   read/abort/decode failure, any 5xx, and any other non-success or non-200 2xx
+ *   status.
+ *
+ * `runtimeLengthMs`/`isAccurate` ride raw and nullable: the trust gate that turns
+ * them into a usable runtime belongs to the service, not the transport.
+ */
+export type ChapterRuntimeOutcome =
+  | { kind: 'ok'; runtimeLengthMs: number | null | undefined; isAccurate: boolean | null | undefined }
+  | { kind: 'not_found' }
+  | { kind: 'invalid_record'; reason: string }
+  | { kind: 'rate_limited'; retryAfterMs: number }
+  | { kind: 'transient_failure'; message: string };
+
 /** Shared fields for all metadata providers. */
 export interface MetadataProviderBase {
   readonly name: string;
@@ -57,4 +85,9 @@ export interface MetadataEnrichmentProvider extends MetadataProviderBase {
   getBook(id: string): Promise<BookMetadata | null>;
   getBookDetailed(id: string): Promise<ProviderLookupResult>;
   getAuthor(id: string): Promise<AuthorMetadata | null>;
+  /**
+   * Edition chapter-runtime lookup (#1942) — never throws; owns no cache and no
+   * throttling (both belong to the calling service). See {@link ChapterRuntimeOutcome}.
+   */
+  getChapterRuntime(id: string): Promise<ChapterRuntimeOutcome>;
 }

--- a/src/server/services/chapter-corroboration.test.ts
+++ b/src/server/services/chapter-corroboration.test.ts
@@ -1,0 +1,361 @@
+/**
+ * #1942 — the chapter-corroboration owner: cache classification, single-flight,
+ * throttle/backoff bridge, and the lazy trigger.
+ *
+ * The load-bearing property under test is NOT "does it return the right number"
+ * but "does the right thing SETTLE". A cached verdict means the rescuable book
+ * never retries, so a transient outcome (a rate-limit page, an auth-proxy 403, a
+ * wrong-edition body) that settles as `no usable runtime` would permanently
+ * re-break the false positive this feature exists to fix. Every case therefore
+ * asserts BOTH the returned value AND the HTTP call count on a second lookup.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createMockLogger, inject } from '../__tests__/helpers.js';
+import type { FastifyBaseLogger } from 'fastify';
+import type { ChapterRuntimeOutcome } from '../../core/index.js';
+import {
+  createChapterCorroborator,
+  corroborateDurationVerdict,
+  type ChapterCorroborator,
+} from './chapter-corroboration.js';
+import type { DurationConfidenceResult } from './match-job.helpers.js';
+
+const ASIN = 'B00CXXEX8W';
+/** Fablehaven Book 1's live chapter runtime (2026-07-25). */
+const FABLEHAVEN_MS = 33219490;
+
+function completeRecord(overrides: Partial<Extract<ChapterRuntimeOutcome, { kind: 'ok' }>> = {}): ChapterRuntimeOutcome {
+  return { kind: 'ok', runtimeLengthMs: FABLEHAVEN_MS, isAccurate: true, ...overrides };
+}
+
+interface Harness {
+  corroborator: ChapterCorroborator;
+  getChapterRuntime: ReturnType<typeof vi.fn>;
+  acquireThrottle: ReturnType<typeof vi.fn>;
+  setRateLimited: ReturnType<typeof vi.fn>;
+  rateLimited: { value: boolean };
+}
+
+function makeHarness(providerName = 'Audnexus'): Harness {
+  const getChapterRuntime = vi.fn<(asin: string) => Promise<ChapterRuntimeOutcome>>();
+  const acquireThrottle = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+  const setRateLimited = vi.fn();
+  const rateLimited = { value: false };
+  const corroborator = createChapterCorroborator({
+    provider: { name: providerName, getChapterRuntime },
+    log: inject<FastifyBaseLogger>(createMockLogger()),
+    acquireThrottle,
+    isRateLimited: () => rateLimited.value,
+    getRateLimitRemainingMs: () => (rateLimited.value ? 30_000 : 0),
+    setRateLimited,
+  });
+  return { corroborator, getChapterRuntime, acquireThrottle, setRateLimited, rateLimited };
+}
+
+describe('createChapterCorroborator — trust gate (D3/AC5)', () => {
+  let h: Harness;
+  beforeEach(() => { h = makeHarness(); });
+
+  it('a complete record with isAccurate true and a positive runtime converts ms → SECONDS', async () => {
+    h.getChapterRuntime.mockResolvedValue(completeRecord());
+
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+  });
+
+  it.each([
+    ['isAccurate false', completeRecord({ isAccurate: false })],
+    ['isAccurate null', completeRecord({ isAccurate: null })],
+    ['isAccurate absent', { kind: 'ok', runtimeLengthMs: FABLEHAVEN_MS, isAccurate: undefined } as ChapterRuntimeOutcome],
+    ['runtimeLengthMs null', completeRecord({ runtimeLengthMs: null })],
+    ['runtimeLengthMs zero', completeRecord({ runtimeLengthMs: 0 })],
+    ['runtimeLengthMs negative', completeRecord({ runtimeLengthMs: -1000 })],
+    ['runtimeLengthMs non-finite', completeRecord({ runtimeLengthMs: Number.POSITIVE_INFINITY })],
+  ])('%s → no usable runtime, and it SETTLES (a second lookup issues no request)', async (_label, outcome) => {
+    h.getChapterRuntime.mockResolvedValue(outcome);
+
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+    expect(h.getChapterRuntime).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createChapterCorroborator — cache matrix (AC2)', () => {
+  let h: Harness;
+  beforeEach(() => { h = makeHarness(); });
+
+  describe('definitive — settles, so a second lookup issues NO request', () => {
+    it('the requested edition\'s complete record with a usable runtime', async () => {
+      h.getChapterRuntime.mockResolvedValue(completeRecord());
+
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+      expect(h.getChapterRuntime).toHaveBeenCalledTimes(1);
+      expect(h.acquireThrottle).toHaveBeenCalledTimes(1);
+    });
+
+    it('not_found (the documented HTTP 400/404 — Audnexus asserts the ASIN is absent)', async () => {
+      h.getChapterRuntime.mockResolvedValue({ kind: 'not_found' });
+
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+      expect(h.getChapterRuntime).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('transient — never settles, so a later call re-requests and a success promotes', () => {
+    it.each([
+      ['invalid_record (a 200 that is not this edition\'s complete record)', { kind: 'invalid_record', reason: 'asin-mismatch' } as ChapterRuntimeOutcome],
+      ['invalid_record (fieldless/error envelope)', { kind: 'invalid_record', reason: 'schema-invalid' } as ChapterRuntimeOutcome],
+      ['transient_failure (pre-header network / 5xx / 401 / 202 / redirect)', { kind: 'transient_failure', message: 'HTTP 503' } as ChapterRuntimeOutcome],
+      ['rate_limited (429)', { kind: 'rate_limited', retryAfterMs: 1 } as ChapterRuntimeOutcome],
+    ])('%s → not cached; the next call re-requests and a valid record then promotes AND settles', async (_label, outcome) => {
+      h.getChapterRuntime.mockResolvedValue(outcome);
+
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+      expect(h.getChapterRuntime).toHaveBeenCalledTimes(2);
+
+      h.getChapterRuntime.mockResolvedValue(completeRecord());
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+      expect(h.getChapterRuntime).toHaveBeenCalledTimes(3);
+
+      // ...and the promotion settles: a fourth lookup issues no request.
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+      expect(h.getChapterRuntime).toHaveBeenCalledTimes(3);
+    });
+
+    it('a wrong-edition chapter body can never settle as a verdict about the requested ASIN', async () => {
+      // The adapter already refuses to hand back another edition's runtime; this
+      // pins that the owner does not cache the resulting `invalid_record` either.
+      h.getChapterRuntime.mockResolvedValue({ kind: 'invalid_record', reason: 'asin-mismatch' });
+
+      await h.corroborator.getChapterRuntimeSeconds(ASIN);
+      h.getChapterRuntime.mockResolvedValue(completeRecord());
+
+      await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+    });
+  });
+});
+
+describe('createChapterCorroborator — throttle and provider-wide backoff (AC4)', () => {
+  let h: Harness;
+  beforeEach(() => { h = makeHarness(); });
+
+  it('acquires the shared throttle before every provider call — never a direct unthrottled call', async () => {
+    const order: string[] = [];
+    h.acquireThrottle.mockImplementation(() => { order.push('throttle'); return Promise.resolve(); });
+    h.getChapterRuntime.mockImplementation(() => { order.push('fetch'); return Promise.resolve(completeRecord()); });
+
+    await h.corroborator.getChapterRuntimeSeconds(ASIN);
+
+    expect(order).toEqual(['throttle', 'fetch']);
+  });
+
+  it('honors an ACTIVE provider-wide backoff — no throttle slot, no request', async () => {
+    h.rateLimited.value = true;
+
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+
+    expect(h.getChapterRuntime).not.toHaveBeenCalled();
+    expect(h.acquireThrottle).not.toHaveBeenCalled();
+  });
+
+  it('a skipped-because-rate-limited lookup does NOT settle — it retries once the window clears', async () => {
+    h.rateLimited.value = true;
+    await h.corroborator.getChapterRuntimeSeconds(ASIN);
+
+    h.rateLimited.value = false;
+    h.getChapterRuntime.mockResolvedValue(completeRecord());
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+  });
+
+  it('a RETURNED 429 feeds its finite window back into the shared backoff gate (F11/F16)', async () => {
+    h.getChapterRuntime.mockResolvedValue({ kind: 'rate_limited', retryAfterMs: 45_000 });
+
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+
+    expect(h.setRateLimited).toHaveBeenCalledWith('Audnexus', 45_000);
+    const [, windowMs] = h.setRateLimited.mock.calls[0]!;
+    expect(Number.isFinite(windowMs)).toBe(true);
+    expect(windowMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not touch the backoff gate for any non-429 outcome', async () => {
+    h.getChapterRuntime.mockResolvedValue({ kind: 'transient_failure', message: 'boom' });
+
+    await h.corroborator.getChapterRuntimeSeconds(ASIN);
+
+    expect(h.setRateLimited).not.toHaveBeenCalled();
+  });
+});
+
+describe('createChapterCorroborator — single-flight (AC2)', () => {
+  let h: Harness;
+  beforeEach(() => { h = makeHarness(); });
+
+  it('concurrent same-ASIN misses share ONE throttle acquisition and ONE request', async () => {
+    let release!: (o: ChapterRuntimeOutcome) => void;
+    h.getChapterRuntime.mockReturnValue(new Promise<ChapterRuntimeOutcome>(resolve => { release = resolve; }));
+
+    const all = Promise.all([
+      h.corroborator.getChapterRuntimeSeconds(ASIN),
+      h.corroborator.getChapterRuntimeSeconds(ASIN),
+      h.corroborator.getChapterRuntimeSeconds(ASIN),
+    ]);
+    release(completeRecord());
+
+    expect(await all).toEqual([33219.49, 33219.49, 33219.49]);
+    expect(h.getChapterRuntime).toHaveBeenCalledTimes(1);
+    expect(h.acquireThrottle).toHaveBeenCalledTimes(1);
+  });
+
+  it('concurrent misses on DIFFERENT ASINs are not coalesced', async () => {
+    h.getChapterRuntime.mockResolvedValue(completeRecord());
+
+    await Promise.all([
+      h.corroborator.getChapterRuntimeSeconds(ASIN),
+      h.corroborator.getChapterRuntimeSeconds('B_OTHER'),
+    ]);
+
+    expect(h.getChapterRuntime).toHaveBeenCalledTimes(2);
+  });
+
+  it('concurrent misses that resolve TRANSIENT share the outcome and leave no cache entry', async () => {
+    let release!: (o: ChapterRuntimeOutcome) => void;
+    h.getChapterRuntime.mockReturnValueOnce(new Promise<ChapterRuntimeOutcome>(resolve => { release = resolve; }));
+
+    const all = Promise.all([
+      h.corroborator.getChapterRuntimeSeconds(ASIN),
+      h.corroborator.getChapterRuntimeSeconds(ASIN),
+    ]);
+    release({ kind: 'transient_failure', message: 'socket hang up' });
+    expect(await all).toEqual([undefined, undefined]);
+    expect(h.getChapterRuntime).toHaveBeenCalledTimes(1);
+
+    h.getChapterRuntime.mockResolvedValue(completeRecord());
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+    expect(h.getChapterRuntime).toHaveBeenCalledTimes(2);
+  });
+
+  it('never rejects — a throwing throttle degrades to "no usable runtime" (AC9)', async () => {
+    h.acquireThrottle.mockRejectedValue(new Error('throttle exploded'));
+
+    await expect(h.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+  });
+});
+
+describe('createChapterCorroborator — owner-instance isolation (F14/AC2)', () => {
+  it('two owners built for different regions each perform and cache their OWN lookup', async () => {
+    const us = makeHarness();
+    const uk = makeHarness();
+    us.getChapterRuntime.mockResolvedValue(completeRecord());
+    uk.getChapterRuntime.mockResolvedValue(completeRecord({ runtimeLengthMs: 30000000 }));
+
+    await expect(us.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+    await expect(uk.corroborator.getChapterRuntimeSeconds(ASIN)).resolves.toBe(30000);
+
+    // Each settled independently — neither reused the other's verdict.
+    expect(us.getChapterRuntime).toHaveBeenCalledTimes(1);
+    expect(uk.getChapterRuntime).toHaveBeenCalledTimes(1);
+    await us.corroborator.getChapterRuntimeSeconds(ASIN);
+    await uk.corroborator.getChapterRuntimeSeconds(ASIN);
+    expect(us.getChapterRuntime).toHaveBeenCalledTimes(1);
+    expect(uk.getChapterRuntime).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('corroborateDurationVerdict — lazy trigger (AC4/AC7/AC9)', () => {
+  const MISMATCH: DurationConfidenceResult = {
+    confidence: 'medium',
+    reason: 'Duration mismatch — scanned 9h 13m vs expected 8h 59m',
+    reasonKind: 'duration-mismatch',
+  };
+  const HIGH: DurationConfidenceResult = { confidence: 'high' };
+
+  let lookupChapterSeconds: ReturnType<typeof vi.fn<(asin: string) => Promise<number | undefined>>>;
+  let log: ReturnType<typeof createMockLogger>;
+
+  beforeEach(() => {
+    lookupChapterSeconds = vi.fn().mockResolvedValue(33219.49);
+    log = createMockLogger();
+  });
+
+  function run(verdict: DurationConfidenceResult, asin: string | undefined, recheck = (_cs: number): DurationConfidenceResult => HIGH) {
+    return corroborateDurationVerdict({
+      verdict,
+      asin,
+      path: '/audiobooks/Fablehaven',
+      log: inject<FastifyBaseLogger>(log),
+      lookupChapterSeconds,
+      recheck,
+    });
+  }
+
+  it.each([
+    ['a scalar-VERIFIED match', HIGH],
+    ['an ambiguity-class review', { confidence: 'medium', reason: 'Multiple results — no duration data to disambiguate', reasonKind: 'no-duration-data' } as DurationConfidenceResult],
+    ['a missing-duration review', { confidence: 'medium', reason: 'Best match missing duration — cannot verify', reasonKind: 'missing-duration' } as DurationConfidenceResult],
+    ['a cap-synthesized reason with no kind', { confidence: 'medium', reason: 'Low confidence match. Please verify.' } as DurationConfidenceResult],
+  ])('%s issues ZERO chapter lookups and is returned untouched', async (_label, verdict) => {
+    const result = await run(verdict, ASIN);
+
+    expect(lookupChapterSeconds).not.toHaveBeenCalled();
+    expect(result).toEqual({ verdict });
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['empty', ''],
+    ['blank', '   '],
+  ])('a duration mismatch whose ASIN is %s issues ZERO lookups and keeps the scalar verdict', async (_label, asin) => {
+    const result = await run(MISMATCH, asin);
+
+    expect(lookupChapterSeconds).not.toHaveBeenCalled();
+    expect(result).toEqual({ verdict: MISMATCH });
+  });
+
+  it('a qualifying mismatch issues exactly ONE lookup and promotes on a usable in-band runtime', async () => {
+    const result = await run(MISMATCH, ASIN);
+
+    expect(lookupChapterSeconds).toHaveBeenCalledExactlyOnceWith(ASIN);
+    expect(result.verdict).toEqual(HIGH);
+    expect(result.chapterSeconds).toBe(33219.49);
+  });
+
+  it('trims the ASIN before looking it up', async () => {
+    await run(MISMATCH, `  ${ASIN}  `);
+
+    expect(lookupChapterSeconds).toHaveBeenCalledWith(ASIN);
+  });
+
+  it('suppress-only: an OUT-OF-BAND chapter runtime leaves the mismatch standing', async () => {
+    const result = await run(MISMATCH, ASIN, () => MISMATCH);
+
+    expect(result.verdict).toEqual(MISMATCH);
+  });
+
+  it('no usable chapter runtime → the scalar verdict stands and the recheck never runs', async () => {
+    lookupChapterSeconds.mockResolvedValue(undefined);
+    const recheck = vi.fn(() => HIGH);
+
+    const result = await run(MISMATCH, ASIN, recheck);
+
+    expect(recheck).not.toHaveBeenCalled();
+    expect(result).toEqual({ verdict: MISMATCH });
+  });
+
+  it('AC9 — a rejecting lookup never escapes: it degrades to the scalar verdict and logs at debug', async () => {
+    lookupChapterSeconds.mockRejectedValue(new Error('chapters blew up'));
+
+    const result = await run(MISMATCH, ASIN);
+
+    expect(result).toEqual({ verdict: MISMATCH });
+    expect(log.debug).toHaveBeenCalledWith(
+      expect.objectContaining({ asin: ASIN }),
+      expect.stringContaining('keeping the scalar duration verdict'),
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/chapter-corroboration.ts
+++ b/src/server/services/chapter-corroboration.ts
@@ -1,0 +1,237 @@
+import type { FastifyBaseLogger } from 'fastify';
+import type { ChapterRuntimeOutcome } from '../../core/index.js';
+import type { DurationConfidenceResult } from './match-job.helpers.js';
+import { serializeError } from '../utils/serialize-error.js';
+
+/**
+ * Chapter-runtime corroboration (#1942) — the ONE stateful owner of the lazy
+ * second-opinion lookup that kills the scalar-vs-chapters false-positive class.
+ *
+ * Background: `isDurationVerified` compares the scanned file runtime against the
+ * provider's `runtimeLengthMin` SCALAR. For a small but real slice of the catalog
+ * (measured: 1 of 227 library ASINs, Fablehaven Book 1 / `B00CXXEX8W`, Δ879s)
+ * that scalar understates the edition's OWN chapter table by minutes, so a
+ * pristine, correct file gets flagged `Duration mismatch`. The chapter table
+ * (`GET /books/{asin}/chapters`) is the strictly more authoritative runtime.
+ *
+ * Because the class is rare (0.4%), the fix must be LAZY: an eager per-book
+ * chapters fetch would cost ~230 requests per scan to rescue one book. So the
+ * scalar check runs first and the chapter lookup fires only where the scalar
+ * check would otherwise flag.
+ *
+ * Everything stateful lives here rather than in `MetadataService`/`MatchJobService`
+ * (both at their `max-lines` budget) or in the provider (a core adapter parses;
+ * it must own no cache and no throttle — and it *cannot* bound throttle
+ * acquisitions, because the service acquires the throttle before calling it).
+ * The collaborators are injected, following `metadata-fix-match.ts` /
+ * `metadata-resolve-book.ts`.
+ */
+
+/** Collaborators the corroborator borrows from {@link MetadataService}. */
+export interface ChapterCorroborationDeps {
+  provider: { readonly name: string; getChapterRuntime(asin: string): Promise<ChapterRuntimeOutcome> };
+  log: FastifyBaseLogger;
+  acquireThrottle(): Promise<void>;
+  isRateLimited(providerName: string): boolean;
+  getRateLimitRemainingMs(providerName: string): number;
+  setRateLimited(providerName: string, durationMs: number): void;
+}
+
+export interface ChapterCorroborator {
+  /**
+   * The edition's chapter-table runtime in SECONDS, or `undefined` when there is
+   * no usable one. Never throws and never rejects.
+   */
+  getChapterRuntimeSeconds(asin: string): Promise<number | undefined>;
+}
+
+/**
+ * Trust gate (D3). Audnexus publishes `isAccurate` as its own trust flag for the
+ * chapter table; without honoring it, provider-declared-INACCURATE chapter data
+ * could clear a genuine mismatch — a true-positive loss, the one thing this
+ * feature must not trade away. A runtime is usable only when the provider
+ * vouches for it AND the value is a finite positive number of milliseconds.
+ *
+ * Applied to the requested edition's COMPLETE record only (the adapter's `ok`);
+ * a record that fails this gate is still an authoritative statement about the
+ * edition, so it settles as a definitive "no usable runtime".
+ */
+function usableChapterSeconds(outcome: { runtimeLengthMs: number | null | undefined; isAccurate: boolean | null | undefined }): number | undefined {
+  if (outcome.isAccurate !== true) return undefined;
+  const ms = outcome.runtimeLengthMs;
+  if (typeof ms !== 'number' || !Number.isFinite(ms) || ms <= 0) return undefined;
+  // ms → SECONDS: the shared duration band is entirely seconds-based
+  // (`book-duration-minutes-vs-quality-seconds`).
+  return ms / 1000;
+}
+
+/**
+ * Build a corroborator bound to ONE {@link MetadataService} instance.
+ *
+ * The cache and the in-flight map are instance state, deliberately NOT module
+ * globals: each `MetadataService` is constructed with one immutable region, so an
+ * ASIN-only key is correct WITHIN an instance and would silently collide across
+ * regions if the maps were shared (a `uk` edition's chapter runtime answering a
+ * `us` lookup).
+ *
+ * **Cache policy — a closed allowlist of authoritative edition verdicts.** Only a
+ * verdict *about this edition* settles:
+ *
+ * | Adapter outcome | Cached |
+ * |---|---|
+ * | `ok` (the requested edition's complete record) → usable seconds, or a trust-fail "none" | yes |
+ * | `not_found` (documented HTTP 400/404 — Audnexus asserts the ASIN is absent) | yes |
+ * | `invalid_record` (a 200 that is not this edition's complete record) | no |
+ * | `rate_limited` / `transient_failure` | no |
+ *
+ * Everything not in the allowlist is transient by default, so there is no third
+ * state and no gap: a transient outcome re-requests next time and a later success
+ * promotes. What settles is the DERIVED verdict (`seconds | none`), never raw
+ * fields — so no wrong-edition body and no error envelope can ever enter the cache.
+ *
+ * **Concurrency.** Match jobs resolve up to five books at once through one shared
+ * `MetadataService`, so same-ASIN lookups are single-flight with the throttle
+ * acquisition INSIDE the coalesced operation: exactly one throttle acquisition and
+ * one HTTP request per settle. Entries are evicted on settle (the
+ * `book-admission.ts` mechanic), so coalescing is concurrency-only — a transient
+ * outcome shared with waiters leaves no cache entry behind.
+ */
+export function createChapterCorroborator(deps: ChapterCorroborationDeps): ChapterCorroborator {
+  /** Settled DEFINITIVE verdicts. Presence of the key — not the value — means "settled". */
+  const settled = new Map<string, number | undefined>();
+  const inFlight = new Map<string, Promise<number | undefined>>();
+
+  async function classify(asin: string): Promise<number | undefined> {
+    const outcome = await deps.provider.getChapterRuntime(asin);
+    switch (outcome.kind) {
+      case 'ok': {
+        const seconds = usableChapterSeconds(outcome);
+        settled.set(asin, seconds);
+        deps.log.debug(
+          { asin, runtimeLengthMs: outcome.runtimeLengthMs, isAccurate: outcome.isAccurate, chapterSeconds: seconds },
+          seconds === undefined
+            ? 'Chapter runtime not usable (trust gate) — settled'
+            : 'Chapter runtime resolved — settled',
+        );
+        return seconds;
+      }
+      case 'not_found':
+        settled.set(asin, undefined);
+        deps.log.debug({ asin }, 'Chapter runtime unavailable for ASIN (documented 400/404) — settled');
+        return undefined;
+      case 'rate_limited':
+        // Feed the FINITE window back into the shared provider-wide gate so the
+        // immediately subsequent Audnexus call short-circuits instead of piling on.
+        deps.setRateLimited(deps.provider.name, outcome.retryAfterMs);
+        return undefined;
+      case 'invalid_record':
+        deps.log.debug({ asin, reason: outcome.reason }, 'Chapter response was not this edition\'s complete record — not settled');
+        return undefined;
+      case 'transient_failure':
+        deps.log.debug({ asin, message: outcome.message }, 'Chapter lookup failed transiently — not settled');
+        return undefined;
+    }
+  }
+
+  async function lookup(asin: string): Promise<number | undefined> {
+    try {
+      if (deps.isRateLimited(deps.provider.name)) {
+        deps.log.debug(
+          { asin, remainingMs: deps.getRateLimitRemainingMs(deps.provider.name) },
+          'Chapter lookup skipped — provider rate limited',
+        );
+        return undefined;
+      }
+      // Inside the coalesced op, so waiters cost neither a throttle slot nor a request.
+      await deps.acquireThrottle();
+      return await classify(asin);
+    } catch (error: unknown) {
+      // The adapter never throws, but a corroboration failure must never escape
+      // into `matchSingleBook`'s catch (where it would become `confidence: 'none'`).
+      deps.log.debug({ error: serializeError(error), asin }, 'Chapter corroboration failed — falling back to the scalar verdict');
+      return undefined;
+    }
+  }
+
+  return {
+    async getChapterRuntimeSeconds(asin: string): Promise<number | undefined> {
+      if (settled.has(asin)) return settled.get(asin);
+
+      const existing = inFlight.get(asin);
+      if (existing) return existing;
+
+      const promise = lookup(asin);
+      inFlight.set(asin, promise);
+      try {
+        return await promise;
+      } finally {
+        if (inFlight.get(asin) === promise) inFlight.delete(asin);
+      }
+    },
+  };
+}
+
+/** Inputs to {@link corroborateDurationVerdict}. */
+export interface CorroborateDurationArgs {
+  /** The verdict the SYNC scalar check already produced. */
+  verdict: DurationConfidenceResult;
+  /** The chosen top candidate's ASIN — the chapter lookup key. */
+  asin: string | undefined;
+  /** Candidate folder path, for the debug trail. */
+  path: string;
+  log: FastifyBaseLogger;
+  lookupChapterSeconds(asin: string): Promise<number | undefined>;
+  /** Re-run the SAME sync helper, now with the chapter runtime as a second reference. */
+  recheck(chapterSeconds: number): DurationConfidenceResult;
+}
+
+export interface CorroboratedDuration {
+  verdict: DurationConfidenceResult;
+  /** The usable chapter runtime in SECONDS, when one was fetched and consulted. */
+  chapterSeconds?: number;
+}
+
+/**
+ * The lazy trigger. Given an already-computed scalar duration verdict, fetch the
+ * edition's chapter runtime and re-check — but ONLY when it can change anything.
+ *
+ * Fires only for `reasonKind: 'duration-mismatch'` with a non-empty ASIN. A
+ * scalar-VERIFIED match, an ambiguity-class review (`no-duration-data`), and a
+ * missing-duration review all issue ZERO fetches; a qualifying mismatch issues
+ * exactly one (deduped further by the corroborator's cache + single-flight).
+ *
+ * Suppress-only: the re-check runs the same helper with an extra corroborating
+ * reference, so it can only ever promote a would-be mismatch to `high`. It never
+ * demotes a scalar-verified match, and a file out of band against BOTH references
+ * flags exactly as it does today.
+ *
+ * Degrades silently to the scalar verdict on any failure — a corroboration error
+ * must not reach `matchSingleBook`'s catch, where it would become
+ * `confidence: 'none'` and lose the match entirely.
+ */
+export async function corroborateDurationVerdict(args: CorroborateDurationArgs): Promise<CorroboratedDuration> {
+  const { verdict, path, log } = args;
+  if (verdict.reasonKind !== 'duration-mismatch') return { verdict };
+
+  const asin = args.asin?.trim();
+  if (!asin) {
+    log.debug({ path }, 'Duration mismatch with no ASIN — skipping chapter corroboration');
+    return { verdict };
+  }
+
+  let chapterSeconds: number | undefined;
+  try {
+    chapterSeconds = await args.lookupChapterSeconds(asin);
+  } catch (error: unknown) {
+    log.debug({ error: serializeError(error), path, asin }, 'Chapter corroboration failed — keeping the scalar duration verdict');
+    return { verdict };
+  }
+  if (chapterSeconds === undefined) return { verdict };
+
+  const rechecked = args.recheck(chapterSeconds);
+  log.debug(
+    { path, asin, chapterSeconds, promoted: rechecked.reasonKind !== 'duration-mismatch' },
+    'Chapter-runtime corroboration applied to a would-be duration mismatch',
+  );
+  return { verdict: rechecked, chapterSeconds };
+}

--- a/src/server/services/match-job.helpers.test.ts
+++ b/src/server/services/match-job.helpers.test.ts
@@ -33,6 +33,7 @@ import {
   tagTitleScore,
   type NarratorCapContext,
 } from './match-job.helpers.js';
+import { DURATION_TOLERANCE_SECONDS } from '../../shared/duration-tolerance.js';
 
 // -------- Factories --------
 
@@ -954,6 +955,25 @@ describe('resolveConfidenceFromDuration', () => {
     expect(result.confidence).toBe('medium');
     expect(result.reason).toBe('Duration mismatch — scanned 29h 53m vs expected 29h 49m');
   });
+
+  describe('chapter-runtime corroboration (#1942)', () => {
+    it('Fablehaven: a usable in-band chapter runtime promotes the would-be mismatch to high with NO reason', () => {
+      const scored = [{ meta: makeBook({ duration: 539 }) }, { meta: makeBook({ duration: 700 }) }];
+      expect(resolveConfidenceFromDuration(scored, 33219.47)).toEqual({
+        confidence: 'medium',
+        reason: expect.stringContaining('Duration mismatch'),
+        reasonKind: 'duration-mismatch',
+      });
+      expect(resolveConfidenceFromDuration(scored, 33219.47, 33219.49)).toEqual({ confidence: 'high' });
+    });
+
+    it('an out-of-band chapter runtime leaves the mismatch reason intact (suppress-only)', () => {
+      const scored = [{ meta: makeBook({ duration: 539 }) }];
+      const result = resolveConfidenceFromDuration(scored, 33519.49, 33219.49);
+      expect(result.confidence).toBe('medium');
+      expect(result.reasonKind).toBe('duration-mismatch');
+    });
+  });
 });
 
 // ============================================================================
@@ -1011,6 +1031,48 @@ describe('isDurationVerified', () => {
   it('same-edition regression: 13.7h book Δ68s → verified', () => {
     // provider 822min → 49320s; scanned 49388s → Δ68s
     expect(isDurationVerified(makeBook({ duration: 822 }), 49388)).toBe(true);
+  });
+
+  // #1942 — the optional chapter-runtime corroborating second source. Suppress-only:
+  // it can turn a scalar disagreement into `verified`, never the reverse.
+  describe('chapter-runtime corroboration (#1942)', () => {
+    it('Fablehaven: scalar disagrees (Δ879s) but the chapter runtime agrees → verified', () => {
+      // scalar 539min → 32340s vs scanned 33219.47s → Δ879s (out of band);
+      // chapter runtime 33219.49s → Δ0.02s (in band).
+      expect(isDurationVerified(makeBook({ duration: 539 }), 33219.47)).toBe(false);
+      expect(isDurationVerified(makeBook({ duration: 539 }), 33219.47, 33219.49)).toBe(true);
+    });
+
+    it('reuses the shared band: exactly 240s from the chapter runtime verifies, 241s does not', () => {
+      const meta = makeBook({ duration: 539 });
+      expect(isDurationVerified(meta, 33219.47, 33219.47 + DURATION_TOLERANCE_SECONDS)).toBe(true);
+      expect(isDurationVerified(meta, 33219.47, 33219.47 + DURATION_TOLERANCE_SECONDS + 1)).toBe(false);
+    });
+
+    it('an out-of-band chapter runtime leaves the scalar disagreement standing', () => {
+      // scanned is 300s past BOTH references (truncated/padded file) — still unverified.
+      expect(isDurationVerified(makeBook({ duration: 539 }), 33519.49, 33219.49)).toBe(false);
+    });
+
+    it('never demotes: a scalar-verified match stays verified even with an off chapter runtime', () => {
+      expect(isDurationVerified(makeBook({ duration: 60 }), 3650, 1)).toBe(true);
+    });
+
+    it('a zero/negative/non-finite chapter runtime is ignored', () => {
+      const meta = makeBook({ duration: 539 });
+      expect(isDurationVerified(meta, 33219.47, 0)).toBe(false);
+      expect(isDurationVerified(meta, 33219.47, -33219.49)).toBe(false);
+      expect(isDurationVerified(meta, 33219.47, Number.NaN)).toBe(false);
+    });
+
+    it('still requires a scanned runtime — a chapter runtime alone cannot verify', () => {
+      expect(isDurationVerified(makeBook({ duration: 539 }), undefined, 33219.49)).toBe(false);
+      expect(isDurationVerified(makeBook({ duration: 539 }), 0, 33219.49)).toBe(false);
+    });
+
+    it('verifies off the chapter runtime even when the candidate has no scalar duration', () => {
+      expect(isDurationVerified(makeBook(), 33219.47, 33219.49)).toBe(true);
+    });
   });
 });
 
@@ -1076,6 +1138,21 @@ describe('resolveSingleResultConfidence', () => {
     const result = resolveSingleResultConfidence(makeBook({ duration: 1789 }), 107620);
     expect(result.confidence).toBe('medium');
     expect(result.reason).toBe('Duration mismatch — scanned 29h 53m vs expected 29h 49m');
+  });
+
+  describe('chapter-runtime corroboration (#1942)', () => {
+    it('Fablehaven: a usable in-band chapter runtime promotes the would-be mismatch to high with NO reason', () => {
+      const result = resolveSingleResultConfidence(makeBook({ duration: 539 }), 33219.47, 33219.49);
+      expect(result.confidence).toBe('high');
+      expect(result.reason).toBeUndefined();
+      expect(result.reasonKind).toBeUndefined();
+    });
+
+    it('an out-of-band chapter runtime leaves the mismatch reason intact (suppress-only)', () => {
+      const result = resolveSingleResultConfidence(makeBook({ duration: 539 }), 33519.49, 33219.49);
+      expect(result.confidence).toBe('medium');
+      expect(result.reasonKind).toBe('duration-mismatch');
+    });
   });
 });
 

--- a/src/server/services/match-job.helpers.ts
+++ b/src/server/services/match-job.helpers.ts
@@ -7,7 +7,7 @@ import { normalizeProductionType } from '../../core/metadata/production-type.js'
 import { cleanTagTitle, extractYear, hasTagSeriesMarker, isPureVolumeMarker } from '../utils/folder-parsing.js';
 import type { Confidence, MatchCandidate, MatchResult } from './match-job.types.js';
 import type { MatchReasonKind } from '../../shared/match-reason-kind.js';
-import type { MatchSource } from './tag-search-planner.js';
+import type { MatchSource, TagSearchOutcome } from './tag-search-planner.js';
 import type { BookService } from './book.service.js';
 import { serializeError } from '../utils/serialize-error.js';
 import { pickPrimarySeries } from '../../shared/pick-primary-series.js';
@@ -152,8 +152,21 @@ export interface DurationConfidenceResult {
 export function isDurationVerified(
   meta: BookMetadata,
   scannedSeconds: number | undefined,
+  chapterSeconds?: number | undefined,
 ): boolean {
   if (!scannedSeconds || scannedSeconds <= 0) return false;
+  // #1942 — the edition's own chapter table is a strictly more authoritative
+  // runtime than the provider's `runtimeLengthMin` scalar (for Fablehaven
+  // B00CXXEX8W the scalar understates its own chapter table by ~14.6 min, so a
+  // pristine file flags). It is consulted as a CORROBORATING SECOND SOURCE, never
+  // a replacement: it is only ever passed in when the scalar check already
+  // disagreed, and the `||` shape means it can only ever ADD agreement. A file
+  // out of band against BOTH references still fails exactly as before. The
+  // caller converts `runtimeLengthMs` → seconds; the same shared band judges both.
+  if (chapterSeconds !== undefined && Number.isFinite(chapterSeconds) && chapterSeconds > 0
+    && withinDurationTolerance(chapterSeconds, scannedSeconds)) {
+    return true;
+  }
   if (!meta.duration || meta.duration <= 0) return false;
   return withinDurationTolerance(meta.duration * 60, scannedSeconds);
 }
@@ -168,17 +181,24 @@ export function isDurationVerified(
  * absolute band lives in exactly one place (#1266/#1850). `scannedSeconds` is the
  * unrounded scanner runtime in SECONDS; the mismatch reason renders it from
  * seconds and the provider side from minutes.
+ *
+ * `chapterSeconds` (#1942) is the optional corroborating chapter-table runtime in
+ * SECONDS, supplied only on a re-check after this function already returned
+ * `duration-mismatch`. It is suppress-only — see `isDurationVerified`. The
+ * mismatch reason still renders the SCALAR expectation, because that is the
+ * runtime the user sees on the catalog page.
  */
 export function resolveConfidenceFromDuration(
   scored: { meta: BookMetadata }[],
   scannedSeconds: number | undefined,
+  chapterSeconds?: number | undefined,
 ): DurationConfidenceResult {
   if (!scannedSeconds || scannedSeconds <= 0) {
     return { confidence: 'medium', reason: 'Multiple results — no duration data to disambiguate', reasonKind: 'no-duration-data' };
   }
   const topResult = scored[0]!;
   if (topResult.meta.duration && topResult.meta.duration > 0) {
-    if (isDurationVerified(topResult.meta, scannedSeconds)) return { confidence: 'high' };
+    if (isDurationVerified(topResult.meta, scannedSeconds, chapterSeconds)) return { confidence: 'high' };
     return {
       confidence: 'medium',
       reason: `Duration mismatch — scanned ${formatDurationSeconds(scannedSeconds)} vs expected ${formatDurationSeconds(topResult.meta.duration * 60)}`,
@@ -200,13 +220,18 @@ export function resolveConfidenceFromDuration(
  * the pre-existing attempt cap, which can clamp a raw `high` to final `medium` for
  * a `maxConfidence: 'medium'` attempt. The helper only ever demotes an otherwise-
  * `high` single; it never raises a capped attempt's ceiling.
+ *
+ * `chapterSeconds` (#1942) is the optional corroborating chapter-table runtime in
+ * SECONDS, supplied only on a re-check after this function already returned
+ * `duration-mismatch`. Suppress-only — see `isDurationVerified`.
  */
 export function resolveSingleResultConfidence(
   meta: BookMetadata,
   scannedSeconds: number | undefined,
+  chapterSeconds?: number | undefined,
 ): DurationConfidenceResult {
   const bothPresent = !!scannedSeconds && scannedSeconds > 0 && !!meta.duration && meta.duration > 0;
-  if (bothPresent && !isDurationVerified(meta, scannedSeconds)) {
+  if (bothPresent && !isDurationVerified(meta, scannedSeconds, chapterSeconds)) {
     return {
       confidence: 'medium',
       reason: `Duration mismatch — scanned ${formatDurationSeconds(scannedSeconds)} vs expected ${formatDurationSeconds(meta.duration! * 60)}`,
@@ -214,6 +239,77 @@ export function resolveSingleResultConfidence(
     };
   }
   return { confidence: 'high' };
+}
+
+/**
+ * Top-result title-similarity floor. Below this, the filename pass emits
+ * `confidence: 'none'` and the tag pass falls through to it.
+ */
+export const TITLE_SIMILARITY_FLOOR = 0.5;
+/** Tag-pass author-name dice threshold (#984). */
+export const TAG_AUTHOR_PREDICATE_FLOOR = 0.7;
+
+/**
+ * AC5 — title floor + author predicate gate for the tag pass. Logs at debug on
+ * failure. Lives here rather than on `MatchJobService` for the `max-lines` budget
+ * (#1942 F12); it needs nothing from the job beyond the logger and the path.
+ */
+export function tagPassPredicatesPass(
+  log: FastifyBaseLogger,
+  path: string,
+  tagQuery: TagQuery,
+  top: { meta: BookMetadata; score: number },
+): boolean {
+  const titleFloor = tagTitleScore(tagQuery.title, top.meta);
+  if (titleFloor < TITLE_SIMILARITY_FLOOR) {
+    log.debug(
+      { path, titleSimilarity: titleFloor.toFixed(2), bestTitle: top.meta.title },
+      'Tag-derived top result below title floor — falling through',
+    );
+    return false;
+  }
+  const topAuthor = top.meta.authors?.[0]?.name;
+  const authorScore = topAuthor
+    ? diceCoefficient(normalizeNarrator(topAuthor), normalizeNarrator(tagQuery.author))
+    : 0;
+  if (authorScore < TAG_AUTHOR_PREDICATE_FLOOR) {
+    log.debug(
+      { path, topResultAuthor: topAuthor, tagAuthor: tagQuery.author, score: authorScore.toFixed(2) },
+      'tag-author predicate failed — falling through to filename-derived path',
+    );
+    return false;
+  }
+  return true;
+}
+
+/**
+ * ASIN kill-shot. Returns a single-candidate outcome when the tagged ASIN
+ * resolves; null on miss or provider throw (the caller falls through to the
+ * planner attempts). Same `max-lines` extraction as `tagPassPredicatesPass`.
+ */
+export async function runAsinKillShot(
+  metadataService: { getBook(id: string): Promise<BookMetadata | null> },
+  log: FastifyBaseLogger,
+  path: string,
+  tagAsin: string,
+  tagQuery: TagQuery,
+): Promise<TagSearchOutcome | null> {
+  try {
+    const found = await metadataService.getBook(tagAsin);
+    if (found) {
+      log.debug({ path, tagAsin, title: found.title }, 'Tag-search ASIN kill-shot hit');
+      return {
+        scored: [{ meta: found, score: 1.0 }],
+        attempt: { title: found.title ?? tagQuery.title, author: tagQuery.author, source: 'asin-tag', maxConfidence: 'high' },
+      };
+    }
+  } catch (error: unknown) {
+    log.warn(
+      { error: serializeError(error), path, tagAsin },
+      'tag-search provider error — falling through to filename-derived path',
+    );
+  }
+  return null;
 }
 
 export interface TagQuery {

--- a/src/server/services/match-job.service.rate-limit.test.ts
+++ b/src/server/services/match-job.service.rate-limit.test.ts
@@ -36,6 +36,9 @@ const mockAudnexus = {
   type: 'audnexus',
   getBook: vi.fn().mockResolvedValue(null),
   getAuthor: vi.fn().mockResolvedValue(null),
+  // #1942 — the chapter-runtime lookup the corroboration bridge calls on a
+  // would-be duration mismatch.
+  getChapterRuntime: vi.fn().mockResolvedValue({ kind: 'not_found' }),
 };
 
 vi.mock('../../core/index.js', async (importOriginal) => {
@@ -78,12 +81,14 @@ describe('MatchJobService — rate-limit provider fan-out (AC26 / F2)', () => {
     mockAudibleProvider.test.mockReset();
     mockAudnexus.getBook.mockReset();
     mockAudnexus.getAuthor.mockReset();
+    mockAudnexus.getChapterRuntime.mockReset();
     mockAudibleProvider.searchBooks.mockResolvedValue({ books: [] });
     mockAudibleProvider.searchSeries.mockResolvedValue([]);
     mockAudibleProvider.getBook.mockResolvedValue(null);
     mockAudibleProvider.test.mockResolvedValue({ success: true });
     mockAudnexus.getBook.mockResolvedValue(null);
     mockAudnexus.getAuthor.mockResolvedValue(null);
+    mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'not_found' });
 
     vi.mocked(scanAudioDirectory).mockReset();
 
@@ -143,5 +148,69 @@ describe('MatchJobService — rate-limit provider fan-out (AC26 / F2)', () => {
     // gate (or if MetadataService's `isRateLimited` short-circuit broke), this
     // would be ≥ 2.
     expect(mockAudibleProvider.searchBooks).toHaveBeenCalledTimes(1);
+  });
+
+  // #1942 — same boundary, for the chapter-runtime corroboration. The mock-service
+  // match-job test stubs `metadataService.getChapterRuntimeSeconds` directly, which
+  // cannot prove the lookup is throttled and 429-gated rather than reaching the
+  // provider on its own.
+  describe('chapter-runtime corroboration through the real service (#1942)', () => {
+    const FABLEHAVEN_ASIN = 'B00CXXEX8W';
+
+    function fablehavenScan() {
+      return {
+        codec: 'AAC',
+        bitrate: 128000,
+        sampleRate: 44100,
+        channels: 2,
+        bitrateMode: 'cbr' as const,
+        fileFormat: 'm4b',
+        totalDuration: 33219.47,
+        totalSize: 100_000_000,
+        fileCount: 1,
+        hasCoverArt: false,
+      };
+    }
+
+    const candidate: MatchCandidate = {
+      path: '/audiobooks/Fablehaven',
+      title: 'Fablehaven',
+      author: 'Brandon Mull',
+    };
+
+    async function runMatch() {
+      vi.mocked(scanAudioDirectory).mockResolvedValue(fablehavenScan());
+      mockAudibleProvider.searchBooks.mockResolvedValue({
+        books: [{ title: 'Fablehaven', authors: [{ name: 'Brandon Mull' }], duration: 539, asin: FABLEHAVEN_ASIN }],
+      });
+      const id = matchService.createJob([candidate]);
+      await waitForJob(matchService, id);
+      return matchService.getJob(id)!.results[0]!;
+    }
+
+    it('rescues the would-be mismatch through the real Audnexus bridge', async () => {
+      mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'ok', runtimeLengthMs: 33219490, isAccurate: true });
+
+      const result = await runMatch();
+
+      expect(result.confidence).toBe('high');
+      expect(result.reasonKind).toBeUndefined();
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledExactlyOnceWith(FABLEHAVEN_ASIN);
+    });
+
+    it('a chapters 429 degrades to the scalar verdict and arms the shared provider backoff', async () => {
+      mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'rate_limited', retryAfterMs: 60_000 });
+
+      const result = await runMatch();
+
+      // Degrades — it must NOT escape into matchSingleBook's catch as 'none'.
+      expect(result.confidence).toBe('medium');
+      expect(result.reasonKind).toBe('duration-mismatch');
+      expect(result.error).toBeUndefined();
+
+      // The provider-wide gate is armed, so the next Audnexus call short-circuits.
+      await expect(metadataService.getChapterRuntimeSeconds('B_ANY_OTHER')).resolves.toBeUndefined();
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/server/services/match-job.service.test.ts
+++ b/src/server/services/match-job.service.test.ts
@@ -45,6 +45,9 @@ function createMockMetadataService(): MetadataService {
   return inject<MetadataService>({
     searchBooks: vi.fn().mockResolvedValue([]),
     getBook: vi.fn().mockResolvedValue(null),
+    // #1942 — the lazy chapter-runtime bridge. Defaults to "no usable runtime",
+    // so every pre-existing duration expectation in this file is unchanged.
+    getChapterRuntimeSeconds: vi.fn().mockResolvedValue(undefined),
     search: vi.fn(),
     searchSeries: vi.fn(),
     getAuthor: vi.fn(),
@@ -4225,6 +4228,364 @@ describe('MatchJobService', () => {
       const result = await runSingle();
       expect(result.confidence).toBe('high');
       expect(log.info).not.toHaveBeenCalledWith(expect.anything(), expect.stringContaining(CAP_LOG));
+    });
+  });
+
+  // ==========================================================================
+  // #1942 — chapter-runtime corroboration of a would-be duration mismatch.
+  //
+  // The Fablehaven Book 1 case, verbatim: the file is 33219.47s and matches the
+  // matched edition's own chapter table to 0.02s, but Audible's `runtimeLengthMin`
+  // scalar for that ASIN (539 min → 32340s) understates its own chapter table by
+  // ~14.6 minutes. Comparing against the scalar flags a pristine file. The chapter
+  // table is consulted as a corroborating SECOND source, lazily and suppress-only.
+  // ==========================================================================
+  describe('#1942 chapter-runtime corroboration', () => {
+    const FABLEHAVEN_ASIN = 'B00CXXEX8W';
+    const SCANNED_SECONDS = 33219.47;
+    const SCALAR_MINUTES = 539;
+    const CHAPTER_SECONDS = 33219.49;
+    const CAP_LOG = 'Narrator wrong-edition cap fired';
+    const MISMATCH = 'Duration mismatch';
+
+    const candidate: MatchCandidate = {
+      path: '/audiobooks/Fablehaven',
+      title: 'Fablehaven',
+      author: 'Brandon Mull',
+    };
+
+    function makeScan(overrides: Partial<Record<string, unknown>> = {}) {
+      return {
+        codec: 'AAC',
+        bitrate: 128000,
+        sampleRate: 44100,
+        channels: 2,
+        bitrateMode: 'cbr' as const,
+        fileFormat: 'm4b',
+        totalSize: 100_000_000,
+        fileCount: 1,
+        hasCoverArt: false,
+        totalDuration: SCANNED_SECONDS,
+        ...overrides,
+      };
+    }
+
+    /** Drives the TAG assembly path (`tagTitle` + `tagAuthor` populated). */
+    function tagScan(overrides: Partial<Record<string, unknown>> = {}) {
+      return makeScan({ tagTitle: 'Fablehaven', tagAuthor: 'Brandon Mull', ...overrides });
+    }
+
+    function fablehaven(overrides: Partial<BookMetadata> = {}): BookMetadata {
+      return makeBookMetadata({
+        title: 'Fablehaven',
+        authors: [{ name: 'Brandon Mull' }],
+        narrators: ['E. B. Stevens'],
+        duration: SCALAR_MINUTES,
+        asin: FABLEHAVEN_ASIN,
+        ...overrides,
+      });
+    }
+
+    async function runSingle(): Promise<MatchResult> {
+      const id = service.createJob([candidate]);
+      await waitForJob(service, id);
+      return service.getJob(id)!.results[0]!;
+    }
+
+    /** Chapter lookups the job actually issued. */
+    function chapterLookups(): unknown[][] {
+      return vi.mocked(metadataService.getChapterRuntimeSeconds).mock.calls;
+    }
+
+    beforeEach(() => {
+      vi.mocked(metadataService.getChapterRuntimeSeconds).mockResolvedValue(CHAPTER_SECONDS);
+    });
+
+    describe('AC6 — rescue, run independently through BOTH assembly paths (F21)', () => {
+      it('FILENAME assembly (single result): high, no duration-mismatch reason, exactly one lookup', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+        expect(result.reasonKind).toBeUndefined();
+        expect(chapterLookups()).toEqual([[FABLEHAVEN_ASIN]]);
+      });
+
+      it('FILENAME assembly (multi result): high, no duration-mismatch reason, exactly one lookup', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          fablehaven(),
+          fablehaven({ asin: 'B0OTHEREDN', duration: 700 }),
+        ]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+        expect(result.reasonKind).toBeUndefined();
+        expect(chapterLookups()).toEqual([[FABLEHAVEN_ASIN]]);
+      });
+
+      it('TAG assembly: high, no duration-mismatch reason, exactly one lookup', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(tagScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+        expect(result.reasonKind).toBeUndefined();
+        expect(chapterLookups()).toEqual([[FABLEHAVEN_ASIN]]);
+      });
+
+      it('TAG assembly via the ASIN kill-shot: high, no duration-mismatch reason, exactly one lookup', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(tagScan({ tagAsin: FABLEHAVEN_ASIN }));
+        vi.mocked(metadataService.getBook).mockResolvedValue(fablehaven());
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('high');
+        // Both reason fields, not just the kind: a rescued row must not carry
+        // stale mismatch TEXT alongside its promoted confidence.
+        expect(result.reason).toBeUndefined();
+        expect(result.reasonKind).toBeUndefined();
+        // The kill-shot short-circuits the planner, so it reaches the corroboration
+        // bridge by its own route — pin the count so duplicated or deleted wiring
+        // on that route fails here.
+        expect(chapterLookups()).toEqual([[FABLEHAVEN_ASIN]]);
+      });
+
+      it('without the corroboration the SAME inputs flag — the rescue is genuinely doing the work', async () => {
+        vi.mocked(metadataService.getChapterRuntimeSeconds).mockResolvedValue(undefined);
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.reason).toContain(MISMATCH);
+        expect(result.reasonKind).toBe('duration-mismatch');
+      });
+    });
+
+    describe('AC8 — cap routing: the promoted verdict reaches applyNarratorCap with durationVerified true', () => {
+      // The cap's observability log is the only place `capCtx.durationVerified`
+      // is observable, and it fires only on an actual high → medium demotion —
+      // so each case pairs the rescue with a narrator mismatch.
+      it('FILENAME single assembly', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan({ tagNarrator: 'Adriel Brandt' }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.reason).toContain('Narrator mismatch');
+        expect(log.info).toHaveBeenCalledWith(
+          expect.objectContaining({ matchSource: 'filename-single', durationVerified: true }),
+          expect.stringContaining(CAP_LOG),
+        );
+      });
+
+      it('FILENAME multi assembly', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan({ tagNarrator: 'Adriel Brandt' }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          fablehaven(),
+          fablehaven({ asin: 'B0OTHEREDN', duration: 700, narrators: ['Some Reader'] }),
+        ]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(log.info).toHaveBeenCalledWith(
+          expect.objectContaining({ matchSource: 'filename-duration-resolved', durationVerified: true }),
+          expect.stringContaining(CAP_LOG),
+        );
+      });
+
+      it('TAG assembly', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(tagScan({ tagNarrator: 'Adriel Brandt' }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(log.info).toHaveBeenCalledWith(
+          expect.objectContaining({ matchSource: 'exact', durationVerified: true }),
+          expect.stringContaining(CAP_LOG),
+        );
+      });
+    });
+
+    describe('AC7 — suppress-only: a genuinely-off file still flags', () => {
+      it('FILENAME assembly: a file 300s past BOTH references stays medium/duration-mismatch', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan({ totalDuration: SCANNED_SECONDS + 300 }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.reason).toContain(MISMATCH);
+        expect(result.reasonKind).toBe('duration-mismatch');
+      });
+
+      it('TAG assembly: a TRUNCATED file (half the runtime) stays medium/duration-mismatch', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(tagScan({ totalDuration: SCANNED_SECONDS / 2 }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.reason).toContain(MISMATCH);
+        expect(result.reasonKind).toBe('duration-mismatch');
+      });
+
+      it('never demotes: a scalar-VERIFIED match stays high even if the chapter runtime disagrees', async () => {
+        vi.mocked(metadataService.getChapterRuntimeSeconds).mockResolvedValue(1);
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan({ totalDuration: SCALAR_MINUTES * 60 }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('high');
+        expect(result.reason).toBeUndefined();
+      });
+
+      it('the mismatch reason still renders the SCALAR expectation when nothing rescues it', async () => {
+        vi.mocked(metadataService.getChapterRuntimeSeconds).mockResolvedValue(undefined);
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.reason).toBe('Duration mismatch — scanned 9h 13m vs expected 8h 59m');
+      });
+    });
+
+    describe('AC4 — laziness: only a qualifying mismatch fetches', () => {
+      it('a scalar-VERIFIED match issues ZERO chapter lookups (filename + tag)', async () => {
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan({ totalDuration: SCALAR_MINUTES * 60 }));
+        expect((await runSingle()).confidence).toBe('high');
+        vi.mocked(scanAudioDirectory).mockResolvedValue(tagScan({ totalDuration: SCALAR_MINUTES * 60 }));
+        expect((await runSingle()).confidence).toBe('high');
+
+        expect(chapterLookups()).toEqual([]);
+      });
+
+      it('an ambiguity-class review (no-duration-data) issues ZERO chapter lookups', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan({ totalDuration: 0 }));
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          fablehaven(),
+          fablehaven({ asin: 'B0OTHEREDN', duration: 700 }),
+        ]);
+
+        const result = await runSingle();
+
+        expect(result.reasonKind).toBe('no-duration-data');
+        expect(chapterLookups()).toEqual([]);
+      });
+
+      it('a missing-duration review issues ZERO chapter lookups', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([
+          fablehaven({ duration: undefined }),
+          fablehaven({ asin: 'B0OTHEREDN', duration: undefined, title: 'Fablehaven' }),
+        ]);
+
+        const result = await runSingle();
+
+        expect(result.reasonKind).toBe('missing-duration');
+        expect(chapterLookups()).toEqual([]);
+      });
+
+      it.each([
+        ['FILENAME', makeScan],
+        ['TAG', tagScan],
+      ])('%s assembly: a duration mismatch whose top candidate has NO asin issues zero lookups and keeps the scalar verdict', async (_label, scan) => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(scan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven({ asin: undefined })]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.reasonKind).toBe('duration-mismatch');
+        expect(chapterLookups()).toEqual([]);
+      });
+
+      it.each([
+        ['FILENAME', makeScan],
+        ['TAG', tagScan],
+      ])('%s assembly: a BLANK asin is treated as absent — zero lookups', async (_label, scan) => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(scan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven({ asin: '   ' })]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.reasonKind).toBe('duration-mismatch');
+        expect(chapterLookups()).toEqual([]);
+      });
+    });
+
+    describe('boundary — the shared 240s band judges the chapter runtime too', () => {
+      it.each([
+        ['exactly 240s from the chapter runtime verifies (inclusive)', 240, 'high'],
+        ['241s flags', 241, 'medium'],
+      ])('%s', async (_label, delta, expected) => {
+        vi.mocked(metadataService.getChapterRuntimeSeconds).mockResolvedValue(SCANNED_SECONDS + delta);
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        expect((await runSingle()).confidence).toBe(expected);
+      });
+    });
+
+    describe('AC9 — graceful degradation', () => {
+      it('a THROWING chapter lookup degrades to the scalar verdict — it never becomes confidence "none"', async () => {
+        vi.mocked(metadataService.getChapterRuntimeSeconds).mockRejectedValue(new Error('Audnexus exploded'));
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.bestMatch?.asin).toBe(FABLEHAVEN_ASIN);
+        expect(result.reasonKind).toBe('duration-mismatch');
+        expect(result.error).toBeUndefined();
+        expect(log.debug).toHaveBeenCalledWith(
+          expect.objectContaining({ asin: FABLEHAVEN_ASIN }),
+          expect.stringContaining('keeping the scalar duration verdict'),
+        );
+      });
+
+      it('the same failure on the TAG path also degrades rather than losing the match', async () => {
+        vi.mocked(metadataService.getChapterRuntimeSeconds).mockRejectedValue(new Error('Audnexus exploded'));
+        vi.mocked(scanAudioDirectory).mockResolvedValue(tagScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(result.confidence).toBe('medium');
+        expect(result.bestMatch?.asin).toBe(FABLEHAVEN_ASIN);
+        expect(result.error).toBeUndefined();
+      });
+    });
+
+    describe('AC10 — no new MatchResult field', () => {
+      it('a rescued row carries no chapter-runtime field for the client to consume', async () => {
+        vi.mocked(scanAudioDirectory).mockResolvedValue(makeScan());
+        vi.mocked(metadataService.searchBooks).mockResolvedValue([fablehaven()]);
+
+        const result = await runSingle();
+
+        expect(Object.keys(result).sort()).toEqual(
+          ['alternatives', 'bestMatch', 'confidence', 'path', 'scannedSeconds'],
+        );
+      });
     });
   });
 });

--- a/src/server/services/match-job.service.ts
+++ b/src/server/services/match-job.service.ts
@@ -10,12 +10,13 @@ import { resolveFfprobePathFromSettings } from '../../core/utils/ffprobe-path.js
 import { resolveFfmpegPath } from '../../core/utils/audio-processor.js';
 import type { SettingsService } from './settings.service.js';
 import { Semaphore } from '../utils/semaphore.js';
-import { diceCoefficient, normalizeNarrator } from '../../core/utils/similarity.js';
+import { diceCoefficient } from '../../core/utils/similarity.js';
 import { searchWithSwapRetryTrace } from '../utils/search-helpers.js';
 import { getErrorMessage } from '../utils/error-message.js';
 import { serializeError } from '../utils/serialize-error.js';
-import { applyAttemptCap, applyLibraryDuplicate, applyNarratorCap, deriveTagQuery, isDurationVerified, rankResults, rankResultsCleaned, resolveConfidenceFromDuration, resolveSingleResultConfidence, tagTitleScore, type NarratorCapContext, type TagQuery } from './match-job.helpers.js';
+import { applyAttemptCap, applyLibraryDuplicate, applyNarratorCap, deriveTagQuery, isDurationVerified, rankResults, rankResultsCleaned, resolveConfidenceFromDuration, resolveSingleResultConfidence, runAsinKillShot, tagPassPredicatesPass, TITLE_SIMILARITY_FLOOR, type DurationConfidenceResult, type NarratorCapContext, type TagQuery } from './match-job.helpers.js';
 import { planTagSearchAttempts, type TagSearchAttempt, type TagSearchOutcome } from './tag-search-planner.js';
+import { corroborateDurationVerdict, type CorroboratedDuration } from './chapter-corroboration.js';
 
 
 // Data contracts live in match-job.types.ts (#1864 file-size cap); re-exported so the
@@ -24,8 +25,6 @@ export type { Confidence, MatchCandidate, MatchResult, MatchJobStatus } from './
 
 const MAX_CONCURRENCY = 5;
 const TTL_MS = 10 * 60 * 1000; // 10 minutes after completion
-const TITLE_SIMILARITY_FLOOR = 0.5; // Below this, confidence is 'none'
-const TAG_AUTHOR_PREDICATE_FLOOR = 0.7; // Tag-pass author-name dice threshold (#984)
 
 // `capConfidence`/`applyAttemptCap` moved to match-job.helpers.ts (#1662, file-size cap);
 // re-exported so the public surface (capConfidence is asserted in tests) is unchanged.
@@ -295,6 +294,7 @@ class MatchJob {
           });
         }
 
+        const scanned = audioResult?.totalDuration;
         if (scored.length === 1) {
           // #1821 — corroborate the single result against the scanned runtime: a
           // grossly-off duration demotes high → medium (Review); a MISSING runtime
@@ -303,14 +303,24 @@ class MatchJob {
           // disproven) — never inferred from the resolved confidence.
           // Unrounded scanned seconds (#1850) — the tolerance check compares
           // full-precision seconds (the minute-rounded `duration` is logging only).
-          resolved = { path: book.path, bestMatch: topScored.meta, alternatives: [], ...resolveSingleResultConfidence(topScored.meta, audioResult?.totalDuration) };
-          capCtx = { log: this.log, matchSource: 'filename-single', durationVerified: isDurationVerified(topScored.meta, audioResult?.totalDuration) };
+          const { verdict, chapterSeconds } = await this.corroborateDuration(
+            book, topScored.meta,
+            resolveSingleResultConfidence(topScored.meta, scanned),
+            cs => resolveSingleResultConfidence(topScored.meta, scanned, cs),
+          );
+          resolved = { path: book.path, bestMatch: topScored.meta, alternatives: [], ...verdict };
+          capCtx = { log: this.log, matchSource: 'filename-single', durationVerified: isDurationVerified(topScored.meta, scanned, chapterSeconds) };
         } else {
           // Multiple results — the winner was already chosen by `rankResults`
           // (text score, with duration only breaking a score tie, #1882); this
           // step reads confidence off that top candidate's runtime agreement.
           // Unrounded seconds (#1850); `duration` (minutes) below is logging only.
-          const { confidence, reason, reasonKind } = resolveConfidenceFromDuration(scored, audioResult?.totalDuration);
+          const { verdict } = await this.corroborateDuration(
+            book, topScored.meta,
+            resolveConfidenceFromDuration(scored, scanned),
+            cs => resolveConfidenceFromDuration(scored, scanned, cs),
+          );
+          const { confidence, reason, reasonKind } = verdict;
           this.log.debug(
             {
               path: book.path,
@@ -355,6 +365,29 @@ class MatchJob {
     }
   }
 
+  /**
+   * Lazy chapter-runtime corroboration of a would-be duration mismatch (#1942).
+   * Thin delegator — the trigger rule, the cache/single-flight, and the throttled
+   * Audnexus bridge all live in `chapter-corroboration.ts` / `MetadataService`.
+   * Runs BEFORE `applyNarratorCap` so the narrator wrong-edition guard evaluates
+   * against the corroborated verdict.
+   */
+  private corroborateDuration(
+    book: MatchCandidate,
+    meta: BookMetadata,
+    verdict: DurationConfidenceResult,
+    recheck: (chapterSeconds: number) => DurationConfidenceResult,
+  ): Promise<CorroboratedDuration> {
+    return corroborateDurationVerdict({
+      verdict,
+      asin: meta.asin,
+      path: book.path,
+      log: this.log,
+      lookupChapterSeconds: asin => this.metadataService.getChapterRuntimeSeconds(asin),
+      recheck,
+    });
+  }
+
   // Pass 1 — tag-derived match (#984, #1036). Returns null on any failure
   // (no tags, zero results across all attempts, floor fail, predicate fail,
   // unexpected throw); caller falls through to filename-derived. Bypasses
@@ -378,24 +411,31 @@ class MatchJob {
     const { scored, attempt } = outcome;
     const top = scored[0]!;
 
-    // #1652 (F6) — genuine runtime corroboration of the chosen edition for EVERY
-    // tag source (the `/import-uat` signal logged by the cap). Distinct from
-    // `capBypassedByDuration`, which is gated on `maxConfidence === 'medium'` and
-    // only governs the strip-attempt cap bypass — an exact/ASIN attempt
-    // (`maxConfidence: 'high'`) can be durationVerified while capBypassed is false.
-    const durationVerified = isDurationVerified(top.meta, scannedSeconds);
-    // #1266 — when the scanned runtime verifies the top candidate, bypass the strip `medium` cap and keep `high`.
-    const capBypassedByDuration = attempt.maxConfidence === 'medium' && durationVerified;
-    const cap = (raw: Confidence, reason: string | undefined, reasonKind: MatchReasonKind | undefined): { confidence: Confidence; reason?: string; reasonKind?: MatchReasonKind } =>
-      capBypassedByDuration ? { confidence: 'high' } : applyAttemptCap(raw, attempt.maxConfidence, reason, reasonKind);
-
     const single = scored.length === 1;
     // #1821 — corroborate the single tag-result (incl. the ASIN kill-shot) against
     // the scanned runtime. The raw value still flows through the attempt `cap()`
     // below: a mismatch → raw `medium` survives (durationVerified false, so
     // capBypassedByDuration false); a missing runtime → raw `high`, clamped to
     // `medium` by a `maxConfidence: 'medium'` attempt exactly as before.
-    const { confidence, reason, reasonKind } = single ? resolveSingleResultConfidence(top.meta, scannedSeconds) : resolveConfidenceFromDuration(scored, scannedSeconds);
+    const resolveVerdict = (chapterSeconds?: number): DurationConfidenceResult => single
+      ? resolveSingleResultConfidence(top.meta, scannedSeconds, chapterSeconds)
+      : resolveConfidenceFromDuration(scored, scannedSeconds, chapterSeconds);
+    // #1942 — a would-be duration mismatch gets one lazy second opinion from the
+    // edition's chapter table BEFORE the attempt cap and the narrator cap see it.
+    const { verdict, chapterSeconds } = await this.corroborateDuration(book, top.meta, resolveVerdict(), resolveVerdict);
+
+    // #1652 (F6) — genuine runtime corroboration of the chosen edition for EVERY
+    // tag source (the `/import-uat` signal logged by the cap). Distinct from
+    // `capBypassedByDuration`, which is gated on `maxConfidence === 'medium'` and
+    // only governs the strip-attempt cap bypass — an exact/ASIN attempt
+    // (`maxConfidence: 'high'`) can be durationVerified while capBypassed is false.
+    const durationVerified = isDurationVerified(top.meta, scannedSeconds, chapterSeconds);
+    // #1266 — when the scanned runtime verifies the top candidate, bypass the strip `medium` cap and keep `high`.
+    const capBypassedByDuration = attempt.maxConfidence === 'medium' && durationVerified;
+    const cap = (raw: Confidence, reason: string | undefined, reasonKind: MatchReasonKind | undefined): { confidence: Confidence; reason?: string; reasonKind?: MatchReasonKind } =>
+      capBypassedByDuration ? { confidence: 'high' } : applyAttemptCap(raw, attempt.maxConfidence, reason, reasonKind);
+
+    const { confidence, reason, reasonKind } = verdict;
     const result: MatchResult = { path: book.path, ...cap(confidence, reason, reasonKind), bestMatch: top.meta, alternatives: single ? [] : scored.slice(1).map(s => s.meta) };
     return { result, ctx: { log: this.log, matchSource: attempt.source, durationVerified } };
   }
@@ -411,7 +451,7 @@ class MatchJob {
     tagQuery: TagQuery,
   ): Promise<TagSearchOutcome | null> {
     if (audioResult.tagAsin) {
-      const asinHit = await this.tryAsinKillShot(book, audioResult.tagAsin, tagQuery);
+      const asinHit = await runAsinKillShot(this.metadataService, this.log, book.path, audioResult.tagAsin, tagQuery);
       if (asinHit) return asinHit;
     }
 
@@ -427,30 +467,6 @@ class MatchJob {
       { path: book.path, tagTitle: tagQuery.title, attemptCount: attempts.length },
       'Tag-search planner exhausted all attempts — falling through',
     );
-    return null;
-  }
-
-  /** ASIN kill-shot. Returns outcome when getBook succeeds; null on miss/throw. */
-  private async tryAsinKillShot(
-    book: MatchCandidate,
-    tagAsin: string,
-    tagQuery: TagQuery,
-  ): Promise<TagSearchOutcome | null> {
-    try {
-      const found = await this.metadataService.getBook(tagAsin);
-      if (found) {
-        this.log.debug({ path: book.path, tagAsin, title: found.title }, 'Tag-search ASIN kill-shot hit');
-        return {
-          scored: [{ meta: found, score: 1.0 }],
-          attempt: { title: found.title ?? tagQuery.title, author: tagQuery.author, source: 'asin-tag', maxConfidence: 'high' },
-        };
-      }
-    } catch (error: unknown) {
-      this.log.warn(
-        { error: serializeError(error), path: book.path, tagAsin },
-        'tag-search provider error — falling through to filename-derived path',
-      );
-    }
     return null;
   }
 
@@ -492,41 +508,13 @@ class MatchJob {
     const top = scored[0];
     if (!top) return null;
 
-    if (!this.tagPassPredicatesPass(book, attemptQuery, top)) return null;
+    if (!tagPassPredicatesPass(this.log, book.path, attemptQuery, top)) return null;
 
     this.log.debug(
       { path: book.path, source: attempt.source, originalTagTitle: tagQuery.title, attemptTitle: attempt.title, bestTitle: top.meta.title },
       'Tag-search attempt won',
     );
     return { scored, attempt };
-  }
-
-  /** AC5 — title floor + author predicate gate for the tag pass. Logs at debug on failure. */
-  private tagPassPredicatesPass(
-    book: MatchCandidate,
-    tagQuery: TagQuery,
-    top: { meta: BookMetadata; score: number },
-  ): boolean {
-    const titleFloor = tagTitleScore(tagQuery.title, top.meta);
-    if (titleFloor < TITLE_SIMILARITY_FLOOR) {
-      this.log.debug(
-        { path: book.path, titleSimilarity: titleFloor.toFixed(2), bestTitle: top.meta.title },
-        'Tag-derived top result below title floor — falling through',
-      );
-      return false;
-    }
-    const topAuthor = top.meta.authors?.[0]?.name;
-    const authorScore = topAuthor
-      ? diceCoefficient(normalizeNarrator(topAuthor), normalizeNarrator(tagQuery.author))
-      : 0;
-    if (authorScore < TAG_AUTHOR_PREDICATE_FLOOR) {
-      this.log.debug(
-        { path: book.path, topResultAuthor: topAuthor, tagAuthor: tagQuery.author, score: authorScore.toFixed(2) },
-        'tag-author predicate failed — falling through to filename-derived path',
-      );
-      return false;
-    }
-    return true;
   }
 
   private async fetchDetails(results: BookMetadata[]): Promise<BookMetadata[]> {

--- a/src/server/services/metadata.service.test.ts
+++ b/src/server/services/metadata.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { RateLimitError, TransientError, METADATA_SEARCH_PROVIDER_FACTORIES, NARRATOR_PLACEHOLDERS } from '../../core/index.js';
 import { createMockLogger, inject } from '../__tests__/helpers.js';
 import type { FastifyBaseLogger } from 'fastify';
@@ -23,6 +23,8 @@ const mockAudnexus = {
   getBook: vi.fn().mockResolvedValue(null),
   getBookDetailed: vi.fn().mockResolvedValue({ kind: 'not_found' }),
   getAuthor: vi.fn().mockResolvedValue(null),
+  // #1942 — the chapter-runtime lookup the corroborator bridges to.
+  getChapterRuntime: vi.fn().mockResolvedValue({ kind: 'not_found' }),
 };
 
 vi.mock('../../core/index.js', async (importOriginal) => {
@@ -52,6 +54,7 @@ describe('MetadataService', () => {
     mockAudnexus.getBook.mockReset();
     mockAudnexus.getBookDetailed.mockReset();
     mockAudnexus.getAuthor.mockReset();
+    mockAudnexus.getChapterRuntime.mockReset();
     // Reset mock return values
     mockAudibleProvider.searchBooks.mockResolvedValue({ books: [] });
     mockAudibleProvider.searchSeries.mockResolvedValue([]);
@@ -61,6 +64,7 @@ describe('MetadataService', () => {
     mockAudnexus.getBook.mockResolvedValue(null);
     mockAudnexus.getBookDetailed.mockResolvedValue({ kind: 'not_found' });
     mockAudnexus.getAuthor.mockResolvedValue(null);
+    mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'not_found' });
 
     mockLog = createMockLogger();
     service = new MetadataService(inject<FastifyBaseLogger>(mockLog));
@@ -1969,6 +1973,127 @@ describe('MetadataService', () => {
       new MetadataService(inject<FastifyBaseLogger>(createMockLogger()), { audibleRegion: 'uk' });
 
       expect(audnexusCtor).toHaveBeenCalledWith({ region: 'uk' });
+    });
+  });
+
+  // #1942 — the chapter-runtime bridge. These run against a REAL MetadataService
+  // (only the provider is mocked), so they prove the corroborator is genuinely
+  // wired to the service's shared throttle and provider-wide 429 backoff rather
+  // than reaching Audnexus on its own.
+  describe('getChapterRuntimeSeconds bridge (#1942)', () => {
+    const ASIN = 'B00CXXEX8W';
+
+    it('returns the trusted chapter runtime in SECONDS', async () => {
+      mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'ok', runtimeLengthMs: 33219490, isAccurate: true });
+
+      await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledExactlyOnceWith(ASIN);
+    });
+
+    it('a returned 429 sets the shared backoff, so the IMMEDIATELY subsequent Audnexus call short-circuits', async () => {
+      mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'rate_limited', retryAfterMs: 60_000 });
+
+      await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+      expect(mockLog.warn).toHaveBeenCalledWith(
+        { provider: 'Audnexus', retryAfterMs: 60_000 },
+        'Provider rate limited',
+      );
+
+      // The gate is provider-wide, not per-ASIN: the very next Audnexus lookup
+      // (a different call, a different ASIN) is skipped without a request.
+      await expect(service.getAuthor('B001H6UJO8')).resolves.toBeNull();
+      expect(mockAudnexus.getAuthor).not.toHaveBeenCalled();
+      // And the chapter path itself does not re-request during the window...
+      await service.getChapterRuntimeSeconds('B_OTHER');
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(1);
+    });
+
+    it('the backoff window is FINITE — a NaN window would make the gate a silent no-op (F16)', async () => {
+      mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'rate_limited', retryAfterMs: Number.NaN });
+
+      await service.getChapterRuntimeSeconds(ASIN);
+
+      // A NaN window leaves `Date.now() + NaN` = NaN, which `isRateLimited` reads
+      // as "not limited" — so the provider WOULD be retried immediately. The
+      // adapter guarantees finite windows; this pins the failure signature so a
+      // regression there surfaces here as an un-gated retry.
+      await service.getChapterRuntimeSeconds('B_OTHER');
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(2);
+    });
+
+    // The backoff deadline is `Date.now() + retryAfterMs`, so a real-time sleep
+    // can only ever approximate the transition. Freezing Date (and ONLY Date —
+    // `toFake: ['Date']` leaves the throttle's and the runner's real timers alone)
+    // lets the window be stepped exactly, pinning both sides of the boundary
+    // instead of just "eventually expired".
+    describe('backoff window expiry, frozen clock', () => {
+      const NOW = Date.parse('2026-07-25T12:00:00.000Z');
+
+      beforeEach(() => {
+        vi.useFakeTimers({ toFake: ['Date'] });
+        vi.setSystemTime(NOW);
+      });
+      afterEach(() => { vi.useRealTimers(); });
+
+      it('holds the gate up to the last millisecond of the window, then retries and promotes', async () => {
+        mockAudnexus.getChapterRuntime.mockResolvedValueOnce({ kind: 'rate_limited', retryAfterMs: 60_000 });
+        await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+        expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(1);
+
+        // 1ms short of the deadline — still gated, no request.
+        vi.setSystemTime(NOW + 59_999);
+        await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+        expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(1);
+
+        // Exactly at the deadline — the gate releases and the provider is retried.
+        vi.setSystemTime(NOW + 60_000);
+        mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'ok', runtimeLengthMs: 33219490, isAccurate: true });
+        await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+        expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(2);
+
+        // ...and the promotion settles, so a fourth lookup issues no request.
+        await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBe(33219.49);
+        expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(2);
+      });
+
+      it('a rate-limited lookup leaves no cache entry, so the post-window retry is a real request', async () => {
+        mockAudnexus.getChapterRuntime.mockResolvedValueOnce({ kind: 'rate_limited', retryAfterMs: 60_000 });
+        await service.getChapterRuntimeSeconds(ASIN);
+
+        vi.setSystemTime(NOW + 60_000);
+        mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'not_found' });
+
+        await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+        // Two real requests for the SAME ASIN: the 429 is transient, so it left no
+        // settled verdict for the post-window call to short-circuit against.
+        expect(mockAudnexus.getChapterRuntime.mock.calls).toEqual([[ASIN], [ASIN]]);
+      });
+    });
+
+    it('an active backoff from ANOTHER path skips the chapter lookup entirely', async () => {
+      mockAudnexus.getBook.mockRejectedValue(new RateLimitError(60_000, 'Audnexus'));
+      await expect(service.enrichBook(ASIN)).rejects.toBeInstanceOf(RateLimitError);
+
+      await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+      expect(mockAudnexus.getChapterRuntime).not.toHaveBeenCalled();
+    });
+
+    it('never throws — a provider that rejects degrades to "no usable runtime"', async () => {
+      mockAudnexus.getChapterRuntime.mockRejectedValue(new Error('boom'));
+
+      await expect(service.getChapterRuntimeSeconds(ASIN)).resolves.toBeUndefined();
+    });
+
+    it('cache state is per-service-instance, so a second service performs its own lookup (F14)', async () => {
+      mockAudnexus.getChapterRuntime.mockResolvedValue({ kind: 'ok', runtimeLengthMs: 33219490, isAccurate: true });
+      await service.getChapterRuntimeSeconds(ASIN);
+      await service.getChapterRuntimeSeconds(ASIN);
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(1);
+
+      const other = new MetadataService(inject<FastifyBaseLogger>(createMockLogger()), { audibleRegion: 'uk' });
+      await other.getChapterRuntimeSeconds(ASIN);
+
+      expect(mockAudnexus.getChapterRuntime).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/server/services/metadata.service.ts
+++ b/src/server/services/metadata.service.ts
@@ -22,6 +22,7 @@ import { getErrorMessage } from '../utils/error-message.js';
 import { serializeError } from '../utils/serialize-error.js';
 import { lookupForFixMatch as runFixMatchLookup, type FixMatchLookupResult } from './metadata-fix-match.js';
 import { resolveBook as runResolveBook, type ResolveBookInput } from './metadata-resolve-book.js';
+import { createChapterCorroborator, type ChapterCorroborator } from './chapter-corroboration.js';
 export type { FixMatchLookupResult } from './metadata-fix-match.js';
 export type { ResolveBookInput } from './metadata-resolve-book.js';
 
@@ -97,6 +98,8 @@ export class MetadataService {
   private audnexus: MetadataEnrichmentProvider;
   private throttle = new RequestThrottle();
   private rateLimitUntil: Map<string, number> = new Map();
+  /** Per-instance chapter-runtime cache + single-flight (#1942) — see {@link createChapterCorroborator}. */
+  private chapterCorroborator: ChapterCorroborator;
 
   constructor(private log: FastifyBaseLogger, config?: MetadataServiceConfig, private settingsService?: SettingsService) {
     const region = config?.audibleRegion ?? process.env.AUDIBLE_REGION ?? 'us';
@@ -109,6 +112,40 @@ export class MetadataService {
 
     this.audnexus = new AudnexusProvider({ region });
     this.log.info({ region }, 'Audnexus enrichment provider loaded');
+
+    // Instance-scoped, so the ASIN-only cache key can never answer a lookup with
+    // another region's chapter data (this service owns exactly one region).
+    this.chapterCorroborator = createChapterCorroborator({
+      provider: this.audnexus,
+      log: this.log,
+      ...this.throttleCollaborators(),
+    });
+  }
+
+  /**
+   * The matched edition's chapter-table runtime in SECONDS, or `undefined` when
+   * there is no usable one (#1942). Thin delegator — the cache, single-flight,
+   * throttle bridge, and outcome classification live in
+   * {@link createChapterCorroborator}. Never throws.
+   */
+  getChapterRuntimeSeconds(asin: string): Promise<number | undefined> {
+    return this.chapterCorroborator.getChapterRuntimeSeconds(asin);
+  }
+
+  /**
+   * The throttle/backoff collaborators every extracted sibling borrows. One home
+   * (DRY-3): `lookupForFixMatch`, `resolveBook`, and the chapter corroborator all
+   * mediate Audnexus/Audible through the SAME shared throttle slot and the SAME
+   * provider-wide `rateLimitUntil` gate, so a copy that drifts would silently
+   * un-throttle one path.
+   */
+  private throttleCollaborators() {
+    return {
+      acquireThrottle: () => this.throttle.acquire(),
+      isRateLimited: (name: string) => this.isRateLimited(name),
+      getRateLimitRemainingMs: (name: string) => this.getRateLimitRemainingMs(name),
+      setRateLimited: (name: string, ms: number) => this.setRateLimited(name, ms),
+    };
   }
 
   async search(query: string): Promise<MetadataSearchResults> {
@@ -357,10 +394,7 @@ export class MetadataService {
       audible: this.providers[0],
       audnexus: this.audnexus,
       log: this.log,
-      acquireThrottle: () => this.throttle.acquire(),
-      isRateLimited: (name) => this.isRateLimited(name),
-      getRateLimitRemainingMs: (name) => this.getRateLimitRemainingMs(name),
-      setRateLimited: (name, ms) => this.setRateLimited(name, ms),
+      ...this.throttleCollaborators(),
     }, asin);
   }
 
@@ -406,10 +440,7 @@ export class MetadataService {
     return runResolveBook({
       provider: this.providers[0],
       enrichBook: (asin) => this.enrichBook(asin),
-      acquireThrottle: () => this.throttle.acquire(),
-      isRateLimited: (name) => this.isRateLimited(name),
-      getRateLimitRemainingMs: (name) => this.getRateLimitRemainingMs(name),
-      setRateLimited: (name, ms) => this.setRateLimited(name, ms),
+      ...this.throttleCollaborators(),
       applyBookFilters: (books) => this.applyBookFilters(books),
       logParseDrop: (result, name) => this.logParseDrop(result, name),
       log: this.log,


### PR DESCRIPTION
Brings #1942 (chapter-runtime corroboration — kills the scalar-vs-chapters duration false-positive class) to main for the v0.9.13 tag.