### PR TITLE
Release: develop -> main (v0.12.1 — merge metadata preservation, cleared-field tombstones)

### DIFF
--- a/drizzle/0001_user_cleared_fields.sql
+++ b/drizzle/0001_user_cleared_fields.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `books` ADD `user_cleared_fields` text;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,2786 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "27037158-f0cf-458f-8d93-d3e215b772cf",
+  "prevId": "da2e0e86-9129-415d-8fb9-fdda6efd33a2",
+  "tables": {
+    "authors": {
+      "name": "authors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asin": {
+          "name": "asin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "authors_public_id_unique": {
+          "name": "authors_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "authors_slug_unique": {
+          "name": "authors_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blacklist": {
+      "name": "blacklist",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "info_hash": {
+          "name": "info_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'other'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blacklist_type": {
+          "name": "blacklist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'permanent'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blacklisted_at": {
+          "name": "blacklisted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_blacklist_info_hash_unique": {
+          "name": "idx_blacklist_info_hash_unique",
+          "columns": [
+            "info_hash"
+          ],
+          "isUnique": true,
+          "where": "info_hash IS NOT NULL"
+        },
+        "idx_blacklist_guid_unique": {
+          "name": "idx_blacklist_guid_unique",
+          "columns": [
+            "guid"
+          ],
+          "isUnique": true,
+          "where": "guid IS NOT NULL"
+        },
+        "idx_blacklist_book_id": {
+          "name": "idx_blacklist_book_id",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blacklist_book_id_books_id_fk": {
+          "name": "blacklist_book_id_books_id_fk",
+          "tableFrom": "blacklist",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "book_authors": {
+      "name": "book_authors",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_book_authors_author_id": {
+          "name": "idx_book_authors_author_id",
+          "columns": [
+            "author_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "book_authors_book_id_books_id_fk": {
+          "name": "book_authors_book_id_books_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_authors_author_id_authors_id_fk": {
+          "name": "book_authors_author_id_authors_id_fk",
+          "tableFrom": "book_authors",
+          "tableTo": "authors",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_authors_book_id_author_id_pk": {
+          "columns": [
+            "book_id",
+            "author_id"
+          ],
+          "name": "book_authors_book_id_author_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "book_events": {
+      "name": "book_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_id": {
+          "name": "download_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "book_title": {
+          "name": "book_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "narrator_name": {
+          "name": "narrator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_book_events_book_id": {
+          "name": "idx_book_events_book_id",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "idx_book_events_book_id_created_at": {
+          "name": "idx_book_events_book_id_created_at",
+          "columns": [
+            "book_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_book_events_event_type": {
+          "name": "idx_book_events_event_type",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "idx_book_events_created_at": {
+          "name": "idx_book_events_created_at",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_book_events_download_id_event_type": {
+          "name": "idx_book_events_download_id_event_type",
+          "columns": [
+            "download_id",
+            "event_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "book_events_book_id_books_id_fk": {
+          "name": "book_events_book_id_books_id_fk",
+          "tableFrom": "book_events",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "book_events_download_id_downloads_id_fk": {
+          "name": "book_events_download_id_downloads_id_fk",
+          "tableFrom": "book_events",
+          "tableTo": "downloads",
+          "columnsFrom": [
+            "download_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "book_narrators": {
+      "name": "book_narrators",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "narrator_id": {
+          "name": "narrator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_book_narrators_narrator_id": {
+          "name": "idx_book_narrators_narrator_id",
+          "columns": [
+            "narrator_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "book_narrators_book_id_books_id_fk": {
+          "name": "book_narrators_book_id_books_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "book_narrators_narrator_id_narrators_id_fk": {
+          "name": "book_narrators_narrator_id_narrators_id_fk",
+          "tableFrom": "book_narrators",
+          "tableTo": "narrators",
+          "columnsFrom": [
+            "narrator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "book_narrators_book_id_narrator_id_pk": {
+          "columns": [
+            "book_id",
+            "narrator_id"
+          ],
+          "name": "book_narrators_book_id_narrator_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "books": {
+      "name": "books",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publisher": {
+          "name": "publisher",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asin": {
+          "name": "asin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "isbn": {
+          "name": "isbn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_name": {
+          "name": "series_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_position": {
+          "name": "series_position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'wanted'"
+        },
+        "enrichment_status": {
+          "name": "enrichment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "production_type": {
+          "name": "production_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "edition_label": {
+          "name": "edition_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enrichment_attempts": {
+          "name": "enrichment_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_cleared_fields": {
+          "name": "user_cleared_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_codec": {
+          "name": "audio_codec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_bitrate": {
+          "name": "audio_bitrate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_sample_rate": {
+          "name": "audio_sample_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_channels": {
+          "name": "audio_channels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_bitrate_mode": {
+          "name": "audio_bitrate_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_file_format": {
+          "name": "audio_file_format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_file_count": {
+          "name": "audio_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "top_level_audio_file_count": {
+          "name": "top_level_audio_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_total_size": {
+          "name": "audio_total_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_duration": {
+          "name": "audio_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_grab_guid": {
+          "name": "last_grab_guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_grab_info_hash": {
+          "name": "last_grab_info_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "import_list_id": {
+          "name": "import_list_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "books_public_id_unique": {
+          "name": "books_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "idx_books_status": {
+          "name": "idx_books_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_books_path": {
+          "name": "idx_books_path",
+          "columns": [
+            "path"
+          ],
+          "isUnique": false
+        },
+        "idx_books_enrichment_status": {
+          "name": "idx_books_enrichment_status",
+          "columns": [
+            "enrichment_status"
+          ],
+          "isUnique": false
+        },
+        "idx_books_asin_unique": {
+          "name": "idx_books_asin_unique",
+          "columns": [
+            "upper(\"asin\")"
+          ],
+          "isUnique": true,
+          "where": "asin IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "books_import_list_id_import_lists_id_fk": {
+          "name": "books_import_list_id_import_lists_id_fk",
+          "tableFrom": "books",
+          "tableTo": "import_lists",
+          "columnsFrom": [
+            "import_list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "companion_ebooks": {
+      "name": "companion_ebooks",
+      "columns": {
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ctime_ms": {
+          "name": "ctime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_code": {
+          "name": "validation_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "candidate_count": {
+          "name": "candidate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "selected_filename": {
+          "name": "selected_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "companion_ebooks_book_id_unique": {
+          "name": "companion_ebooks_book_id_unique",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "companion_ebooks_book_id_books_id_fk": {
+          "name": "companion_ebooks_book_id_books_id_fk",
+          "tableFrom": "companion_ebooks",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_companion_ebooks_status_domain": {
+          "name": "ck_companion_ebooks_status_domain",
+          "value": "\"companion_ebooks\".\"status\" IN ('available', 'none', 'ambiguous', 'invalid', 'drm_protected')"
+        },
+        "ck_companion_ebooks_file_present": {
+          "name": "ck_companion_ebooks_file_present",
+          "value": "\"companion_ebooks\".\"status\" NOT IN ('available', 'invalid', 'drm_protected') OR (\"companion_ebooks\".\"filename\" IS NOT NULL AND \"companion_ebooks\".\"size_bytes\" IS NOT NULL AND \"companion_ebooks\".\"mtime_ms\" IS NOT NULL AND \"companion_ebooks\".\"ctime_ms\" IS NOT NULL)"
+        },
+        "ck_companion_ebooks_file_absent": {
+          "name": "ck_companion_ebooks_file_absent",
+          "value": "\"companion_ebooks\".\"status\" NOT IN ('none', 'ambiguous') OR (\"companion_ebooks\".\"filename\" IS NULL AND \"companion_ebooks\".\"size_bytes\" IS NULL AND \"companion_ebooks\".\"mtime_ms\" IS NULL AND \"companion_ebooks\".\"ctime_ms\" IS NULL)"
+        },
+        "ck_companion_ebooks_validation_code": {
+          "name": "ck_companion_ebooks_validation_code",
+          "value": "(\"companion_ebooks\".\"status\" <> 'invalid' OR \"companion_ebooks\".\"validation_code\" IS NOT NULL) AND (\"companion_ebooks\".\"status\" = 'invalid' OR \"companion_ebooks\".\"validation_code\" IS NULL)"
+        },
+        "ck_companion_ebooks_candidate_count": {
+          "name": "ck_companion_ebooks_candidate_count",
+          "value": "typeof(\"companion_ebooks\".\"candidate_count\") = 'integer' AND \"companion_ebooks\".\"candidate_count\" >= 0 AND (\"companion_ebooks\".\"status\" <> 'none' OR \"companion_ebooks\".\"candidate_count\" = 0) AND (\"companion_ebooks\".\"status\" <> 'ambiguous' OR \"companion_ebooks\".\"candidate_count\" >= 2) AND (\"companion_ebooks\".\"status\" NOT IN ('available', 'invalid', 'drm_protected') OR \"companion_ebooks\".\"candidate_count\" >= 1)"
+        },
+        "ck_companion_ebooks_selection": {
+          "name": "ck_companion_ebooks_selection",
+          "value": "\"companion_ebooks\".\"selected_filename\" IS NULL OR (\"companion_ebooks\".\"status\" IN ('available', 'invalid', 'drm_protected') AND \"companion_ebooks\".\"filename\" IS NOT NULL AND \"companion_ebooks\".\"selected_filename\" = \"companion_ebooks\".\"filename\")"
+        },
+        "ck_companion_ebooks_multi_candidate_selection": {
+          "name": "ck_companion_ebooks_multi_candidate_selection",
+          "value": "\"companion_ebooks\".\"status\" NOT IN ('available', 'invalid', 'drm_protected') OR \"companion_ebooks\".\"candidate_count\" < 2 OR \"companion_ebooks\".\"selected_filename\" IS NOT NULL"
+        },
+        "ck_companion_ebooks_fingerprint": {
+          "name": "ck_companion_ebooks_fingerprint",
+          "value": "(\"companion_ebooks\".\"size_bytes\" IS NULL OR (typeof(\"companion_ebooks\".\"size_bytes\") = 'integer' AND \"companion_ebooks\".\"size_bytes\" >= 0)) AND (\"companion_ebooks\".\"mtime_ms\" IS NULL OR typeof(\"companion_ebooks\".\"mtime_ms\") = 'integer') AND (\"companion_ebooks\".\"ctime_ms\" IS NULL OR typeof(\"companion_ebooks\".\"ctime_ms\") = 'integer')"
+        }
+      }
+    },
+    "connectors": {
+      "name": "connectors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_connectors_enabled": {
+          "name": "idx_connectors_enabled",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "download_clients": {
+      "name": "download_clients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_download_clients_enabled": {
+          "name": "idx_download_clients_enabled",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "downloads": {
+      "name": "downloads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "indexer_id": {
+          "name": "indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'torrent'"
+        },
+        "info_hash": {
+          "name": "info_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_url": {
+          "name": "download_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seeders": {
+          "name": "seeders",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "client_status": {
+          "name": "client_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "pipeline_stage": {
+          "name": "pipeline_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "guid": {
+          "name": "guid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "book_status_at_grab": {
+          "name": "book_status_at_grab",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "progress_updated_at": {
+          "name": "progress_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_cleanup": {
+          "name": "pending_cleanup",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "downloads_public_id_unique": {
+          "name": "downloads_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "idx_downloads_status": {
+          "name": "idx_downloads_status",
+          "columns": [
+            "client_status",
+            "pipeline_stage"
+          ],
+          "isUnique": false
+        },
+        "idx_downloads_status_completed": {
+          "name": "idx_downloads_status_completed",
+          "columns": [
+            "client_status",
+            "completed_at"
+          ],
+          "isUnique": false
+        },
+        "idx_downloads_book_id": {
+          "name": "idx_downloads_book_id",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        },
+        "idx_downloads_pending_cleanup": {
+          "name": "idx_downloads_pending_cleanup",
+          "columns": [
+            "pending_cleanup"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "downloads_book_id_books_id_fk": {
+          "name": "downloads_book_id_books_id_fk",
+          "tableFrom": "downloads",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "downloads_indexer_id_indexers_id_fk": {
+          "name": "downloads_indexer_id_indexers_id_fk",
+          "tableFrom": "downloads",
+          "tableTo": "indexers",
+          "columnsFrom": [
+            "indexer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "downloads_download_client_id_download_clients_id_fk": {
+          "name": "downloads_download_client_id_download_clients_id_fk",
+          "tableFrom": "downloads",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_jobs": {
+      "name": "import_jobs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase_history": {
+          "name": "phase_history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_import_jobs_status_created": {
+          "name": "idx_import_jobs_status_created",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_import_jobs_book_active": {
+          "name": "idx_import_jobs_book_active",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": true,
+          "where": "status IN ('pending', 'processing')"
+        }
+      },
+      "foreignKeys": {
+        "import_jobs_book_id_books_id_fk": {
+          "name": "import_jobs_book_id_books_id_fk",
+          "tableFrom": "import_jobs",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_lists": {
+      "name": "import_lists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_interval_minutes": {
+          "name": "sync_interval_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1440
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_sync_error": {
+          "name": "last_sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_import_lists_enabled": {
+          "name": "idx_import_lists_enabled",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_submission_items": {
+      "name": "import_submission_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ordinal": {
+          "name": "ordinal",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_payload": {
+          "name": "item_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_book_id": {
+          "name": "existing_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "existing_title": {
+          "name": "existing_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_import_submission_items_ordinal_unique": {
+          "name": "idx_import_submission_items_ordinal_unique",
+          "columns": [
+            "submission_id",
+            "ordinal"
+          ],
+          "isUnique": true
+        },
+        "idx_import_submission_items_submission_disposition": {
+          "name": "idx_import_submission_items_submission_disposition",
+          "columns": [
+            "submission_id",
+            "disposition"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "import_submission_items_submission_id_import_submissions_id_fk": {
+          "name": "import_submission_items_submission_id_import_submissions_id_fk",
+          "tableFrom": "import_submission_items",
+          "tableTo": "import_submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "import_submission_items_book_id_books_id_fk": {
+          "name": "import_submission_items_book_id_books_id_fk",
+          "tableFrom": "import_submission_items",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "import_submission_items_existing_book_id_books_id_fk": {
+          "name": "import_submission_items_existing_book_id_books_id_fk",
+          "tableFrom": "import_submission_items",
+          "tableTo": "books",
+          "columnsFrom": [
+            "existing_book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_submissions": {
+      "name": "import_submissions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "client_submission_id": {
+          "name": "client_submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload_digest": {
+          "name": "payload_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expected_count": {
+          "name": "expected_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'receiving'"
+        },
+        "received_count": {
+          "name": "received_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "received_bytes": {
+          "name": "received_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "accepted_count": {
+          "name": "accepted_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "held_count": {
+          "name": "held_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "import_submissions_client_submission_id_unique": {
+          "name": "import_submissions_client_submission_id_unique",
+          "columns": [
+            "client_submission_id"
+          ],
+          "isUnique": true
+        },
+        "idx_import_submissions_status_updated": {
+          "name": "idx_import_submissions_status_updated",
+          "columns": [
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_import_submissions_source_created_id": {
+          "name": "idx_import_submissions_source_created_id",
+          "columns": [
+            "source",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_import_submissions_created_id": {
+          "name": "idx_import_submissions_created_id",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "indexers": {
+      "name": "indexers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_indexer_id": {
+          "name": "source_indexer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_indexers_enabled": {
+          "name": "idx_indexers_enabled",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "narrators": {
+      "name": "narrators",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "narrators_public_id_unique": {
+          "name": "narrators_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "narrators_slug_unique": {
+          "name": "narrators_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifiers": {
+      "name": "notifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_notifiers_enabled": {
+          "name": "idx_notifiers_enabled",
+          "columns": [
+            "enabled"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "remote_path_mappings": {
+      "name": "remote_path_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "download_client_id": {
+          "name": "download_client_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_path": {
+          "name": "remote_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_path": {
+          "name": "local_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_remote_path_mappings_client": {
+          "name": "idx_remote_path_mappings_client",
+          "columns": [
+            "download_client_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "remote_path_mappings_download_client_id_download_clients_id_fk": {
+          "name": "remote_path_mappings_download_client_id_download_clients_id_fk",
+          "tableFrom": "remote_path_mappings",
+          "tableTo": "download_clients",
+          "columnsFrom": [
+            "download_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series": {
+      "name": "series",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hardcover_series_id": {
+          "name": "hardcover_series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_fetched_at": {
+          "name": "last_fetched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "series_public_id_unique": {
+          "name": "series_public_id_unique",
+          "columns": [
+            "public_id"
+          ],
+          "isUnique": true
+        },
+        "idx_series_hardcover_series_id_unique": {
+          "name": "idx_series_hardcover_series_id_unique",
+          "columns": [
+            "hardcover_series_id"
+          ],
+          "isUnique": true,
+          "where": "hardcover_series_id IS NOT NULL"
+        },
+        "idx_series_normalized_name": {
+          "name": "idx_series_normalized_name",
+          "columns": [
+            "normalized_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "series_members": {
+      "name": "series_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "book_id": {
+          "name": "book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hardcover_book_id": {
+          "name": "hardcover_book_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "normalized_title": {
+          "name": "normalized_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'hardcover'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_series_members_hardcover_book_unique": {
+          "name": "idx_series_members_hardcover_book_unique",
+          "columns": [
+            "series_id",
+            "hardcover_book_id"
+          ],
+          "isUnique": true,
+          "where": "hardcover_book_id IS NOT NULL"
+        },
+        "idx_series_members_local_unique": {
+          "name": "idx_series_members_local_unique",
+          "columns": [
+            "series_id",
+            "book_id"
+          ],
+          "isUnique": true,
+          "where": "hardcover_book_id IS NULL"
+        },
+        "idx_series_members_series_id": {
+          "name": "idx_series_members_series_id",
+          "columns": [
+            "series_id"
+          ],
+          "isUnique": false
+        },
+        "idx_series_members_book_id": {
+          "name": "idx_series_members_book_id",
+          "columns": [
+            "book_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "series_members_series_id_series_id_fk": {
+          "name": "series_members_series_id_series_id_fk",
+          "tableFrom": "series_members",
+          "tableTo": "series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "series_members_book_id_books_id_fk": {
+          "name": "series_members_book_id_books_id_fk",
+          "tableFrom": "series_members",
+          "tableTo": "books",
+          "columnsFrom": [
+            "book_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings": {
+      "name": "settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "settings_migrations": {
+      "name": "settings_migrations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "suggestions": {
+      "name": "suggestions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "asin": {
+          "name": "asin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_asin": {
+          "name": "author_asin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "narrator_name": {
+          "name": "narrator_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_name": {
+          "name": "series_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "series_position": {
+          "name": "series_position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason_context": {
+          "name": "reason_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "refreshed_at": {
+          "name": "refreshed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "idx_suggestions_status_score": {
+          "name": "idx_suggestions_status_score",
+          "columns": [
+            "status",
+            "score"
+          ],
+          "isUnique": false
+        },
+        "idx_suggestions_asin_unique": {
+          "name": "idx_suggestions_asin_unique",
+          "columns": [
+            "asin"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "unmatched_genres": {
+      "name": "unmatched_genres",
+      "columns": {
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "columns": [
+            "username"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_books_asin_unique": {
+        "columns": {
+          "upper(\"asin\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1785340262791,
       "tag": "0000_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1785698210569,
+      "tag": "0001_user_cleared_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/playwright-image-pin.test.ts
+++ b/e2e/playwright-image-pin.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { createRequire } from 'node:module';
+
+/**
+ * Drift sentinel: the CI e2e job runs inside the mcr.microsoft.com/playwright
+ * container, whose baked-in browsers must match the installed @playwright/test
+ * version — a mismatch kills every browser launch with "Executable doesn't
+ * exist". That job executes only on PRs to main, so the mismatch is invisible
+ * to local runs and every develop-side gate; this test turns it into a red
+ * unit test at commit time instead (it broke the v0.12.0 release PR).
+ */
+describe('e2e container image pin', () => {
+  it('ci.yml pins the playwright image at the installed @playwright/test version', () => {
+    const require = createRequire(import.meta.url);
+    const pkgPath = join(dirname(require.resolve('@playwright/test')), 'package.json');
+    const installed = (JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string }).version;
+
+    const workflow = readFileSync(join(process.cwd(), '.github', 'workflows', 'ci.yml'), 'utf8');
+    const pinned = workflow.match(/image:\s*mcr\.microsoft\.com\/playwright:v(\d+\.\d+\.\d+)/)?.[1];
+
+    expect(
+      pinned,
+      'ci.yml e2e image pin must track @playwright/test — update the image tag (or this sentinel if the job moved)',
+    ).toBe(installed);
+  });
+});

--- a/src/client/components/book/BookMetadataModal.test.tsx
+++ b/src/client/components/book/BookMetadataModal.test.tsx
@@ -588,3 +588,220 @@ describe('BookMetadataModal', () => {
     });
   });
 });
+
+// ─── #2069 AC25: the modal diffs against what the operator SEES ───
+//
+// For a post-import book the series exists only as a provider fallback
+// (`series_name = NULL`, `enrichmentStatus: 'enriched'` forever), so a
+// stored-value baseline renders the input empty and blanking it produces no diff —
+// the clear would be inexpressible for the most common book in the library.
+describe('BookMetadataModal — displayed baseline (#2069 AC25)', () => {
+  /** A book at `enriched` whose clearable columns are all empty. */
+  const providerOnlyBook = createMockBook({
+    title: 'Tress of the Emerald Sea',
+    authors: [{ id: 1, name: 'Brandon Sanderson', slug: 'brandon-sanderson' }],
+    narrators: [],
+    enrichmentStatus: 'enriched',
+    seriesName: null, seriesPosition: null, subtitle: null, description: null,
+    publisher: null, publishedDate: null, genres: null,
+    path: '/library/Brandon Sanderson/Tress of the Emerald Sea',
+    status: 'imported',
+  });
+
+  const providerDisplayed = {
+    seriesName: 'Secret Projects',
+    seriesPosition: 1,
+    subtitle: 'Provider Subtitle',
+    description: 'Provider description',
+    publisher: 'Dragonsteel',
+    publishedDate: '2023-01-10',
+    genres: ['Fantasy', 'Epic'],
+  };
+
+  /** The resolver output for a fully-tombstoned book — every field resolves to nothing. */
+  const clearedDisplayed = {
+    seriesName: undefined, seriesPosition: undefined, subtitle: undefined,
+    description: undefined, publisher: undefined, publishedDate: undefined, genres: undefined,
+  };
+
+  function renderProviderOnly(overrides = {}) {
+    return renderModal({ book: providerOnlyBook, displayed: providerDisplayed, ...overrides });
+  }
+
+  it('F11: renders the provider-only series and turns blanking it into a real null diff', async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    renderProviderOnly({ onSave });
+
+    expect(screen.getByLabelText(/series$/i)).toHaveValue('Secret Projects');
+
+    await user.clear(screen.getByLabelText(/series$/i));
+    await user.click(screen.getByText('Save'));
+
+    // Without the displayed baseline the payload is empty and no tombstone can
+    // ever exist for this book.
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ seriesName: null }), false);
+    });
+  });
+
+  it('does NOT promote a provider value into the DB on an unrelated edit', async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    renderProviderOnly({ onSave });
+
+    await user.clear(screen.getByLabelText(/^title/i));
+    await user.type(screen.getByLabelText(/^title/i), 'New Title');
+    await user.click(screen.getByText('Save'));
+
+    // This is the arm that makes the prefill change safe.
+    await waitFor(() => expect(onSave).toHaveBeenCalled());
+    const payload = onSave.mock.calls[0]![0] as Record<string, unknown>;
+    expect(payload.title).toBe('New Title');
+    for (const key of ['seriesName', 'subtitle', 'description', 'publisher', 'publishedDate', 'genres']) {
+      expect(payload).not.toHaveProperty(key);
+    }
+  });
+
+  it('replacing a provider-only value sends the typed value, not null', async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    renderProviderOnly({ onSave });
+
+    await user.clear(screen.getByLabelText(/series$/i));
+    await user.type(screen.getByLabelText(/series$/i), 'Cosmere');
+    await user.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ seriesName: 'Cosmere' }), false);
+    });
+  });
+
+  describe('F19 — reopening after a clear shows the field BLANK', () => {
+    it.each([
+      ['series', /series$/i],
+      ['subtitle', /subtitle/i],
+      ['description', /description/i],
+      ['publisher', /publisher/i],
+      ['published date', /published date/i],
+      ['genres', /genres/i],
+    ])('%s renders empty for a tombstoned book', (_label, labelMatcher) => {
+      renderModal({ book: providerOnlyBook, displayed: clearedDisplayed });
+
+      // An implementation that baselines on `stored ?? providerFallback` shows the
+      // value the operator just removed.
+      expect(screen.getByLabelText(labelMatcher)).toHaveValue('');
+    });
+
+    it('saving that reopened modal untouched sends no clearable key, so the tombstone survives', async () => {
+      const onSave = vi.fn();
+      const user = userEvent.setup();
+      renderModal({ book: providerOnlyBook, displayed: clearedDisplayed, onSave });
+
+      await user.click(screen.getByText('Save'));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalled());
+      const payload = onSave.mock.calls[0]![0] as Record<string, unknown>;
+      for (const key of ['seriesName', 'seriesPosition', 'subtitle', 'description', 'publisher', 'publishedDate', 'genres']) {
+        expect(payload).not.toHaveProperty(key);
+      }
+    });
+  });
+
+  it('a stored empty string on a || field renders the provider value and IS clearable', async () => {
+    const onSave = vi.fn();
+    const user = userEvent.setup();
+    // The resolver already applied `'' || provider`; the modal consumes its output.
+    renderModal({
+      book: createMockBook({ ...providerOnlyBook, publisher: '' }),
+      displayed: providerDisplayed,
+      onSave,
+    });
+
+    expect(screen.getByLabelText(/publisher/i)).toHaveValue('Dragonsteel');
+    await user.clear(screen.getByLabelText(/publisher/i));
+    await user.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ publisher: null }), false);
+    });
+  });
+
+  it('a stored genres: [] renders blank — the ?? override means there is no provider list to clear', () => {
+    renderModal({
+      book: createMockBook({ ...providerOnlyBook, genres: [] }),
+      displayed: { ...providerDisplayed, genres: [] },
+    });
+
+    expect(screen.getByLabelText(/genres/i)).toHaveValue('');
+  });
+
+  it('seriesPosition is pre-filled from the resolved pair, not the stored column', () => {
+    renderModal({ book: providerOnlyBook, displayed: providerDisplayed });
+    expect(screen.getByLabelText(/position/i)).toHaveValue('1');
+  });
+
+  it('seriesPosition renders blank when the pair resolves to nothing', () => {
+    renderModal({ book: providerOnlyBook, displayed: clearedDisplayed });
+    expect(screen.getByLabelText(/position/i)).toHaveValue('');
+  });
+
+  describe('F22 — the baseline can settle AFTER the modal mounts', () => {
+    it('adopts a late-arriving provider baseline for untouched fields, without reopening', async () => {
+      const onSave = vi.fn();
+      const user = userEvent.setup();
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      // Opened BEFORE the provider metadata query resolved.
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <BookMetadataModal {...defaultProps} book={providerOnlyBook} onSave={onSave} />
+        </QueryClientProvider>,
+      );
+      expect(screen.getByLabelText(/series$/i)).toHaveValue('');
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <BookMetadataModal {...defaultProps} book={providerOnlyBook} displayed={providerDisplayed} onSave={onSave} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => expect(screen.getByLabelText(/series$/i)).toHaveValue('Secret Projects'));
+
+      await user.clear(screen.getByLabelText(/series$/i));
+      await user.click(screen.getByText('Save'));
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ seriesName: null }), false);
+      });
+    });
+
+    it('never overwrites a field the operator has already typed into', async () => {
+      const user = userEvent.setup();
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      const { rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <BookMetadataModal {...defaultProps} book={providerOnlyBook} />
+        </QueryClientProvider>,
+      );
+
+      await user.type(screen.getByLabelText(/series$/i), 'My Own Series');
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <BookMetadataModal {...defaultProps} book={providerOnlyBook} displayed={providerDisplayed} />
+        </QueryClientProvider>,
+      );
+
+      expect(screen.getByLabelText(/series$/i)).toHaveValue('My Own Series');
+      // …while an untouched sibling still adopts the settled baseline.
+      await waitFor(() => expect(screen.getByLabelText(/publisher/i)).toHaveValue('Dragonsteel'));
+    });
+  });
+
+  it('with the prop absent every existing behavior holds (optional-prop compatibility)', () => {
+    renderModal();
+
+    expect(screen.getByLabelText(/series$/i)).toHaveValue('The Stormlight Archive');
+    expect(screen.getByLabelText(/publisher/i)).toHaveValue('Macmillan Audio');
+    expect(screen.getByLabelText(/genres/i)).toHaveValue('Fantasy, Epic');
+  });
+});

--- a/src/client/components/book/BookMetadataModal.tsx
+++ b/src/client/components/book/BookMetadataModal.tsx
@@ -3,6 +3,8 @@ import type { BookWithAuthor, UpdateBookPayload } from '@/lib/api';
 import { XIcon } from '@/components/icons';
 import { Modal } from '@/components/Modal';
 import { MetadataEditFields } from '@/components/book/MetadataEditFields';
+import type { DisplayedFields } from '@/pages/book/helpers.js';
+import { useBaselinedFields } from '@/components/book/useBaselinedFields.js';
 
 interface BookMetadataModalProps {
   book: BookWithAuthor;
@@ -10,6 +12,31 @@ interface BookMetadataModalProps {
   onClose: () => void;
   isSaving: boolean;
   isOpen?: boolean;
+  /**
+   * What the operator SEES for each clearable field — `resolveDisplayedFields`
+   * output, the same call the header's meta line derives from (#2069 AC18/AC25).
+   * Both the initial input value and the diff baseline come from it, so blanking a
+   * value that exists only as a provider fallback produces a real `null` diff and
+   * a tombstone, and reopening after a clear shows the field BLANK rather than
+   * resurrecting what was just removed.
+   *
+   * OPTIONAL: with the prop absent the baseline is the stored value and behavior is
+   * byte-identical to before.
+   */
+  displayed?: DisplayedFields;
+}
+
+/** The stored-value baseline used when no resolved `displayed` prop is supplied. */
+function storedBaseline(book: BookWithAuthor): DisplayedFields {
+  return {
+    seriesName: book.seriesName ?? undefined,
+    seriesPosition: book.seriesPosition ?? undefined,
+    subtitle: book.subtitle ?? undefined,
+    description: book.description ?? undefined,
+    publisher: book.publisher ?? undefined,
+    publishedDate: book.publishedDate ?? undefined,
+    genres: book.genres ?? undefined,
+  };
 }
 
 /** Parse a comma-separated input into a trimmed, non-empty list (narrators/authors/genres). */
@@ -50,25 +77,32 @@ function diffSeriesPosition(input: string, stored: number | null | undefined): {
 }
 
 /**
- * Edit Metadata is a pure MANUAL field editor (#1609). It diffs each stored,
- * author-supplied column against its pre-filled value and sends only what changed:
- * `undefined`/omitted = unchanged, `null` = clear (detail page falls back to the
- * merged provider value), a value = set. Re-pointing a book to a different provider
- * match is Fix Match's job — there is intentionally no embedded search-and-apply
- * here (it previously produced inconsistent "Frankenbook" metadata).
+ * Edit Metadata is a pure MANUAL field editor (#1609). It diffs each clearable
+ * field against its pre-filled value and sends only what changed:
+ * `undefined`/omitted = unchanged, `null` = clear, a value = set. Re-pointing a
+ * book to a different provider match is Fix Match's job — there is intentionally
+ * no embedded search-and-apply here (it previously produced inconsistent
+ * "Frankenbook" metadata).
+ *
+ * The pre-filled value and the diff baseline are what the operator SEES — the
+ * `displayed` prop (#2069 AC25), not the stored column. That matters because a
+ * post-import book sits at `enrichmentStatus: 'enriched'` with `series_name = NULL`
+ * indefinitely: its series exists only as a provider fallback, so a stored-value
+ * baseline renders the input empty and blanking it produces no diff — the clear is
+ * inexpressible for the most common book in the library. It also means a field the
+ * operator just cleared reopens BLANK instead of showing the value again.
+ *
+ * A clear sends only `null` for the field; the server derives and persists the
+ * tombstone. Nothing tombstone-shaped is sent from here.
  */
-export function BookMetadataModal({ book, onSave, onClose, isSaving, isOpen = true }: BookMetadataModalProps) {
+export function BookMetadataModal({ book, onSave, onClose, isSaving, isOpen = true, displayed }: BookMetadataModalProps) {
+  const baseline = displayed ?? storedBaseline(book);
+  const { values, setField } = useBaselinedFields(baseline);
   const [title, setTitle] = useState(book.title);
-  const [subtitle, setSubtitle] = useState(book.subtitle ?? '');
   const [author, setAuthor] = useState(book.authors.map((a) => a.name).join(', '));
-  const [seriesName, setSeriesName] = useState(book.seriesName ?? '');
-  const [seriesPosition, setSeriesPosition] = useState(book.seriesPosition?.toString() ?? '');
   const [narrator, setNarrator] = useState(book.narrators.map((n) => n.name).join(', '));
-  const [description, setDescription] = useState(book.description ?? '');
-  const [publishedDate, setPublishedDate] = useState(book.publishedDate ?? '');
-  const [genres, setGenres] = useState((book.genres ?? []).join(', '));
-  const [publisher, setPublisher] = useState(book.publisher ?? '');
   const [renameFiles, setRenameFiles] = useState(false);
+  const { subtitle, seriesName, seriesPosition, description, publishedDate, genres, publisher } = values;
 
   if (!isOpen) return null;
 
@@ -85,7 +119,11 @@ export function BookMetadataModal({ book, onSave, onClose, isSaving, isOpen = tr
 
     if (title.trim() !== book.title) data.title = title.trim();
 
-    const sub = diffTrimmedNullable(subtitle, book.subtitle);
+    // Every clearable field diffs against `baseline` — the DISPLAYED value — so an
+    // untouched field sends nothing (a provider value is never silently promoted
+    // into the DB by an unrelated edit), a blanked one sends `null` even when the
+    // stored column was already NULL, and a replaced one sends the new value.
+    const sub = diffTrimmedNullable(subtitle, baseline.subtitle);
     if (sub !== undefined) data.subtitle = sub;
 
     // authors.min(1) — when the field is blanked, omit `authors` entirely rather
@@ -96,25 +134,28 @@ export function BookMetadataModal({ book, onSave, onClose, isSaving, isOpen = tr
       if (names.length > 0) data.authors = names.map((name) => ({ name }));
     }
 
-    if (seriesName.trim() !== (book.seriesName ?? '')) data.seriesName = seriesName.trim() || null;
+    if (seriesName.trim() !== (baseline.seriesName ?? '')) data.seriesName = seriesName.trim() || null;
 
-    const pos = diffSeriesPosition(seriesPosition, book.seriesPosition);
+    // `seriesPosition` follows `seriesName` (the pair rule) — it is never baselined
+    // against the provider independently, so it inherits whatever the resolver
+    // decided for the pair.
+    const pos = diffSeriesPosition(seriesPosition, baseline.seriesPosition);
     if (pos) data.seriesPosition = pos.value;
 
     const existingNarrator = book.narrators.map((n) => n.name).join(', ');
     if (narrator.trim() !== existingNarrator) data.narrators = parseList(narrator);
 
     // Nullable fields — `undefined` = unchanged (omitted), `null` = clear, value = set.
-    const desc = diffDescription(description, book.description);
+    const desc = diffDescription(description, baseline.description);
     if (desc !== undefined) data.description = desc;
 
-    const pubDate = diffTrimmedNullable(publishedDate, book.publishedDate);
+    const pubDate = diffTrimmedNullable(publishedDate, baseline.publishedDate);
     if (pubDate !== undefined) data.publishedDate = pubDate;
 
-    const newGenres = diffGenres(genres, book.genres);
+    const newGenres = diffGenres(genres, baseline.genres);
     if (newGenres !== undefined) data.genres = newGenres;
 
-    const pub = diffTrimmedNullable(publisher, book.publisher);
+    const pub = diffTrimmedNullable(publisher, baseline.publisher);
     if (pub !== undefined) data.publisher = pub;
 
     onSave(data, renameFiles);
@@ -149,24 +190,24 @@ export function BookMetadataModal({ book, onSave, onClose, isSaving, isOpen = tr
           title={title}
           onTitleChange={setTitle}
           subtitle={subtitle}
-          onSubtitleChange={setSubtitle}
+          onSubtitleChange={(v) => setField('subtitle', v)}
           author={author}
           onAuthorChange={setAuthor}
           seriesName={seriesName}
-          onSeriesNameChange={setSeriesName}
+          onSeriesNameChange={(v) => setField('seriesName', v)}
           seriesPosition={seriesPosition}
-          onSeriesPositionChange={setSeriesPosition}
+          onSeriesPositionChange={(v) => setField('seriesPosition', v)}
           positionError={positionError}
           narrator={narrator}
           onNarratorChange={setNarrator}
           description={description}
-          onDescriptionChange={setDescription}
+          onDescriptionChange={(v) => setField('description', v)}
           publishedDate={publishedDate}
-          onPublishedDateChange={setPublishedDate}
+          onPublishedDateChange={(v) => setField('publishedDate', v)}
           genres={genres}
-          onGenresChange={setGenres}
+          onGenresChange={(v) => setField('genres', v)}
           publisher={publisher}
-          onPublisherChange={setPublisher}
+          onPublisherChange={(v) => setField('publisher', v)}
           renameFiles={renameFiles}
           onRenameFilesChange={setRenameFiles}
           hasPath={hasPath}

--- a/src/client/components/book/useBaselinedFields.ts
+++ b/src/client/components/book/useBaselinedFields.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react';
+import type { DisplayedFields } from '@/pages/book/helpers.js';
+
+/** The Edit Metadata inputs whose value AND diff baseline come from `DisplayedFields`. */
+export interface BaselinedFieldValues {
+  subtitle: string;
+  seriesName: string;
+  seriesPosition: string;
+  description: string;
+  publishedDate: string;
+  genres: string;
+  publisher: string;
+}
+
+export type BaselinedFieldKey = keyof BaselinedFieldValues;
+
+/** Render a resolved baseline as the string each input holds. */
+export function baselineToInputs(baseline: DisplayedFields): BaselinedFieldValues {
+  return {
+    subtitle: baseline.subtitle ?? '',
+    seriesName: baseline.seriesName ?? '',
+    seriesPosition: baseline.seriesPosition?.toString() ?? '',
+    description: baseline.description ?? '',
+    publishedDate: baseline.publishedDate ?? '',
+    genres: (baseline.genres ?? []).join(', '),
+    publisher: baseline.publisher ?? '',
+  };
+}
+
+const KEYS: readonly BaselinedFieldKey[] = [
+  'subtitle', 'seriesName', 'seriesPosition', 'description', 'publishedDate', 'genres', 'publisher',
+];
+
+/**
+ * Hold the modal's baseline-driven inputs, and keep them coherent with a baseline
+ * that can settle AFTER mount (#2069 F22).
+ *
+ * `BookPage` renders `BookDetails` as soon as the LIBRARY query resolves, while
+ * provider metadata is a separate query. A plain `useState(initial)` therefore
+ * freezes whatever baseline existed at open time, so opening Edit before metadata
+ * arrives would leave both the input and the diff baseline on the pre-provider
+ * value — and a provider-only clear stays inexpressible until the modal is closed
+ * and reopened, which is exactly the case AC25 exists to fix.
+ *
+ * The sync is DIRTY-AWARE: a field whose current input still equals the PREVIOUS
+ * baseline's rendering is untouched and adopts the new one; a field the operator
+ * has typed into is left exactly as they left it. The effect keys off the rendered
+ * baseline's value (a JSON string), not object identity, so a caller rebuilding
+ * `DisplayedFields` each render does not re-trigger it.
+ */
+export function useBaselinedFields(baseline: DisplayedFields) {
+  const inputs = baselineToInputs(baseline);
+  const key = JSON.stringify(inputs);
+
+  const [values, setValues] = useState<BaselinedFieldValues>(inputs);
+  const previous = useRef({ key, inputs });
+
+  useEffect(() => {
+    const prior = previous.current;
+    if (prior.key === key) return;
+    previous.current = { key, inputs };
+    setValues((current) => {
+      const merged = { ...current };
+      let changed = false;
+      for (const field of KEYS) {
+        if (current[field] === prior.inputs[field] && inputs[field] !== current[field]) {
+          merged[field] = inputs[field];
+          changed = true;
+        }
+      }
+      return changed ? merged : current;
+    });
+    // `inputs` is derived from `key` — depending on it too would fire on every
+    // render, since the caller builds a fresh object each time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const setField = (field: BaselinedFieldKey, value: string) => {
+    setValues((current) => ({ ...current, [field]: value }));
+  };
+
+  return { values, setField };
+}

--- a/src/client/lib/api/books.ts
+++ b/src/client/lib/api/books.ts
@@ -1,4 +1,4 @@
-import type { BookStatus, EnrichmentStatus, LibraryFilterBucket, RetagExcludableField } from '@shared/schemas.js';
+import type { BookStatus, ClearableBookField, EnrichmentStatus, LibraryFilterBucket, RetagExcludableField } from '@shared/schemas.js';
 import type { LibraryBookListItem, LibraryBookListResponse } from '@shared/schemas/library-book.js';
 import type { BookMetadata, AuthorMetadata, MetadataSearchResults } from '@core/metadata/types.js';
 import { ApiError, fetchApi, fetchMultipart } from './client.js';
@@ -42,6 +42,13 @@ export interface BookWithAuthor {
   path?: string | null;
   size?: number | null;
   enrichmentStatus?: EnrichmentStatus | null;
+  /**
+   * The operator's explicit clears (#2069), PARSED — only ever received from a
+   * hydrated DETAIL response (`GET /api/books/:id`, and the PUT/Fix-Match/create
+   * echoes). Never a raw JSON string: the server projects the raw column out of
+   * every list and activity response. Absent on list rows.
+   */
+  userClearedFields?: ClearableBookField[];
   // Audio technical info
   audioCodec?: string | null;
   audioBitrate?: number | null;

--- a/src/client/pages/SettingsPage.test.tsx
+++ b/src/client/pages/SettingsPage.test.tsx
@@ -87,17 +87,17 @@ function renderSettingsPage(route = '/settings/indexers') {
 }
 
 /**
- * #2033 — wait until the settings query has actually HYDRATED the forms. The mocked
- * settings equal the defaults, so the input's value is identical before and after the
- * query lands and nothing in the DOM distinguishes "form populated from the query" from
- * "form still on defaults" — which made the pre-hydration window invisible to every
- * anchor these tests could use, and un-waitable. Query state is the observable the DOM
- * cannot provide (the react-query-error-after-retry-ladder idiom, success-side).
+ * #2033 — two-stage barrier: wait until the settings query has hydrated the forms AND the
+ * hydration has finished applying. Stage 1 observes cache success (the
+ * react-query-error-after-retry-ladder idiom, success-side). Stage 2 waits for the fixture's
+ * deliberately-distinct library.path ('/audiobooks-hydrated' — see mockSettings) to render:
+ * RHF's reset() applies field values a commit after the hydrate effect fires, and that value
+ * is written by the same application wave, so its appearance proves every card's reset has
+ * flushed. Callers need no follow-up DOM waitFor — typing is safe once this resolves.
  *
- * PRECISION: this observes CACHE success, which precedes the hydrate effect's form flush by
- * one act cycle. A caller asserting anything about hydration's EFFECT must follow this with
- * its own waitFor over the DOM (see the #2033 regression pin) — success alone is necessary,
- * not sufficient.
+ * Historically the fixture's values equaled the code defaults, so the reset's application was
+ * invisible in the DOM and un-waitable — the clobber window the #2033 flake lived in (and the
+ * regression pin below exercises).
  */
 async function settingsHydrated(queryClient: QueryClient): Promise<void> {
   await waitFor(() => {

--- a/src/client/pages/SettingsPage.test.tsx
+++ b/src/client/pages/SettingsPage.test.tsx
@@ -54,6 +54,11 @@ import { createMockSettings, createMockIndexer, createMockDownloadClient } from 
 const mockSettings = createMockSettings({
   search: { enabled: true, intervalMinutes: 30, blacklistTtlDays: 7 },
   import: { deleteAfterImport: false, minSeedTime: 0, minSeedRatio: 0, minFreeSpaceGB: 5 },
+  // #2033 root cause: with fixture values identical to the code defaults, hydration's reset is
+  // invisible in the DOM, so no barrier could wait for it to FINISH. This one deliberately
+  // distinct, unasserted field makes the reset's DOM application observable — settingsHydrated
+  // waits for it, closing the reset-application window the flake lived in.
+  library: { path: '/audiobooks-hydrated' },
 });
 
 const mockIndexer = createMockIndexer({ id: 1, name: 'AudioBookBay' });
@@ -97,6 +102,16 @@ function renderSettingsPage(route = '/settings/indexers') {
 async function settingsHydrated(queryClient: QueryClient): Promise<void> {
   await waitFor(() => {
     expect(queryClient.getQueryState(['settings'])?.status).toBe('success');
+  });
+  // Cache success is necessary but NOT sufficient: useSettingsForm's hydrate effect fires one
+  // act cycle later, and RHF's reset() applies field values in a FURTHER commit — a keystroke
+  // landing inside that window is silently overwritten by the reset's deferred application
+  // (flight-recorder tape, 2026-07-31: settings commit t+0, hydrate decision t+5ms, test
+  // keystroke t+8ms, reset application clobbers t+13ms). The fixture's distinct library path
+  // is written by that same application wave, so once it appears in the DOM, every card's
+  // reset has fully flushed and typing is safe.
+  await waitFor(() => {
+    expect((screen.getByPlaceholderText('/audiobooks') as HTMLInputElement).value).toBe('/audiobooks-hydrated');
   });
 }
 

--- a/src/client/pages/book/BookDetails.tsx
+++ b/src/client/pages/book/BookDetails.tsx
@@ -14,7 +14,7 @@ import type { BookWithAuthor } from '@/lib/api';
 import { BookHero } from './BookHero.js';
 import { BookDetailsContent } from './BookDetailsContent.js';
 import { BookEventHistory } from './BookEventHistory.js';
-import { mergeBookData, type MetadataBook } from './helpers.js';
+import { mergeBookData, resolveDisplayedFields, type DisplayedFields, type MetadataBook } from './helpers.js';
 import { useBookActions } from './useBookActions.js';
 import { useMergeProgress, type MergeProgress } from '@/hooks/useMergeProgress.js';
 import { useBookModals } from '@/hooks/useBookModals.js';
@@ -44,6 +44,10 @@ export function BookDetails({ libraryBook, metadataBook }: {
   const [tab, setTab] = useState<'details' | 'history'>('details');
 
   const merged = mergeBookData(libraryBook, metadataBook);
+  // The modal's pre-fill and diff baseline come from the SAME resolver call the
+  // header's meta line does (#2069 AC18/AC25), so what the header hides and what
+  // the modal pre-fills cannot drift apart.
+  const displayed = resolveDisplayedFields(libraryBook, metadataBook);
   const { renameMutation, mergeMutation, cancelMergeMutation, retagMutation, refreshScanMutation, deleteMutation, wrongReleaseMutation, retryImportMutation, uploadCoverMutation, ffmpegConfigured, isSaving, handleSave } =
     useBookActions(libraryBook.id);
 
@@ -143,6 +147,7 @@ export function BookDetails({ libraryBook, metadataBook }: {
 
       <BookDetailsModals
         libraryBook={libraryBook}
+        displayed={displayed}
         modals={modals}
         close={close}
         isSaving={isSaving}
@@ -164,6 +169,7 @@ type BookActions = ReturnType<typeof useBookActions>;
 
 function BookDetailsModals({
   libraryBook,
+  displayed,
   modals,
   close,
   isSaving,
@@ -176,6 +182,7 @@ function BookDetailsModals({
   navigate,
 }: {
   libraryBook: BookWithAuthor;
+  displayed: DisplayedFields;
   modals: BookModalsState;
   close: CloseFn;
   isSaving: boolean;
@@ -198,6 +205,7 @@ function BookDetailsModals({
       {modals.edit && (
         <BookMetadataModal
           book={libraryBook}
+          displayed={displayed}
           onSave={(data, renameFiles) => handleSave(data, renameFiles, () => close('edit'))}
           onClose={() => close('edit')}
           isSaving={isSaving}

--- a/src/client/pages/book/helpers.test.ts
+++ b/src/client/pages/book/helpers.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { mergeBookData } from './helpers.js';
+import { mergeBookData, resolveDisplayedFields } from './helpers.js';
 import { bookStatusConfig } from '@/lib/status';
 import { createMockBook } from '@/__tests__/factories';
-import type { BookStatus } from '@shared/schemas.js';
+import type { BookStatus, ClearableBookField } from '@shared/schemas.js';
 
 describe('mergeBookData', () => {
   describe('status palette flow-through', () => {
@@ -218,5 +218,149 @@ describe('mergeBookData', () => {
       const result = mergeBookData(book, null);
       expect(result.metaDots).toContain('Stored Publisher');
     });
+  });
+});
+
+// ─── #2069: the operator's explicit clears suppress the provider fallback ───
+describe('resolveDisplayedFields / mergeBookData — user-cleared fields (#2069)', () => {
+  const providerMeta = {
+    subtitle: 'Provider Subtitle',
+    description: 'Provider description',
+    publisher: 'Tor Books',
+    publishedDate: '2010-08-31',
+    genres: ['Fantasy', 'Epic'],
+    seriesPrimary: { name: 'The Stormlight Archive', position: 2 },
+    series: [{ name: 'Cosmere', position: 5 }],
+  };
+
+  /** A book whose stored clearable columns are all empty — provider-only display. */
+  function providerOnlyBook(userClearedFields?: ClearableBookField[]) {
+    return createMockBook({
+      seriesName: null, seriesPosition: null, subtitle: null, description: null,
+      publisher: null, publishedDate: null, genres: null,
+      ...(userClearedFields ? { userClearedFields } : {}),
+    });
+  }
+
+  describe('AC21 — nothing changes for a book that was never cleared', () => {
+    it.each([
+      ['absent', undefined],
+      ['empty', [] as ClearableBookField[]],
+    ])('%s userClearedFields resolves every field from the provider', (_label, cleared) => {
+      const book = providerOnlyBook(cleared as ClearableBookField[] | undefined);
+      const displayed = resolveDisplayedFields(book, providerMeta);
+
+      expect(displayed).toEqual({
+        seriesName: 'The Stormlight Archive',
+        seriesPosition: 2,
+        subtitle: 'Provider Subtitle',
+        description: 'Provider description',
+        publisher: 'Tor Books',
+        publishedDate: '2010-08-31',
+        genres: ['Fantasy', 'Epic'],
+      });
+      expect(mergeBookData(book, providerMeta).metaDots).toContain('The Stormlight Archive #2');
+    });
+  });
+
+  describe('AC18 — a tombstone resolves to nothing, per field', () => {
+    it('seriesName suppresses the header series dot AND its position (the pair rule)', () => {
+      const book = providerOnlyBook(['seriesName']);
+      const displayed = resolveDisplayedFields(book, providerMeta);
+
+      expect(displayed.seriesName).toBeUndefined();
+      expect(displayed.seriesPosition).toBeUndefined();
+
+      const merged = mergeBookData(book, providerMeta);
+      expect(merged.metaDots.some((d) => /Stormlight|Cosmere/.test(d))).toBe(false);
+      // Untouched neighbours still render.
+      expect(merged.metaDots).toContain('2010');
+      expect(merged.metaDots).toContain('Tor Books');
+    });
+
+    it.each([
+      ['subtitle', 'subtitle'],
+      ['description', 'description'],
+      ['publisher', 'publisher'],
+      ['publishedDate', 'publishedDate'],
+      ['genres', 'genres'],
+    ] as const)('%s suppresses only its own fallback', (_label, field) => {
+      const displayed = resolveDisplayedFields(providerOnlyBook([field]), providerMeta);
+
+      expect(displayed[field]).toBeUndefined();
+      // Every sibling still resolves in the same call.
+      for (const other of ['subtitle', 'description', 'publisher', 'publishedDate', 'genres'] as const) {
+        if (other !== field) expect(displayed[other]).toBeDefined();
+      }
+      expect(displayed.seriesName).toBe('The Stormlight Archive');
+    });
+
+    it('a publisher tombstone drops the publisher dot but keeps year and series', () => {
+      const merged = mergeBookData(providerOnlyBook(['publisher']), providerMeta);
+      expect(merged.metaDots).not.toContain('Tor Books');
+      expect(merged.metaDots).toContain('2010');
+      expect(merged.metaDots).toContain('The Stormlight Archive #2');
+    });
+
+    it('a publishedDate tombstone drops the year dot only', () => {
+      const merged = mergeBookData(providerOnlyBook(['publishedDate']), providerMeta);
+      expect(merged.metaDots).not.toContain('2010');
+      expect(merged.metaDots).toContain('Tor Books');
+    });
+
+    it('description/genres/subtitle tombstones flow through mergeBookData', () => {
+      const merged = mergeBookData(providerOnlyBook(['description', 'genres', 'subtitle']), providerMeta);
+      expect(merged.description).toBeUndefined();
+      expect(merged.genres).toBeUndefined();
+      expect(merged.subtitle).toBeUndefined();
+    });
+  });
+
+  describe('AC18 — the || / ?? asymmetry is preserved by construction', () => {
+    it.each(['description', 'seriesName', 'publisher', 'publishedDate', 'subtitle'] as const)(
+      'a stored empty string on %s still falls through to the provider value',
+      (field) => {
+        const book = createMockBook({
+          seriesName: null, seriesPosition: null, subtitle: null, description: null,
+          publisher: null, publishedDate: null, genres: null,
+          [field]: '',
+        });
+        expect(resolveDisplayedFields(book, providerMeta)[field]).toBe(
+          field === 'seriesName' ? 'The Stormlight Archive' : providerMeta[field as 'subtitle'],
+        );
+      },
+    );
+
+    it('a stored genres: [] OVERRIDES the provider list and does not fall through', () => {
+      const book = createMockBook({ genres: [] });
+      expect(resolveDisplayedFields(book, providerMeta).genres).toEqual([]);
+    });
+
+    it('seriesPosition prefers pickPrimarySeries over series[0]', () => {
+      const displayed = resolveDisplayedFields(providerOnlyBook(), providerMeta);
+      expect(displayed.seriesName).toBe('The Stormlight Archive');
+      expect(displayed.seriesPosition).toBe(2);
+    });
+
+    it('seriesPosition resolves only when seriesName does', () => {
+      const book = createMockBook({ seriesName: null, seriesPosition: 7 });
+      expect(resolveDisplayedFields(book, null).seriesName).toBeUndefined();
+      expect(resolveDisplayedFields(book, null).seriesPosition).toBeUndefined();
+    });
+  });
+
+  it('the header and the modal baseline derive from ONE call, so they cannot disagree', () => {
+    // Consistency guard: a future divergence between what the header hides and what
+    // the modal pre-fills fails here rather than shipping.
+    const book = providerOnlyBook(['seriesName', 'publisher']);
+    const displayed = resolveDisplayedFields(book, providerMeta);
+    const merged = mergeBookData(book, providerMeta);
+
+    expect(displayed.seriesName).toBeUndefined();
+    expect(merged.metaDots.some((d) => /Stormlight/.test(d))).toBe(false);
+    expect(displayed.publisher).toBeUndefined();
+    expect(merged.metaDots).not.toContain('Tor Books');
+    expect(displayed.publishedDate).toBe('2010-08-31');
+    expect(merged.metaDots).toContain('2010');
   });
 });

--- a/src/client/pages/book/helpers.ts
+++ b/src/client/pages/book/helpers.ts
@@ -17,19 +17,89 @@ export interface MetadataBook {
   seriesPrimary?: { name: string; position?: number | undefined } | undefined;
 }
 
+/**
+ * The RAW resolved value of each clearable field, plus `seriesPosition` — "what
+ * does the operator actually see" (#2069 AC18).
+ *
+ * `undefined` means "resolves to nothing": either nothing is stored and the
+ * provider has none, or the field carries a tombstone.
+ */
+export interface DisplayedFields {
+  seriesName: string | undefined;
+  seriesPosition: number | undefined;
+  subtitle: string | undefined;
+  description: string | undefined;
+  publisher: string | undefined;
+  publishedDate: string | undefined;
+  genres: string[] | undefined;
+}
+
+/**
+ * ONE decision, in one place: what the header shows and what the Edit Metadata
+ * modal pre-fills and diffs against must not be able to disagree (#2069 AC18/AC25).
+ *
+ * Order of application:
+ *
+ *  1. **Tombstoned → resolves to nothing.** An explicit clear stays cleared
+ *     everywhere until the operator sets a new value; the provider fallback must
+ *     not resurrect it.
+ *  2. **Otherwise → today's exact per-field operator, unchanged.** `||` for
+ *     `description`, `seriesName`, `publisher`, `publishedDate`, `subtitle` (so a
+ *     stored empty string still falls through to the provider value, as it does
+ *     today); `??` for `genres` (so a stored `[]` deliberately OVERRIDES the
+ *     provider list) and for `seriesPosition`; `pickPrimarySeries` for the series
+ *     ref (#1088/#1097 — `series[0]` on Audible can be a broader universe entry).
+ *
+ * The `||`/`??` asymmetry is preserved by construction, not re-derived: a uniform
+ * operator would change behavior on exactly the `''` and `[]` cases.
+ *
+ * `seriesPosition` follows `seriesName` (the #1927 AC10 pair rule) and is never
+ * resolved independently. `coverUrl`, `duration`, and `narratorNames` are NOT part
+ * of this decision — none of them is clearable — and stay inside `mergeBookData`.
+ */
+export function resolveDisplayedFields(
+  libraryBook: BookWithAuthor,
+  metadataBook?: MetadataBook | null | undefined,
+): DisplayedFields {
+  const cleared = new Set<string>(libraryBook.userClearedFields ?? []);
+  const primaryMetaSeries = pickPrimarySeries(metadataBook);
+  const seriesName = orProvider(cleared, 'seriesName', libraryBook.seriesName, primaryMetaSeries?.name);
+
+  return {
+    seriesName,
+    // Pair rule: the position resolves only when the name does.
+    seriesPosition: seriesName ? (libraryBook.seriesPosition ?? primaryMetaSeries?.position) : undefined,
+    subtitle: orProvider(cleared, 'subtitle', libraryBook.subtitle, metadataBook?.subtitle),
+    description: orProvider(cleared, 'description', libraryBook.description, metadataBook?.description),
+    publisher: orProvider(cleared, 'publisher', libraryBook.publisher, metadataBook?.publisher),
+    publishedDate: orProvider(cleared, 'publishedDate', libraryBook.publishedDate, metadataBook?.publishedDate),
+    // `??`, not `||`: a stored `[]` is a deliberate override that must NOT fall
+    // through to the provider list.
+    genres: cleared.has('genres') ? undefined : (libraryBook.genres ?? metadataBook?.genres),
+  };
+}
+
+/**
+ * The `||` arm shared by the five string fields: tombstoned resolves to nothing,
+ * otherwise a stored empty string still defers to the provider value — today's
+ * exact behavior, preserved by construction.
+ */
+function orProvider(
+  cleared: ReadonlySet<string>,
+  field: string,
+  stored: string | null | undefined,
+  provider: string | undefined,
+): string | undefined {
+  if (cleared.has(field)) return undefined;
+  return stored || provider;
+}
+
 // eslint-disable-next-line complexity -- flat data coalescing across two sources, no nesting
 export function mergeBookData(libraryBook: BookWithAuthor, metadataBook?: MetadataBook | null | undefined) {
-  const description = libraryBook.description || metadataBook?.description;
+  const displayed = resolveDisplayedFields(libraryBook, metadataBook);
   const coverUrl = libraryBook.coverUrl || metadataBook?.coverUrl;
-  const genres = libraryBook.genres ?? metadataBook?.genres;
-  // Prefer canonical `seriesPrimary` over `series[0]` (#1088 / #1097) — `series[0]`
-  // on Audible can be a broader universe entry rather than the real book series.
-  const primaryMetaSeries = pickPrimarySeries(metadataBook);
-  const seriesName = libraryBook.seriesName || primaryMetaSeries?.name;
-  const seriesPosition = libraryBook.seriesPosition ?? primaryMetaSeries?.position;
   const duration = formatDurationMinutes(libraryBook.duration ?? metadataBook?.duration);
-  const publisher = libraryBook.publisher || metadataBook?.publisher;
-  const year = formatYear(libraryBook.publishedDate || metadataBook?.publishedDate);
+  const year = formatYear(displayed.publishedDate);
   const status = requireDefined(
     bookStatusConfig[libraryBook.status],
     `mergeBookData: bookStatusConfig missing entry for "${libraryBook.status}"`,
@@ -37,23 +107,23 @@ export function mergeBookData(libraryBook: BookWithAuthor, metadataBook?: Metada
   const narratorNames = (libraryBook.narrators.length > 0 ? libraryBook.narrators.map((n) => n.name).join(', ') : null) || metadataBook?.narrators?.join(', ');
 
   const metaDots: string[] = [];
-  if (seriesName) {
-    metaDots.push(`${seriesName}${seriesPosition != null ? ` #${seriesPosition}` : ''}`);
+  if (displayed.seriesName) {
+    metaDots.push(`${displayed.seriesName}${displayed.seriesPosition != null ? ` #${displayed.seriesPosition}` : ''}`);
   }
   if (duration) metaDots.push(duration);
   if (year) metaDots.push(year);
-  if (publisher) metaDots.push(publisher);
+  if (displayed.publisher) metaDots.push(displayed.publisher);
 
   return {
-    description,
+    description: displayed.description,
     coverUrl,
-    genres,
+    genres: displayed.genres,
     narratorNames,
     metaDots,
     statusLabel: status.label,
     statusDotClass: status.dotClass,
     statusBarClass: status.barClass,
-    subtitle: libraryBook.subtitle || metadataBook?.subtitle,
+    subtitle: displayed.subtitle,
     authorName: libraryBook.authors[0]?.name,
     authorAsin: libraryBook.authors[0]?.asin,
   };

--- a/src/client/pages/book/metadata-clear-flow.test.tsx
+++ b/src/client/pages/book/metadata-clear-flow.test.tsx
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createMockBook } from '@/__tests__/factories';
+import type { BookWithAuthor, UpdateBookPayload } from '@/lib/api';
+import type { ClearableBookField } from '@shared/schemas.js';
+import { BookPage } from './BookPage';
+
+// importOriginal form, NOT a bare replacement factory — BookDetails transitively
+// loads CompanionEbookSection, which reads named exports at RUNTIME
+// (`vimock-barrel-replace-drops-named-exports`). The reciprocal hazard applies too:
+// every method left unstubbed stays REAL and issues a genuine relative-URL fetch, so
+// the standing `issues no real network request` guard below is what keeps this suite
+// honest as child components change.
+vi.mock('@/lib/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/api')>();
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getBookById: vi.fn(),
+      getBook: vi.fn(),
+      updateBook: vi.fn(),
+      getBookSeries: vi.fn(),
+      getBookFiles: vi.fn(),
+      getCompanionEbookState: vi.fn(),
+      getCompanionEbookMetadata: vi.fn(),
+      getFfmpegStatus: vi.fn(),
+      mintStreamToken: vi.fn(),
+    },
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+import { api } from '@/lib/api';
+
+/**
+ * The CLIENT half of the #2069 provider-only clear workflow (AC20/AC25), end to end
+ * across the real page: `BookPage` → `BookDetails` → `resolveDisplayedFields` →
+ * `BookMetadataModal` → `useBookActions` → the API call → cache invalidation →
+ * refetch → the re-rendered header.
+ *
+ * The `api` layer is backed by an in-memory fake that models the SERVER's tombstone
+ * semantics (recompute on `seriesName: null`, hydrate the parsed array on read), so
+ * the invalidation/refetch loop is exercised for real rather than asserted about.
+ *
+ * The server half — the same PUT payload against the real Fastify app, real
+ * BookService and a real migrated DB, plus the persistence, series-card and
+ * post-enrichment assertions — is
+ * `src/server/__tests__/metadata-clear-flow.e2e.test.ts`. The two meet at the PUT
+ * payload, which both assert on literally (`{ seriesName: null }`); they cannot be
+ * one test because client suites run in jsdom and server suites in node.
+ */
+describe('Provider-only metadata clear — client E2E (#2069)', () => {
+  let fetchSpy: MockInstance<typeof globalThis.fetch>;
+  /** The fake server's row for book 1, mutated by the PUT the way the service would. */
+  let storedBook: BookWithAuthor;
+
+  /** A post-import book: `enriched`, no stored series — the series is provider-only. */
+  function providerOnlyBook(): BookWithAuthor {
+    return createMockBook({
+      id: 1,
+      title: 'Tress of the Emerald Sea',
+      authors: [{ id: 1, name: 'Brandon Sanderson', slug: 'brandon-sanderson' }],
+      narrators: [],
+      status: 'imported',
+      enrichmentStatus: 'enriched',
+      // `useBook` is keyed off the ASIN — without one the provider query never fires
+      // and the fallback under test could not exist.
+      asin: 'B0BTRESS01',
+      seriesName: null,
+      seriesPosition: null,
+      publisher: 'Dragonsteel',
+      path: '/library/Brandon Sanderson/Tress of the Emerald Sea',
+      userClearedFields: [],
+    });
+  }
+
+  const metadataBook = {
+    title: 'Tress of the Emerald Sea',
+    authors: [{ name: 'Brandon Sanderson' }],
+    seriesPrimary: { name: 'Secret Projects', position: 1 },
+    series: [{ name: 'Secret Projects', position: 1 }],
+    publisher: 'Dragonsteel',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storedBook = providerOnlyBook();
+
+    // The fake server: `getBookById` always returns CURRENT state, so a refetch after
+    // invalidation observes the write — the loop this test exists to cover.
+    vi.mocked(api.getBookById).mockImplementation(async () => storedBook);
+    vi.mocked(api.getBook).mockResolvedValue(metadataBook);
+    vi.mocked(api.updateBook).mockImplementation(async (_id: number, payload: UpdateBookPayload) => {
+      // Mirror the server's AC6 recompute for the one field this flow touches: a
+      // blank value adds the tombstone and normalizes the stored column to NULL; a
+      // non-blank value removes it.
+      const cleared = new Set<ClearableBookField>(storedBook.userClearedFields ?? []);
+      if ('seriesName' in payload) {
+        if (payload.seriesName == null || payload.seriesName.trim() === '') {
+          cleared.add('seriesName');
+          storedBook = { ...storedBook, seriesName: null, seriesPosition: null };
+        } else {
+          cleared.delete('seriesName');
+          storedBook = { ...storedBook, seriesName: payload.seriesName };
+        }
+      }
+      storedBook = { ...storedBook, userClearedFields: [...cleared].sort() };
+      return storedBook;
+    });
+
+    vi.mocked(api.getBookSeries).mockImplementation(async () =>
+      storedBook.seriesName ? { series: { id: 1, name: storedBook.seriesName, hardcoverSeriesId: null, seriesAuthor: null, lastFetchedAt: null, members: [] } } : { series: null },
+    );
+    vi.mocked(api.getBookFiles).mockResolvedValue([]);
+    vi.mocked(api.getFfmpegStatus).mockResolvedValue({ detected: true, version: '8.0.1', path: '/usr/bin/ffmpeg' });
+    vi.mocked(api.mintStreamToken).mockRejectedValue(new Error('no stream token in this suite'));
+    fetchSpy = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  function renderPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/books/1']}>
+          <Routes>
+            <Route path="books/:id" element={<BookPage />} />
+            <Route path="library" element={<div>Library Page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  }
+
+  async function openEditModal(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByLabelText('More actions'));
+    await user.click(screen.getByRole('menuitem', { name: /Edit/ }));
+  }
+
+  it('clears a provider-only series through the real UI and the header updates without a reload', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // 1. The header shows the series from the PROVIDER fallback — nothing is stored.
+    await waitFor(() => expect(screen.getByText('Tress of the Emerald Sea')).toBeInTheDocument());
+    // The provider metadata is a separate query from the library book — wait for it
+    // to settle rather than asserting on the library-only first paint.
+    await waitFor(() => expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument());
+
+    // 2. The modal pre-fills from the SAME resolver decision (AC18/AC25) — this is
+    //    what makes the clear expressible at all for this book.
+    await openEditModal(user);
+    const seriesInput = screen.getByLabelText(/series$/i);
+    expect(seriesInput).toHaveValue('Secret Projects');
+
+    // 3. Blank it and save.
+    await user.clear(seriesInput);
+    await user.click(screen.getByText('Save'));
+
+    // 4. The exact payload the server half consumes.
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalled());
+    expect(api.updateBook).toHaveBeenCalledWith(1, { seriesName: null });
+
+    // 5. Invalidation → refetch → re-render. No remount, no reload: the same tree
+    //    that rendered the dot must stop rendering it.
+    await waitFor(() => expect(screen.queryByText(/Secret Projects/)).not.toBeInTheDocument());
+
+    // 6. The tombstone came back on the refetched detail and is what suppresses the
+    //    provider fallback — the header is not merely showing a stale empty string.
+    expect(storedBook.userClearedFields).toEqual(['seriesName']);
+    // Untouched neighbours still render, so this is a targeted suppression.
+    expect(screen.getByText(/Dragonsteel/)).toBeInTheDocument();
+  });
+
+  it('reopening the modal after the clear shows the series BLANK, not the provider value', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument());
+
+    await openEditModal(user);
+    await user.clear(screen.getByLabelText(/series$/i));
+    await user.click(screen.getByText('Save'));
+    await waitFor(() => expect(screen.queryByText(/Secret Projects/)).not.toBeInTheDocument());
+
+    await openEditModal(user);
+
+    // The operator never sees the value they just removed reappear.
+    expect(screen.getByLabelText(/series$/i)).toHaveValue('');
+  });
+
+  it('saving the reopened modal untouched does not resurrect the series', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument());
+
+    await openEditModal(user);
+    await user.clear(screen.getByLabelText(/series$/i));
+    await user.click(screen.getByText('Save'));
+    await waitFor(() => expect(screen.queryByText(/Secret Projects/)).not.toBeInTheDocument());
+
+    vi.mocked(api.updateBook).mockClear();
+    await openEditModal(user);
+    await user.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalled());
+    expect(api.updateBook).toHaveBeenCalledWith(1, {});
+    expect(storedBook.userClearedFields).toEqual(['seriesName']);
+    expect(screen.queryByText(/Secret Projects/)).not.toBeInTheDocument();
+  });
+
+  it('AC22: typing a new series removes the tombstone and the header shows it', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument());
+
+    await openEditModal(user);
+    await user.clear(screen.getByLabelText(/series$/i));
+    await user.click(screen.getByText('Save'));
+    await waitFor(() => expect(screen.queryByText(/Secret Projects/)).not.toBeInTheDocument());
+
+    await openEditModal(user);
+    await user.type(screen.getByLabelText(/series$/i), 'Cosmere');
+    await user.click(screen.getByText('Save'));
+
+    // Scope to the header meta line — the series card sidebar also renders the name
+    // once the tombstone is gone, and `getByText` would ambiguously match both.
+    await waitFor(() => expect(screen.getByText(/^Cosmere #1 ·/)).toBeInTheDocument());
+    expect(storedBook.userClearedFields).toEqual([]);
+  });
+
+  it('AC21 control: an unrelated edit never promotes the provider series into the payload', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument());
+
+    await openEditModal(user);
+    await user.clear(screen.getByLabelText(/^title/i));
+    await user.type(screen.getByLabelText(/^title/i), 'Renamed Book');
+    await user.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(api.updateBook).toHaveBeenCalled());
+    const payload = vi.mocked(api.updateBook).mock.calls[0]![1] as Record<string, unknown>;
+    expect(payload).toEqual({ title: 'Renamed Book' });
+    expect(payload).not.toHaveProperty('seriesName');
+    // The header keeps showing the provider fallback — nothing was tombstoned.
+    expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument();
+  });
+
+  // Standing guard (`vimock-barrel-replace-drops-named-exports`): a method left real
+  // by the preserved barrel reaches `fetchApi`, which resolves a relative `/api/...`
+  // URL against jsdom's base and issues a genuine request.
+  it('issues no real network request across the whole clear flow', async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await waitFor(() => expect(screen.getByText('Tress of the Emerald Sea')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText(/Secret Projects #1/)).toBeInTheDocument());
+
+    await openEditModal(user);
+    await user.clear(screen.getByLabelText(/series$/i));
+    await user.click(screen.getByText('Save'));
+    await waitFor(() => expect(screen.queryByText(/Secret Projects/)).not.toBeInTheDocument());
+
+    expect(fetchSpy.mock.calls.map((call) => String(call[0]))).toEqual([]);
+  });
+});

--- a/src/client/pages/book/useBookActions.test.ts
+++ b/src/client/pages/book/useBookActions.test.ts
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement, type ReactNode } from 'react';
 import { api } from '@/lib/api';
 import { useBookActions } from './useBookActions.js';
+import { queryKeys } from '@/lib/queryKeys.js';
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() },
@@ -187,6 +188,41 @@ describe('useBookActions', () => {
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['books', 42] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['books', 42, 'files'] });
       expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['books'] });
+    });
+
+    // #2069 AC17 — the series card lives in the SINGULAR `book` root namespace, so
+    // no prefix cascade from `['books', id]` reaches it. Without this the card keeps
+    // rendering the old series after a metadata save that cleared it.
+    it('also invalidates the series-card query after a successful save', async () => {
+      (api.updateBook as Mock).mockResolvedValue({});
+      const { queryClient, wrapper } = createTestHarness();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const { result } = renderHook(() => useBookActions(42), { wrapper });
+
+      await act(async () => {
+        await result.current.handleSave({ seriesName: null }, false);
+      });
+
+      // The EXACT key array — a prefix-shaped assertion is what let the false
+      // "it already cascades" claim through in the first place.
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['book', 42, 'series'] });
+      expect(queryKeys.bookSeries(42)).toEqual(['book', 42, 'series']);
+      expect(queryKeys.book(42)).toEqual(['books', 42]);
+    });
+
+    it('also invalidates the series-card query after a standalone rename', async () => {
+      (api.renameBook as Mock).mockResolvedValue({ message: 'Moved' });
+      const { queryClient, wrapper } = createTestHarness();
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const { result } = renderHook(() => useBookActions(42), { wrapper });
+
+      await act(async () => {
+        await result.current.renameMutation.mutateAsync();
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['book', 42, 'series'] });
     });
 
     it('invalidates queries twice when save + rename both succeed', async () => {

--- a/src/client/pages/book/useBookActions.ts
+++ b/src/client/pages/book/useBookActions.ts
@@ -15,6 +15,16 @@ export function useBookActions(bookId: number) {
     queryClient.invalidateQueries({ queryKey: queryKeys.book(bookId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.bookFiles(bookId) });
     queryClient.invalidateQueries({ queryKey: queryKeys.books() });
+    // The series card lives in its own ROOT namespace — `queryKeys.book(id)` is
+    // `['books', id]` while `queryKeys.bookSeries(id)` is `['book', id, 'series']`
+    // — so no prefix cascade reaches it and a metadata save that clears the series
+    // would otherwise leave the card rendering stale cached data until a reload
+    // (#2069 AC17). `BookFixMatchModal` already invalidates this key explicitly;
+    // putting it in the shared helper also covers the rename mutation, which is
+    // strictly more invalidation and loses nothing. Retag is deliberately NOT
+    // covered: its success handler never calls this helper, and a re-tag rewrites
+    // file tags without changing any stored series.
+    queryClient.invalidateQueries({ queryKey: queryKeys.bookSeries(bookId) });
   };
 
   const renameMutation = useMutation({

--- a/src/client/pages/settings/AudioToolsSettings.test.tsx
+++ b/src/client/pages/settings/AudioToolsSettings.test.tsx
@@ -39,6 +39,33 @@ describe('AudioToolsSettings', () => {
     mockApi.getFfmpegStatus.mockResolvedValue({ detected: true, version: '8.0.1', path: '/usr/bin/ffmpeg' });
   });
 
+  // #2068 — these two strings are the only place a run-time guarantee is paraphrased for
+  // humans, and loose restatements have twice shipped inaccurate copy ("caps at 320 kbps",
+  // then "nearest legal rate"). Exact-match, not substring, so the wording is a reviewed
+  // artifact rather than prose that drifts.
+  const KEEP_ORIGINAL_DESCRIPTION =
+    'Copies the audio when the parts are compatible. Otherwise re-encodes using the source '
+    + 'bitrate where it is known, or a conservative default where it is not, adjusted to a '
+    + 'value the output format accepts.';
+  const TARGET_BITRATE_DESCRIPTION =
+    'The bitrate to encode to \u2014 active only when Keep original is off. MP3 output rounds '
+    + 'down to the next supported rate \u2014 or up to the minimum, if lower \u2014 and its '
+    + 'maximum depends on the source sample rate.';
+
+  it('describes the bitrate controls in the exact pinned wording', async () => {
+    renderWithProviders(<AudioToolsSettings />);
+    await waitFor(() => expect(screen.getByText('Merge & Convert')).toBeInTheDocument());
+
+    expect(screen.getByText(KEEP_ORIGINAL_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.getByText(TARGET_BITRATE_DESCRIPTION)).toBeInTheDocument();
+
+    // AC8 snaps DOWN, so no proximity word is true of it: 251 kbps evidence at 44.1 kHz
+    // emits 224 even though 256 is legal and nearer.
+    for (const copy of [KEEP_ORIGINAL_DESCRIPTION, TARGET_BITRATE_DESCRIPTION]) {
+      expect(copy).not.toMatch(/close|closest|nearest/i);
+    }
+  });
+
   it('renders the Merge & Convert engine fields', async () => {
     renderWithProviders(<AudioToolsSettings />);
     await waitFor(() => expect(screen.getByText('Merge & Convert')).toBeInTheDocument());

--- a/src/client/pages/settings/AudioToolsSettings.tsx
+++ b/src/client/pages/settings/AudioToolsSettings.tsx
@@ -113,11 +113,11 @@ export function AudioToolsSettings() {
             </div>
           </SettingsRow>
 
-          <SettingsRow htmlFor="keepOriginalBitrate" label="Keep original bitrate" description="Re-encode at each file’s source bitrate.">
+          <SettingsRow htmlFor="keepOriginalBitrate" label="Keep original bitrate" description="Copies the audio when the parts are compatible. Otherwise re-encodes using the source bitrate where it is known, or a conservative default where it is not, adjusted to a value the output format accepts.">
             <ToggleSwitch id="keepOriginalBitrate" {...register('keepOriginalBitrate')} />
           </SettingsRow>
 
-          <SettingsRow htmlFor="bitrate" label="Target bitrate" description="The bitrate to encode to — active only when Keep original is off." muted={keepOriginalBitrate}>
+          <SettingsRow htmlFor="bitrate" label="Target bitrate" description="The bitrate to encode to — active only when Keep original is off. MP3 output rounds down to the next supported rate — or up to the minimum, if lower — and its maximum depends on the source sample rate." muted={keepOriginalBitrate}>
             <NumberField
               id="bitrate"
               {...register('bitrate', { valueAsNumber: true })}

--- a/src/core/utils/audio-processor.roundtrip.test.ts
+++ b/src/core/utils/audio-processor.roundtrip.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Real-ffmpeg round-trip tests for the #2068 encode strategy.
+ *
+ * `audio-processor.test.ts` mocks `node:child_process` wholesale, so it can prove what argv
+ * this module CONSTRUCTS but not that ffmpeg accepts it — and the two defects this issue is
+ * really about live on that boundary: whether the concat demuxer will stream-copy the set at
+ * all, and whether `libmp3lame` accepts the bitrate we picked. This file fills that gap with
+ * real fixtures, following the harness pattern in `src/server/services/tagging.roundtrip.test.ts`.
+ *
+ * It guards on ffmpeg PRESENCE (that suite's ffmpeg-8 floor is an xHE-AAC concern that does
+ * not apply here). Fixtures are non-silent on purpose: `anullsrc` silence encodes to almost
+ * nothing, which makes a nominal `-b:a` an unstable expectation, so every fixture is a 440 Hz
+ * sine and every bitrate expectation is compared against the fixture's own MEASURED stream
+ * bit_rate rather than the flag it was generated with.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { processAudioFiles, type ProcessingConfig, type ProcessingContext } from './audio-processor.js';
+import { MP3_BITRATES_MPEG2 } from './encode-strategy.js';
+
+const FFMPEG = 'ffmpeg';
+const FFPROBE = 'ffprobe';
+
+function hasFfmpeg(): boolean {
+  try {
+    execFileSync(FFMPEG, ['-version'], { stdio: 'ignore' });
+    execFileSync(FFPROBE, ['-version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const FFMPEG_PRESENT = hasFfmpeg();
+
+interface StreamFacts {
+  codecName: string;
+  bitRate: number;
+  sampleRate: number;
+  channels: number;
+}
+
+function probeStream(file: string): StreamFacts {
+  const out = execFileSync(FFPROBE, [
+    '-v', 'quiet', '-select_streams', 'a:0',
+    '-show_entries', 'stream=codec_name,bit_rate,sample_rate,channels',
+    '-of', 'json', file,
+  ], { encoding: 'utf8' });
+  const s = JSON.parse(out).streams?.[0] ?? {};
+  return {
+    codecName: String(s.codec_name),
+    bitRate: Number.parseInt(String(s.bit_rate), 10),
+    sampleRate: Number.parseInt(String(s.sample_rate), 10),
+    channels: Number(s.channels),
+  };
+}
+
+function chapterTitles(file: string): string[] {
+  const out = execFileSync(FFPROBE, ['-v', 'quiet', '-print_format', 'json', '-show_chapters', file], { encoding: 'utf8' });
+  return ((JSON.parse(out).chapters ?? []) as Array<{ tags?: { title?: string } }>)
+    .map((c) => c.tags?.title ?? '');
+}
+
+/**
+ * md5 of the file's copied audio PACKETS. The md5 muxer hashes packet payloads, so this is
+ * container-agnostic: two files carrying the same encoded frames digest identically, and any
+ * re-encode changes it. This is the primary no-re-encode oracle.
+ */
+function audioPacketDigest(inputArgs: string[]): string {
+  const out = execFileSync(FFMPEG, ['-v', 'quiet', ...inputArgs, '-map', '0:a', '-c', 'copy', '-f', 'md5', '-'], { encoding: 'utf8' });
+  return out.trim();
+}
+
+const CONTEXT: ProcessingContext = { author: 'Sanderson', title: 'Oathbringer' };
+
+function keepOriginal(outputFormat: 'm4b' | 'mp3'): ProcessingConfig {
+  return { ffmpegPath: FFMPEG, outputFormat, mergeBehavior: 'always' };
+}
+
+describe.skipIf(!FFMPEG_PRESENT)('#2068 encode strategy round-trip (real ffmpeg)', () => {
+  let root: string;
+  let caseIndex = 0;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'narratorr-encode-strategy-'));
+  });
+
+  afterAll(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  /** A fresh per-test directory, since mergeFiles deletes its sources on success. */
+  function caseDir(): string {
+    const dir = join(root, `case-${caseIndex++}`);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  /**
+   * Generate one deterministic, non-silent part. `extraArgs` sets the codec and any bitrate;
+   * the caller reads back the MEASURED bit_rate rather than trusting the flag.
+   */
+  function makePart(dir: string, name: string, opts: {
+    seconds?: number;
+    sampleRate?: number;
+    channels?: number;
+    codecArgs: string[];
+  }): string {
+    const path = join(dir, name);
+    const { seconds = 4, sampleRate = 44_100, channels = 2 } = opts;
+    execFileSync(FFMPEG, [
+      '-y', '-v', 'quiet',
+      '-f', 'lavfi',
+      '-i', `sine=frequency=440:sample_rate=${sampleRate}:duration=${seconds}`,
+      '-ac', String(channels),
+      ...opts.codecArgs,
+      path,
+    ], { stdio: 'ignore' });
+    return path;
+  }
+
+  function outputIn(dir: string, ext: string): string {
+    const found = readdirSync(dir).find((f) => f.toLowerCase().endsWith(ext));
+    if (!found) throw new Error(`no ${ext} output in ${dir} (saw ${readdirSync(dir).join(', ')})`);
+    return join(dir, found);
+  }
+
+  function concatListFor(dir: string, files: string[]): string {
+    const listPath = join(dir, 'reference-concat.txt');
+    writeFileSync(listPath, files.map((f) => `file '${f}'`).join('\n'), 'utf-8');
+    return listPath;
+  }
+
+  it('stream-copies a homogeneous 256 kbps AAC set and keeps the generated chapters', async () => {
+    const dir = caseDir();
+    const parts = ['01.m4b', '02.m4b', '03.m4b'].map((name) =>
+      makePart(dir, name, { codecArgs: ['-c:a', 'aac', '-b:a', '256k'] }));
+    const measured = probeStream(parts[0]!);
+
+    // Both computed BEFORE the run — mergeFiles deletes its sources on success.
+    const listPath = concatListFor(dir, parts);
+    const reference = audioPacketDigest(['-f', 'concat', '-safe', '0', '-i', listPath]);
+
+    const result = await processAudioFiles(dir, keepOriginal('m4b'), CONTEXT);
+    expect(result.success).toBe(true);
+
+    const merged = outputIn(dir, '.m4b');
+    // Primary oracle: identical packets ⇒ no re-encode happened.
+    expect(audioPacketDigest(['-i', merged])).toBe(reference);
+
+    // Secondary, readable: a re-encode at ffmpeg's implicit ~128k default would blow this band.
+    const out = probeStream(merged);
+    expect(out.codecName).toBe('aac');
+    expect(Math.abs(out.bitRate - measured.bitRate) / measured.bitRate).toBeLessThan(0.1);
+
+    expect(chapterTitles(merged)).toEqual(['Chapter 1', 'Chapter 2', 'Chapter 3']);
+  });
+
+  it('re-encodes homogeneous 128 kbps MP3 parts into m4b at a comparable rate', async () => {
+    const dir = caseDir();
+    ['01.mp3', '02.mp3'].forEach((name) =>
+      makePart(dir, name, { codecArgs: ['-c:a', 'libmp3lame', '-b:a', '128k'] }));
+
+    const result = await processAudioFiles(dir, keepOriginal('m4b'), CONTEXT);
+    expect(result.success).toBe(true);
+
+    // A well-conditioned case on purpose: 128 is comfortably inside both encoders' legal
+    // domains, so the observed rate is a stable expectation. This is NOT a general
+    // "output >= source" claim — no such claim is made anywhere.
+    const out = probeStream(outputIn(dir, '.m4b'));
+    expect(out.codecName).toBe('aac');
+    expect(Math.abs(out.bitRate - 128_000) / 128_000).toBeLessThan(0.1);
+  });
+
+  it('reaches the real MPEG-2 encoder for a 22.05 kHz source, where a naive 320k is re-rated', async () => {
+    const dir = caseDir();
+    // The sources must be INELIGIBLE for a stream copy, or this proves nothing about the
+    // encoder command: a homogeneous 22.05 kHz `.mp3`/mp3 set into mp3 output is copy-eligible,
+    // so it would take `-c:a copy` and the read-back would only observe the fixture's own rate.
+    // `.wav`/pcm_s16le can never copy into mp3, so the production call genuinely reaches
+    // libmp3lame — which is the boundary AC8a exists to defend.
+    ['01.wav', '02.wav'].forEach((name) =>
+      makePart(dir, name, { sampleRate: 22_050, codecArgs: ['-c:a', 'pcm_s16le'] }));
+    const source = join(dir, '01.wav');
+
+    // Counterfactual first, while the sources still exist: at 22.05 kHz LAME does not deliver
+    // the MPEG-1 answer. Observed on ffmpeg 6.0, it silently re-rates 320k down to 160k rather
+    // than failing — silent re-rating is exactly why the target is snapped before it is emitted.
+    const naive = join(dir, 'naive.mp3');
+    let naiveRate: number | null;
+    try {
+      execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-i', source, '-c:a', 'libmp3lame', '-b:a', '320k', naive], { stdio: 'ignore' });
+      naiveRate = probeStream(naive).bitRate;
+    } catch {
+      naiveRate = null; // an outright rejection is the other legal way for the naive path to break
+    }
+    expect(naiveRate).not.toBe(320_000);
+    rmSync(naive, { force: true });
+
+    const result = await processAudioFiles(dir, keepOriginal('mp3'), CONTEXT);
+    expect(result.success).toBe(true);
+
+    // Proves the ENCODE branch was taken, not the copy branch: only an encode records an
+    // `mp3-table` step, and 705 kbps is the PCM source rate snapped to the MPEG-2 maximum.
+    expect(result.warnings!.some((w) => w.includes('705') && w.includes('160'))).toBe(true);
+
+    const out = probeStream(outputIn(dir, '.mp3'));
+    // A pcm_s16le source cannot yield an mp3 stream without a real encode.
+    expect(out.codecName).toBe('mp3');
+    // Asserted against the constant table rather than a hand-typed literal, so a future edit
+    // to MP3_BITRATES_MPEG2 cannot silently make the "legal at this rate" claim false.
+    expect(MP3_BITRATES_MPEG2.map((k) => k * 1000)).toContain(out.bitRate);
+    expect(out.bitRate).toBeLessThanOrEqual(160_000);
+    expect(out.sampleRate).toBe(22_050);
+  });
+
+  it('legalizes an explicit 512 kbps mp3 target down to 320 kbps at 44.1 kHz', async () => {
+    const dir = caseDir();
+    ['01.mp3', '02.mp3'].forEach((name) =>
+      makePart(dir, name, { codecArgs: ['-c:a', 'libmp3lame', '-b:a', '320k'] }));
+
+    const result = await processAudioFiles(dir, { ...keepOriginal('mp3'), bitrate: 512 }, CONTEXT);
+    expect(result.success).toBe(true);
+    expect(probeStream(outputIn(dir, '.mp3')).bitRate).toBe(320_000);
+  });
+
+  it('raises a sub-table request to the 32 kbps MPEG-1 minimum rather than emitting it', async () => {
+    const dir = caseDir();
+    ['01.mp3', '02.mp3'].forEach((name) =>
+      makePart(dir, name, { codecArgs: ['-c:a', 'libmp3lame', '-b:a', '8k'] }));
+
+    const result = await processAudioFiles(dir, { ...keepOriginal('mp3'), bitrate: 8 }, CONTEXT);
+    expect(result.success).toBe(true);
+    expect(probeStream(outputIn(dir, '.mp3')).bitRate).toBe(32_000);
+  });
+
+  it('emits no -ar, so a 48 kHz source keeps its sample rate through an mp3 encode', async () => {
+    const dir = caseDir();
+    ['01.m4a', '02.m4a'].forEach((name) =>
+      makePart(dir, name, { sampleRate: 48_000, codecArgs: ['-c:a', 'aac', '-b:a', '128k'] }));
+
+    const result = await processAudioFiles(dir, keepOriginal('mp3'), CONTEXT);
+    expect(result.success).toBe(true);
+    expect(probeStream(outputIn(dir, '.mp3')).sampleRate).toBe(48_000);
+  });
+
+  it('is honest about a lossless source: it succeeds, discloses the cap, and claims nothing about the output', async () => {
+    const dir = caseDir();
+    ['01.wav', '02.wav'].forEach((name) =>
+      makePart(dir, name, { channels: 1, codecArgs: ['-c:a', 'pcm_s16le'] }));
+
+    const result = await processAudioFiles(dir, keepOriginal('m4b'), CONTEXT);
+    expect(result.success).toBe(true);
+    // 44.1 kHz mono PCM is 705 kbps; we request the 512 cap and say so.
+    expect(result.warnings!.some((w) => w.includes('705') && w.includes('512'))).toBe(true);
+    // Deliberately NO assertion relating the output bitrate to the request or to the source:
+    // FFmpeg's AAC encoder clamps to its per-frame limit (~265 kbps here), and this module
+    // neither predicts nor claims that.
+    expect(probeStream(outputIn(dir, '.m4b')).codecName).toBe('aac');
+  });
+
+  it('caps the same lossless source at 320 kbps for mp3, with the same disclosure', async () => {
+    const dir = caseDir();
+    ['01.wav', '02.wav'].forEach((name) =>
+      makePart(dir, name, { channels: 1, codecArgs: ['-c:a', 'pcm_s16le'] }));
+
+    const result = await processAudioFiles(dir, keepOriginal('mp3'), CONTEXT);
+    expect(result.success).toBe(true);
+    expect(result.warnings!.some((w) => w.includes('705') && w.includes('320'))).toBe(true);
+    expect(probeStream(outputIn(dir, '.mp3')).bitRate).toBeLessThanOrEqual(320_000);
+  });
+});

--- a/src/core/utils/audio-processor.roundtrip.test.ts
+++ b/src/core/utils/audio-processor.roundtrip.test.ts
@@ -15,7 +15,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readdirSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, renameSync, writeFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { processAudioFiles, type ProcessingConfig, type ProcessingContext } from './audio-processor.js';
@@ -271,5 +271,250 @@ describe.skipIf(!FFMPEG_PRESENT)('#2068 encode strategy round-trip (real ffmpeg)
     expect(result.success).toBe(true);
     expect(result.warnings!.some((w) => w.includes('705') && w.includes('320'))).toBe(true);
     expect(probeStream(outputIn(dir, '.mp3')).bitRate).toBeLessThanOrEqual(320_000);
+  });
+});
+
+// ============================================================================
+// #2078 — a merge must not destroy the metadata and cover art its sources had.
+//
+// The mocked suite can only prove what argv this module CONSTRUCTS. The production defect was
+// downstream of that: `-map_metadata 1` pointed at the generated FFMETADATA1 file, which has
+// only [CHAPTER] blocks, so ffmpeg wrote an EMPTY global tag set and every auto-merged m4b came
+// out carrying nothing but `major_brand`/`encoder`. Only a real read-back can see that.
+//
+// Gated on ffmpeg PRESENCE, like the block above: nothing here needs the ffmpeg-8 xHE-AAC floor.
+// ============================================================================
+
+/** Format-level tags as a lowercased-key map (ffprobe casing varies by container). */
+function readFormatTags(file: string): Record<string, string> {
+  const out = execFileSync(FFPROBE, ['-v', 'quiet', '-print_format', 'json', '-show_format', file], { encoding: 'utf8' });
+  const tags = (JSON.parse(out).format?.tags ?? {}) as Record<string, unknown>;
+  return Object.fromEntries(Object.entries(tags).map(([k, v]) => [k.toLowerCase(), String(v)]));
+}
+
+/** True when the file carries a video stream flagged `attached_pic` (an embedded cover). */
+function hasAttachedPic(file: string): boolean {
+  const out = execFileSync(FFPROBE, [
+    '-v', 'quiet', '-select_streams', 'v', '-show_entries', 'stream_disposition=attached_pic',
+    '-of', 'json', file,
+  ], { encoding: 'utf8' });
+  return ((JSON.parse(out).streams ?? []) as Array<{ disposition?: { attached_pic?: number } }>)
+    .some((s) => s.disposition?.attached_pic === 1);
+}
+
+/**
+ * The AUDIO STREAM's duration — deliberately NOT `format=duration`.
+ *
+ * In an m4b the chapter track counts toward the container duration, so `format=duration` reads
+ * the full 9 s even when only the 3 s first part was muxed: it CANNOT see the truncation
+ * `-map 0:a` exists to prevent. The audio stream's own duration can.
+ */
+function audioStreamDuration(file: string): number {
+  const out = execFileSync(FFPROBE, [
+    '-v', 'quiet', '-select_streams', 'a:0', '-show_entries', 'stream=duration', '-of', 'json', file,
+  ], { encoding: 'utf8' });
+  return Number.parseFloat(String(JSON.parse(out).streams?.[0]?.duration));
+}
+
+/** The tags every fixture part carries, so a naked output is unambiguous. */
+const SOURCE_TAGS: Record<string, string> = {
+  artist: 'Brandon Sanderson',
+  album_artist: 'Brandon Sanderson',
+  album: 'Oathbringer',
+  date: '2017',
+  genre: 'Fantasy',
+};
+
+const PART_SECONDS = 3;
+
+describe.skipIf(!FFMPEG_PRESENT)('#2078 merge preserves source metadata and cover art (real ffmpeg)', () => {
+  let root: string;
+  let caseIndex = 0;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'narratorr-2078-'));
+  });
+
+  afterAll(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  function caseDir(): string {
+    const dir = join(root, `case-${caseIndex++}`);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function makeCover(dir: string): string {
+    const path = join(dir, 'art.jpg');
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-f', 'lavfi', '-i', 'color=c=red:s=64x64:d=1', '-frames:v', '1', path], { stdio: 'ignore' });
+    return path;
+  }
+
+  /**
+   * One tagged, non-silent part. `cover` embeds an attached picture; `internalChapters` gives
+   * the part its OWN chapter set, which is what makes the `-map_chapters` assertion real —
+   * ffmpeg's default picks the input with the MOST chapters, so a part carrying more chapters
+   * than the generated set would win without the explicit map.
+   */
+  function makeTaggedPart(dir: string, name: string, opts: {
+    codecArgs: string[];
+    title: string;
+    cover?: string | undefined;
+    internalChapters?: number | undefined;
+  }): string {
+    const path = join(dir, name);
+    const metadataArgs = Object.entries({ ...SOURCE_TAGS, title: opts.title })
+      .flatMap(([k, v]) => ['-metadata', `${k}=${v}`]);
+
+    execFileSync(FFMPEG, [
+      '-y', '-v', 'quiet',
+      '-f', 'lavfi', '-i', `sine=frequency=440:sample_rate=44100:duration=${PART_SECONDS}`,
+      ...(opts.cover ? ['-i', opts.cover, '-map', '0:a', '-map', '1:v', '-c:v', 'copy', '-disposition:v', 'attached_pic'] : []),
+      ...opts.codecArgs,
+      ...metadataArgs,
+      path,
+    ], { stdio: 'ignore' });
+
+    if (!opts.internalChapters) return path;
+
+    const metaPath = join(dir, `${name}.internal.ffmeta`);
+    const slice = Math.floor((PART_SECONDS * 1000) / opts.internalChapters);
+    writeFileSync(metaPath, [';FFMETADATA1', ...Array.from({ length: opts.internalChapters }, (_, i) =>
+      ['[CHAPTER]', 'TIMEBASE=1/1000', `START=${i * slice}`, `END=${(i + 1) * slice}`, `title=Source Chapter ${i + 1}`].join('\n'),
+    )].join('\n') + '\n', 'utf-8');
+
+    const withChapters = join(dir, `chaptered-${name}`);
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-i', path, '-i', metaPath, '-map_metadata', '0', '-map_chapters', '1', '-c', 'copy', withChapters], { stdio: 'ignore' });
+    rmSync(path);
+    rmSync(metaPath);
+    renameSync(withChapters, path);
+    return path;
+  }
+
+  function outputIn(dir: string, ext: string): string {
+    const found = readdirSync(dir).find((f) => f.toLowerCase().endsWith(ext));
+    if (!found) throw new Error(`no ${ext} output in ${dir} (saw ${readdirSync(dir).join(', ')})`);
+    return join(dir, found);
+  }
+
+  /**
+   * The output must carry the WHOLE book, not just the metadata donor's single part.
+   *
+   * A band rather than `toBeCloseTo`: an AAC re-encode adds encoder priming/padding that
+   * differs by ffmpeg version (~24 ms on copy, ~42 ms at 64 kbps here), which would sit right
+   * on `toBeCloseTo(…, 0)`'s 0.05 edge. Half a second still separates the 9 s whole from a
+   * truncated 3 s first part by a factor the assertion can never confuse.
+   */
+  function expectFullBookDuration(file: string): void {
+    const total = PART_SECONDS * 3;
+    const actual = audioStreamDuration(file);
+    expect(actual, `audio-stream duration of ${file}`).toBeGreaterThan(total - 0.5);
+    expect(actual, `audio-stream duration of ${file}`).toBeLessThan(total + 0.5);
+  }
+
+  /**
+   * Every tag the sources carried, INCLUDING the global `title`.
+   *
+   * `title` is passed per scenario rather than folded into SOURCE_TAGS because it is the one
+   * field whose expected value differs by fixture: a merge inherits the metadata DONOR's title
+   * (part 01's `Part 1`), while a convert keeps the single file's own. Leaving it out of the
+   * shared set is exactly how a merge or convert could silently drop or overwrite the global
+   * title with the whole real-ffmpeg suite still green.
+   */
+  function expectSourceTagsPreserved(file: string, expectedTitle: string): void {
+    const tags = readFormatTags(file);
+    for (const [key, value] of Object.entries(SOURCE_TAGS)) {
+      expect(tags[key], `tag "${key}" on ${file}`).toBe(value);
+    }
+    expect(tags.title, `tag "title" on ${file}`).toBe(expectedTitle);
+  }
+
+  /** Build a tagged, chaptered, cover-bearing 3-part set. Part 01 carries 5 internal chapters. */
+  function buildParts(dir: string, ext: string, codecArgs: string[], opts: { cover?: boolean } = {}): string[] {
+    const cover = opts.cover === false ? undefined : makeCover(dir);
+    return ['01', '02', '03'].map((n, i) => makeTaggedPart(dir, `${n}.${ext}`, {
+      codecArgs, title: `Part ${i + 1}`, cover,
+      ...(i === 0 && { internalChapters: 5 }),
+    }));
+  }
+
+  it('m4b stream-copy: keeps the source tags, the cover, the generated chapters and the full duration', async () => {
+    const dir = caseDir();
+    buildParts(dir, 'm4b', ['-c:a', 'aac', '-b:a', '128k']);
+
+    const result = await processAudioFiles(dir, keepOriginal('m4b'), CONTEXT);
+    expect(result.success).toBe(true);
+
+    const merged = outputIn(dir, '.m4b');
+    // AC1/AC5 — pre-#2078 this read `{major_brand, minor_version, compatible_brands, encoder}`.
+    expectSourceTagsPreserved(merged, 'Part 1');
+    // AC8 — the extract/reattach lifecycle survives the 60 s stall timer and lands the picture.
+    expect(hasAttachedPic(merged)).toBe(true);
+    // AC3/F5 — the generated set (3, from the parts' title tags) beats part 01's competing 5.
+    expect(chapterTitles(merged)).toEqual(['Part 1', 'Part 2', 'Part 3']);
+    // AC2 — the whole book, not just the metadata donor's 3 s.
+    expectFullBookDuration(merged);
+    // AC4 — the extra input forced no re-encode.
+    expect(probeStream(merged).codecName).toBe('aac');
+    expect(result.warnings ?? []).toEqual([]);
+  });
+
+  it('m4b encode mode: the same guarantees hold when the set is re-encoded (AC3, AC4)', async () => {
+    const dir = caseDir();
+    buildParts(dir, 'm4b', ['-c:a', 'aac', '-b:a', '128k']);
+
+    // A usable explicit target always re-encodes, whatever the source codec.
+    const result = await processAudioFiles(dir, { ...keepOriginal('m4b'), bitrate: 64 }, CONTEXT);
+    expect(result.success).toBe(true);
+
+    const merged = outputIn(dir, '.m4b');
+    expectSourceTagsPreserved(merged, 'Part 1');
+    expect(hasAttachedPic(merged)).toBe(true);
+    expect(chapterTitles(merged)).toEqual(['Part 1', 'Part 2', 'Part 3']);
+    expectFullBookDuration(merged);
+  });
+
+  it('mp3 output: global tags survive, and there is deliberately NO embedded cover (AC8b)', async () => {
+    const dir = caseDir();
+    buildParts(dir, 'mp3', ['-c:a', 'libmp3lame', '-b:a', '128k']);
+
+    const result = await processAudioFiles(dir, keepOriginal('mp3'), CONTEXT);
+    expect(result.success).toBe(true);
+
+    const merged = outputIn(dir, '.mp3');
+    // The mp3 merge path has no generated-chapter input, so the first source is input 1.
+    expectSourceTagsPreserved(merged, 'Part 1');
+    // Pinned, not implied: `withCoverArtPipeline` gains no MP3 reattach arm in this issue.
+    expect(hasAttachedPic(merged)).toBe(false);
+  });
+
+  it('sources with no embedded art merge cleanly, with no spurious cover warning', async () => {
+    const dir = caseDir();
+    buildParts(dir, 'm4b', ['-c:a', 'aac', '-b:a', '128k'], { cover: false });
+
+    const result = await processAudioFiles(dir, keepOriginal('m4b'), CONTEXT);
+    expect(result.success).toBe(true);
+
+    const merged = outputIn(dir, '.m4b');
+    expectSourceTagsPreserved(merged, 'Part 1');
+    expect(hasAttachedPic(merged)).toBe(false);
+    expect(result.warnings ?? []).toEqual([]);
+  });
+
+  it('convert path: a per-file convert keeps its tags and its cover (AC18)', async () => {
+    const dir = caseDir();
+    const cover = makeCover(dir);
+    makeTaggedPart(dir, 'book.m4b', { codecArgs: ['-c:a', 'aac', '-b:a', '128k'], title: 'Oathbringer', cover });
+    rmSync(cover);
+
+    // An explicit target defeats the single-m4b keep-original short-circuit, so this really
+    // runs `convertFiles` — which emits no `-map_metadata` at all and relies on ffmpeg's default.
+    const result = await processAudioFiles(dir, { ...keepOriginal('m4b'), bitrate: 64 }, CONTEXT);
+    expect(result.success).toBe(true);
+
+    const converted = outputIn(dir, '.m4b');
+    expectSourceTagsPreserved(converted, 'Oathbringer');
+    expect(hasAttachedPic(converted)).toBe(true);
   });
 });

--- a/src/core/utils/audio-processor.test.ts
+++ b/src/core/utils/audio-processor.test.ts
@@ -151,7 +151,11 @@ interface StreamInfoFixture {
 let streamInfoByFile: Record<string, StreamInfoFixture | null> = {};
 
 function setStreamInfo(map: Record<string, StreamInfoFixture | null>): void {
-  streamInfoByFile = map;
+  // Fixture maps are keyed by path strings that tests write either as POSIX literals or via
+  // join() (backslashes on Windows). Re-key POSIX so both styles hit on every platform.
+  streamInfoByFile = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [k.split('\\').join('/'), v]),
+  );
 }
 
 /**
@@ -170,15 +174,22 @@ function installExecFileDispatcher(opts: {
   videoStreams?: Record<string, number>;
 } = {}): void {
   let durationIdx = 0;
+  // Same POSIX re-keying as setStreamInfo: callers key this map both ways.
+  const videoStreams = Object.fromEntries(
+    Object.entries(opts.videoStreams ?? {}).map(([k, v]) => [k.split('\\').join('/'), v]),
+  );
   mockExecFile.mockImplementation((...args: unknown[]) => {
     const cb = args[args.length - 1];
     if (typeof cb !== 'function') return {} as never;
     const execArgs = (args[1] as string[] | undefined) ?? [];
     const filePath = execArgs[execArgs.length - 1] ?? '';
+    // Production probes join()-built paths (backslashes on Windows); fixture maps are keyed
+    // POSIX. Normalize at the lookup boundary or every keyed probe silently misses on Windows.
+    const posixPath = filePath.split('\\').join('/');
 
     if (execArgs.includes('stream=codec_name,bit_rate,sample_rate,channels')) {
       const positional = cb as (err: Error | null, stdout: string, stderr: string) => void;
-      const fixture = streamInfoByFile[filePath];
+      const fixture = streamInfoByFile[posixPath];
       positional(null, JSON.stringify({ streams: fixture ? [fixture] : [] }), '');
       return {} as never;
     }
@@ -186,7 +197,7 @@ function installExecFileDispatcher(opts: {
     const objectCb = cb as (err: Error | null, result: { stdout: string; stderr: string }) => void;
     if (execArgs.includes('stream=codec_type')) {
       const lines = ['audio'];
-      for (let i = 0; i < (opts.videoStreams?.[filePath] ?? 0); i++) lines.push('video');
+      for (let i = 0; i < (videoStreams[posixPath] ?? 0); i++) lines.push('video');
       objectCb(null, { stdout: `${lines.join('\n')}\n`, stderr: '' });
     } else if (execArgs.includes('format=duration')) {
       objectCb(null, { stdout: `${opts.durations?.[durationIdx++] ?? 120}\n`, stderr: '' });
@@ -2277,7 +2288,9 @@ describe('#2068 stream-copy path (AC1–AC4)', () => {
       '-i', join('/lib/book', '_metadata.txt'),
       // #2078: the first source is opened as an extra input purely so its global tags can be
       // mapped forward. `-map 0:a` keeps the concat input the only audio source.
-      '-i', join('/lib/book', '01.m4b'),
+      // The donor input is audioFiles[0] passed VERBATIM (a POSIX fixture literal), not a
+      // join()-built path — asserting join() here fails on Windows.
+      '-i', '/lib/book/01.m4b',
       '-map', '0:a',
       '-map_metadata', '2',
       '-map_chapters', '1',
@@ -2327,7 +2340,8 @@ describe('#2068 stream-copy path (AC1–AC4)', () => {
     // the global tags forward. `-map_metadata` is now present on this path — pointed at the
     // SOURCE, never at a chapter file (there isn't one here).
     expect(args[args.indexOf('-map_metadata') + 1]).toBe('1');
-    expect(args[args.indexOf('-i', args.indexOf('-i') + 1) + 1]).toBe(join('/lib/book', '01.mp3'));
+    // Verbatim donor path (POSIX fixture literal), never join()-built — see the m4b twin above.
+    expect(args[args.indexOf('-i', args.indexOf('-i') + 1) + 1]).toBe('/lib/book/01.mp3');
     expect(args[args.length - 1]).toBe(MERGED_MP3);
   });
 

--- a/src/core/utils/audio-processor.test.ts
+++ b/src/core/utils/audio-processor.test.ts
@@ -2275,7 +2275,11 @@ describe('#2068 stream-copy path (AC1–AC4)', () => {
       '-safe', '0',
       '-i', join('/lib/book', '_concat.txt'),
       '-i', join('/lib/book', '_metadata.txt'),
-      '-map_metadata', '1',
+      // #2078: the first source is opened as an extra input purely so its global tags can be
+      // mapped forward. `-map 0:a` keeps the concat input the only audio source.
+      '-i', join('/lib/book', '01.m4b'),
+      '-map', '0:a',
+      '-map_metadata', '2',
       '-map_chapters', '1',
       '-c:a', 'copy',
       '-vn',
@@ -2304,7 +2308,7 @@ describe('#2068 stream-copy path (AC1–AC4)', () => {
     expect(encodeSpawnArgs()).toContain('copy');
   });
 
-  it('copies an eligible .mp3 set into mp3, with no metadata input and no -map_chapters', async () => {
+  it('copies an eligible .mp3 set into mp3, with no chapter input and no -map_chapters', async () => {
     const paths = setupMergeSet(['01.mp3', '02.mp3']);
     setStreamInfo(streamInfoFor(paths, {
       codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
@@ -2319,7 +2323,11 @@ describe('#2068 stream-copy path (AC1–AC4)', () => {
     const args = encodeSpawnArgs();
     expect(args[args.indexOf('-c:a') + 1]).toBe('copy');
     expect(args).not.toContain('-map_chapters');
-    expect(args).not.toContain('-map_metadata');
+    // #2078: mp3 has no generated-chapter input, so the first source is input 1 and carries
+    // the global tags forward. `-map_metadata` is now present on this path — pointed at the
+    // SOURCE, never at a chapter file (there isn't one here).
+    expect(args[args.indexOf('-map_metadata') + 1]).toBe('1');
+    expect(args[args.indexOf('-i', args.indexOf('-i') + 1) + 1]).toBe(join('/lib/book', '01.mp3'));
     expect(args[args.length - 1]).toBe(MERGED_MP3);
   });
 
@@ -2334,7 +2342,9 @@ describe('#2068 stream-copy path (AC1–AC4)', () => {
 
     const args = encodeSpawnArgs();
     expect(args[args.indexOf('-i', args.indexOf('-i') + 1) + 1]).toBe(join('/lib/book', '_metadata.txt'));
-    expect(args[args.indexOf('-map_metadata') + 1]).toBe('1');
+    // #2078 moved global metadata onto the first source (input 2); chapters stay on the
+    // generated ffmetadata input (1), which is the #2068 guarantee.
+    expect(args[args.indexOf('-map_metadata') + 1]).toBe('2');
     expect(args[args.indexOf('-map_chapters') + 1]).toBe('1');
     expect(args[args.indexOf('-c:a') + 1]).toBe('aac');
     expect(args).toContain('-b:a');
@@ -2664,5 +2674,155 @@ describe('#2068 the caller delivers the resolver notices verbatim (AC14)', () =>
     expect(result.success).toBe(true);
     expect(result.warnings).toEqual(stubbed);
     expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('96k');
+  });
+});
+
+// ============================================================================
+// #2078 — merge carries the source parts' global tags into the output
+// ============================================================================
+
+/** The ordered `-i` operands of a spawn argv — ffmpeg input N is `inputPaths(args)[N]`. */
+function inputPaths(args: string[]): string[] {
+  const paths: string[] = [];
+  for (let i = 0; i < args.length - 1; i++) {
+    if (args[i] === '-i') paths.push(args[i + 1]!);
+  }
+  return paths;
+}
+
+/**
+ * Resolve a `-map_metadata` / `-map_chapters` operand back to the FILE it points at.
+ *
+ * The index is computed by production, so asserting the literal digit would pin a
+ * position rather than the mapping. Reading the operand back through the input list
+ * asserts the property the AC is actually about: which file the flag resolves to.
+ */
+function mappedInput(args: string[], flag: '-map_metadata' | '-map_chapters'): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  return inputPaths(args)[Number(args[idx + 1])];
+}
+
+describe('#2078 merge preserves the source files\' global tags (AC1–AC4)', () => {
+  const CONCAT = join('/lib/book', '_concat.txt');
+  const FFMETADATA = join('/lib/book', '_metadata.txt');
+
+  it('m4b: opens the first source as an extra input and maps global metadata from it', async () => {
+    const paths = setupMergeSet(['01.m4b', '02.m4b', '03.m4b']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'aac', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(inputPaths(args)).toEqual([CONCAT, FFMETADATA, paths[0]]);
+    expect(mappedInput(args, '-map_metadata')).toBe(paths[0]);
+  });
+
+  it('m4b: -map_metadata never resolves to the generated chapter ffmetadata file', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    // The pre-#2078 defect exactly: input 1 is the generated FFMETADATA1 file, which carries
+    // only [CHAPTER] blocks, so mapping global metadata from it wrote an EMPTY tag set.
+    expect(mappedInput(encodeSpawnArgs(), '-map_metadata')).not.toBe(FFMETADATA);
+  });
+
+  it('m4b: -map_chapters still resolves to the generated ffmetadata input (#2068, AC3)', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(mappedInput(args, '-map_chapters')).toBe(FFMETADATA);
+    expect(args).toContain('-b:a'); // encode mode, not copy
+  });
+
+  it('m4b: -map_chapters resolves to the generated ffmetadata input in copy mode too (AC3)', async () => {
+    const paths = setupMergeSet(['01.m4b', '02.m4b']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'aac', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(mappedInput(args, '-map_chapters')).toBe(FFMETADATA);
+    expect(args[args.indexOf('-c:a') + 1]).toBe('copy');
+  });
+
+  it('mp3: opens the first source as input 1 and maps metadata from it, still no -map_chapters', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3' }, defaultContext,
+    );
+
+    const args = encodeSpawnArgs();
+    expect(inputPaths(args)).toEqual([CONCAT, paths[0]]);
+    expect(mappedInput(args, '-map_metadata')).toBe(paths[0]);
+    expect(args).not.toContain('-map_chapters');
+  });
+
+  it('emits an explicit -map 0:a so the concat input is the only audio source (AC2)', async () => {
+    const paths = setupMergeSet(['01.m4b', '02.m4b']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'aac', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    // Two audio-bearing inputs are now open (concat + the first source). Without an explicit
+    // map, ffmpeg picks the "best" audio stream across ALL inputs, which can silently emit the
+    // first part alone. Assert the operand resolves to the concat input, not its position.
+    const args = encodeSpawnArgs();
+    const mapIdx = args.indexOf('-map');
+    expect(mapIdx).toBeGreaterThan(-1);
+    const [inputIndex, specifier] = args[mapIdx + 1]!.split(':');
+    expect(inputPaths(args)[Number(inputIndex)]).toBe(CONCAT);
+    expect(specifier).toBe('a');
+  });
+
+  it('a copy-eligible set still copies, with no -b:a, despite the extra input (AC4)', async () => {
+    const paths = setupMergeSet(['01.m4b', '02.m4b', '03.m4b']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'aac', bit_rate: '251000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-c:a') + 1]).toBe('copy');
+    expect(args).not.toContain('-b:a');
+    expect(args).not.toContain('aac');
+  });
+
+  it('convert emits no -map_metadata override — ffmpeg\'s default already keeps them (AC18a)', async () => {
+    setupConvertFile();
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', defaultConfig, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(inputPaths(args)).toEqual([join('/lib/book', 'book.mp3')]);
+    expect(args).not.toContain('-map_metadata');
   });
 });

--- a/src/core/utils/audio-processor.test.ts
+++ b/src/core/utils/audio-processor.test.ts
@@ -32,6 +32,16 @@ vi.mock('./chapter-resolver.js', () => ({
   resolveChapterTitle: vi.fn(),
 }));
 
+// Passthrough spy on the encode-strategy seam — real behavior by default, so only the test
+// that pins "the caller does not re-derive resolver predicates" overrides it.
+vi.mock('./encode-strategy.js', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveCodecArgs: vi.fn().mockImplementation(actual.resolveCodecArgs as (...args: unknown[]) => unknown),
+  };
+});
+
 // Spy on naming.js — passthrough to real implementation
 vi.mock('./naming.js', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>;
@@ -45,6 +55,12 @@ import { execFile, spawn } from 'node:child_process';
 import { readdir, rename, unlink, writeFile, rm, stat } from 'node:fs/promises';
 import { readChapterSources, resolveChapterTitle } from './chapter-resolver.js';
 import { renderFilename } from './naming.js';
+import { resolveCodecArgs } from './encode-strategy.js';
+
+// The real implementation, re-installed on the spy in beforeEach. `vi.clearAllMocks()` clears
+// call history but neither drains `*Once()` queues nor restores implementations, so an
+// override in one test would otherwise leak into every test after it.
+const actualEncodeStrategy = await vi.importActual<typeof import('./encode-strategy.js')>('./encode-strategy.js');
 
 // execFile is callback-based; mock the promisified version (used by probeFfmpeg, detectFfmpegPath, getFileDurations)
 const mockExecFile = vi.mocked(execFile);
@@ -117,8 +133,91 @@ const defaultContext: ProcessingContext = {
   title: 'The Way of Kings',
 };
 
+/** An ffprobe `stream=codec_name,bit_rate,sample_rate,channels` payload for one source file. */
+interface StreamInfoFixture {
+  codec_name?: string;
+  /** bps, as ffprobe reports it — the collector is what floors it to kbps. */
+  bit_rate?: string;
+  sample_rate?: string;
+  channels?: number;
+}
+
+/**
+ * Per-file stream-info fixtures for the encode-strategy probe collector, keyed by file path.
+ * A missing entry (or an explicit null) makes that file's probe return null, which is what an
+ * unreadable stream looks like to the resolver. Reset in beforeEach — never queued with
+ * `mockResolvedValueOnce`, since `vi.clearAllMocks()` does not drain `*Once()` queues.
+ */
+let streamInfoByFile: Record<string, StreamInfoFixture | null> = {};
+
+function setStreamInfo(map: Record<string, StreamInfoFixture | null>): void {
+  streamInfoByFile = map;
+}
+
+/**
+ * Install an execFile mock that dispatches on argv AND returns the callback shape each caller
+ * expects.
+ *
+ * Two shapes, not one: the duration and cover-detection callers go through
+ * `promisify(execFile)` and receive a single `{ stdout, stderr }` object, while
+ * `getFFprobeStreamInfo` calls raw `execFile` and receives `(error, stdout, stderr)`
+ * positionally. A dispatcher preserving only one shape either breaks the duration tests or
+ * silently makes every stream probe null — which would disable the copy path without failing
+ * anything. `asserts a parsed stream probe` below pins that it does not happen.
+ */
+function installExecFileDispatcher(opts: {
+  durations?: number[];
+  videoStreams?: Record<string, number>;
+} = {}): void {
+  let durationIdx = 0;
+  mockExecFile.mockImplementation((...args: unknown[]) => {
+    const cb = args[args.length - 1];
+    if (typeof cb !== 'function') return {} as never;
+    const execArgs = (args[1] as string[] | undefined) ?? [];
+    const filePath = execArgs[execArgs.length - 1] ?? '';
+
+    if (execArgs.includes('stream=codec_name,bit_rate,sample_rate,channels')) {
+      const positional = cb as (err: Error | null, stdout: string, stderr: string) => void;
+      const fixture = streamInfoByFile[filePath];
+      positional(null, JSON.stringify({ streams: fixture ? [fixture] : [] }), '');
+      return {} as never;
+    }
+
+    const objectCb = cb as (err: Error | null, result: { stdout: string; stderr: string }) => void;
+    if (execArgs.includes('stream=codec_type')) {
+      const lines = ['audio'];
+      for (let i = 0; i < (opts.videoStreams?.[filePath] ?? 0); i++) lines.push('video');
+      objectCb(null, { stdout: `${lines.join('\n')}\n`, stderr: '' });
+    } else if (execArgs.includes('format=duration')) {
+      objectCb(null, { stdout: `${opts.durations?.[durationIdx++] ?? 120}\n`, stderr: '' });
+    } else {
+      objectCb(null, { stdout: 'audio\n', stderr: '' });
+    }
+    return {} as never;
+  });
+}
+
+/** The argv the encode-strategy collector probes each source file with. */
+function streamProbeCalls(): unknown[][] {
+  return mockExecFile.mock.calls.filter(
+    (call) => (call[1] as string[] | undefined)?.includes('stream=codec_name,bit_rate,sample_rate,channels') ?? false,
+  );
+}
+
+/** The ffmpeg encode spawn — selected by argv, since cover art adds extract/reattach spawns. */
+function encodeSpawnArgs(index = 0): string[] {
+  const encodes = mockSpawn.mock.calls
+    .map((call) => call[1] as string[])
+    .filter((args) => args.includes('-c:a'));
+  const found = encodes[index];
+  if (!found) throw new Error(`no encode spawn at index ${index} (saw ${encodes.length})`);
+  return found;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(resolveCodecArgs).mockImplementation(actualEncodeStrategy.resolveCodecArgs);
+  streamInfoByFile = {};
   mockUnlink.mockResolvedValue(undefined);
   mockRename.mockResolvedValue(undefined);
   mockWriteFile.mockResolvedValue(undefined);
@@ -365,15 +464,7 @@ function setupMergeFiles(durations: number[] = [300, 300, 300]) {
   mockReadChapterSources.mockResolvedValue(sources);
   mockResolveChapterTitle.mockImplementation((_s, i) => `Chapter ${i + 1}`);
 
-  // ffprobe calls for durations (still use execFile)
-  let callIdx = 0;
-  mockExecFile.mockImplementation((...args: unknown[]) => {
-    const cb = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
-    if (typeof cb === 'function') {
-      cb(null, { stdout: `${durations[callIdx++] ?? 0}\n`, stderr: '' });
-    }
-    return {} as never;
-  });
+  installExecFileDispatcher({ durations });
 }
 
 /**
@@ -385,13 +476,7 @@ function setupMergeFiles(durations: number[] = [300, 300, 300]) {
  * this, or they stay order-coupled on whatever execFile impl leaked through clearAllMocks.
  */
 function seedNoCoverFfprobe() {
-  mockExecFile.mockImplementation((...args: unknown[]) => {
-    const cb = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
-    if (typeof cb === 'function') {
-      cb(null, { stdout: 'audio\n', stderr: '' });
-    }
-    return {} as never;
-  });
+  installExecFileDispatcher();
 }
 
 /** Setup helpers for convert path tests. */
@@ -409,15 +494,54 @@ function setupConvertFile() {
 }
 
 describe('processAudioFiles', () => {
-  it('skips processing for single m4b input', async () => {
+  it('skips processing for single m4b input under keep-original', async () => {
     mockReaddir.mockResolvedValue([
       { name: 'book.m4b', isFile: () => true, isDirectory: () => false },
     ] as never);
 
-    const result = await processAudioFiles('/lib/book', defaultConfig, defaultContext);
+    // Omits `bitrate` deliberately: the early return is the zero-work copy path, so it applies
+    // only when no usable target is configured. Passing 128 here would pin the behavior AC13
+    // removes.
+    const { bitrate: _bitrate, ...keepOriginal } = defaultConfig;
+    const result = await processAudioFiles('/lib/book', keepOriginal, defaultContext);
     expect(result).toEqual({ success: true, outputFiles: [join('/lib/book', 'book.m4b')] });
     expect(mockExecFile).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('takes the same no-op path for an unusable bitrate, surfacing the notice', async () => {
+    mockReaddir.mockResolvedValue([
+      { name: 'book.m4b', isFile: () => true, isDirectory: () => false },
+    ] as never);
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...defaultConfig, bitrate: Number.NaN }, defaultContext,
+    );
+    expect(result.success).toBe(true);
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings![0]).toContain('NaN');
+  });
+
+  it('re-encodes a single m4b to an explicit target instead of short-circuiting', async () => {
+    mockReaddir.mockResolvedValue([
+      { name: 'book.m4b', isFile: () => true, isDirectory: () => false },
+    ] as never);
+    mockReadChapterSources.mockResolvedValue([
+      { filePath: join('/lib/book', 'book.m4b'), title: 'Ch 1', trackNumber: 1 },
+    ]);
+    seedNoCoverFfprobe();
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...defaultConfig, bitrate: 64 }, defaultContext,
+    );
+    expect(result.success).toBe(true);
+    const args = encodeSpawnArgs();
+    expect(args).toContain('-c:a');
+    expect(args[args.indexOf('-c:a') + 1]).toBe('aac');
+    expect(args[args.indexOf('-b:a') + 1]).toBe('64k');
   });
 
   it('re-encodes single m4b input to mp3 when outputFormat is mp3 (does not short-circuit)', async () => {
@@ -551,19 +675,39 @@ describe('processAudioFiles', () => {
     expect(mockRename).not.toHaveBeenCalled();
   });
 
-  it('omits -b:a flag when bitrate is undefined (keep original)', async () => {
+  it('stream-copies an eligible source under keep-original (convert path)', async () => {
     setupConvertFile();
+    setStreamInfo({
+      '/lib/book/book.mp3': { codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2 },
+    });
     mockSpawnSuccess();
 
     const { bitrate: _bitrate, ...configWithoutBitrate } = defaultConfig;
-    const config: ProcessingConfig = configWithoutBitrate;
+    const config: ProcessingConfig = { ...configWithoutBitrate, outputFormat: 'mp3' };
     const result = await processAudioFiles('/lib/book', config, defaultContext);
     expect(result.success).toBe(true);
 
-    // spawn should be called — check args
-    const spawnArgs = mockSpawn.mock.calls[0]![1] as string[];
+    const spawnArgs = encodeSpawnArgs();
+    expect(spawnArgs[spawnArgs.indexOf('-c:a') + 1]).toBe('copy');
     expect(spawnArgs).not.toContain('-b:a');
-    expect(spawnArgs).toContain('-c:a');
+    expect(spawnArgs).not.toContain('libmp3lame');
+  });
+
+  it('encodes with an explicit -b:a under keep-original when the source is ineligible', async () => {
+    setupConvertFile();
+    setStreamInfo({
+      '/lib/book/book.mp3': { codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2 },
+    });
+    mockSpawnSuccess();
+
+    // outputFormat m4b against an mp3 source — a genuine transcode, so `-b:a` is mandatory.
+    const { bitrate: _bitrate, ...configWithoutBitrate } = defaultConfig;
+    const result = await processAudioFiles('/lib/book', configWithoutBitrate, defaultContext);
+    expect(result.success).toBe(true);
+
+    const spawnArgs = encodeSpawnArgs();
+    expect(spawnArgs[spawnArgs.indexOf('-c:a') + 1]).toBe('aac');
+    expect(spawnArgs[spawnArgs.indexOf('-b:a') + 1]).toBe('128k');
   });
 
   it('returns error result on non-zero ffmpeg exit', async () => {
@@ -910,13 +1054,23 @@ describe('bitrate capping — sourceBitrateKbps', () => {
     expect(spawnArgs[bitrateIdx + 1]).toBe('128k');
   });
 
-  it('omits -b:a flag when config.bitrate is undefined regardless of sourceBitrateKbps', async () => {
+  it('still emits an explicit -b:a when config.bitrate is undefined (keep original, ineligible)', async () => {
     const { bitrate: _bitrate, ...configWithoutBitrate } = defaultConfig;
     const config: ProcessingConfig = { ...configWithoutBitrate, sourceBitrateKbps: 64 };
     await processAudioFiles('/lib/book', config, defaultContext);
 
-    const spawnArgs = mockSpawn.mock.calls[0]![1] as string[];
-    expect(spawnArgs).not.toContain('-b:a');
+    const spawnArgs = encodeSpawnArgs();
+    expect(spawnArgs[spawnArgs.indexOf('-c:a') + 1]).toBe('aac');
+    expect(spawnArgs[spawnArgs.indexOf('-b:a') + 1]).toBe('64k');
+  });
+
+  it('never emits -b:a 0k for a zero sourceBitrateKbps', async () => {
+    const config: ProcessingConfig = { ...defaultConfig, bitrate: 128, sourceBitrateKbps: 0 };
+    await processAudioFiles('/lib/book', config, defaultContext);
+
+    const spawnArgs = encodeSpawnArgs();
+    expect(spawnArgs).not.toContain('0k');
+    expect(spawnArgs[spawnArgs.indexOf('-b:a') + 1]).toBe('128k');
   });
 });
 
@@ -1323,27 +1477,7 @@ describe('#424 spawnFfmpeg — stall timeout', () => {
  * For each file path, returns ffprobe output with the specified number of video streams.
  */
 function mockExecFileWithStreams(fileStreamMap: Record<string, number>) {
-  mockExecFile.mockImplementation((...args: unknown[]) => {
-    const cb = args[args.length - 1] as (err: Error | null, result: { stdout: string; stderr: string }) => void;
-    if (typeof cb !== 'function') return {} as never;
-
-    const execArgs = args[1] as string[];
-    // Detect if this is a stream-detection ffprobe call (has -show_entries stream=codec_type)
-    if (execArgs?.includes('stream=codec_type')) {
-      const filePath = execArgs[execArgs.length - 1]!;
-      const videoCount = fileStreamMap[filePath] ?? 0;
-      const lines = ['audio'];
-      for (let i = 0; i < videoCount; i++) lines.push('video');
-      cb(null, { stdout: lines.join('\n') + '\n', stderr: '' });
-    } else if (execArgs?.includes('format=duration')) {
-      // Duration probe
-      cb(null, { stdout: '120\n', stderr: '' });
-    } else {
-      // Default (version probe etc.)
-      cb(null, { stdout: 'ffmpeg version 6.1.1\n', stderr: '' });
-    }
-    return {} as never;
-  });
+  installExecFileDispatcher({ videoStreams: fileStreamMap });
 }
 
 describe('#424 cover art detection and extraction', () => {
@@ -2091,5 +2225,444 @@ describe('processAudioFiles — fileFormat token threading (#1720)', () => {
       if (!result.success) return;
       expect(result.outputFiles).toEqual([join('/lib/book', 'Tolkien - The Hobbit.m4b')]);
     });
+  });
+});
+
+// ============================================================================
+// #2068 — keepOriginalBitrate: stream copy, and an explicit -b:a on every encode
+// ============================================================================
+
+/** Merge-path setup with explicit file names, so extension-sensitive cases are constructible. */
+function setupMergeSet(names: string[], durations?: number[]): string[] {
+  mockReaddir.mockResolvedValue(
+    names.map((name) => ({ name, isFile: () => true, isDirectory: () => false })) as never,
+  );
+  const sources = names.map((name, i) => ({
+    filePath: `/lib/book/${name}`, title: `Ch ${i + 1}`, trackNumber: i + 1,
+  }));
+  mockReadChapterSources.mockResolvedValue(sources);
+  mockResolveChapterTitle.mockImplementation((_s, i) => `Chapter ${i + 1}`);
+  installExecFileDispatcher({ durations: durations ?? names.map(() => 120) });
+  return sources.map((s) => s.filePath);
+}
+
+function streamInfoFor(paths: string[], fixture: StreamInfoFixture): Record<string, StreamInfoFixture> {
+  return Object.fromEntries(paths.map((p) => [p, fixture]));
+}
+
+const MERGE_ALWAYS = { ...defaultConfig, mergeBehavior: 'always' as const };
+const KEEP_ORIGINAL = (() => {
+  const { bitrate: _bitrate, ...rest } = MERGE_ALWAYS;
+  return rest;
+})();
+const MERGED_M4B = join('/lib/book', 'Brandon Sanderson - The Way of Kings.m4b');
+const MERGED_MP3 = join('/lib/book', 'Brandon Sanderson - The Way of Kings.mp3');
+
+describe('#2068 stream-copy path (AC1–AC4)', () => {
+  it('copies an eligible AAC/m4b set, preserving every other arg in position', async () => {
+    const paths = setupMergeSet(['01.m4b', '02.m4b', '03.m4b']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'aac', bit_rate: '251000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+    expect(result.success).toBe(true);
+
+    expect(encodeSpawnArgs()).toEqual([
+      '-y',
+      '-f', 'concat',
+      '-safe', '0',
+      '-i', join('/lib/book', '_concat.txt'),
+      '-i', join('/lib/book', '_metadata.txt'),
+      '-map_metadata', '1',
+      '-map_chapters', '1',
+      '-c:a', 'copy',
+      '-vn',
+      '-max_muxing_queue_size', '4096',
+      '-f', 'mp4',
+      '-progress', 'pipe:1',
+      MERGED_M4B,
+    ]);
+    expect(encodeSpawnArgs()).not.toContain('-b:a');
+    expect(encodeSpawnArgs()).not.toContain('aac');
+    expect(encodeSpawnArgs()).not.toContain('libmp3lame');
+  });
+
+  it('parses the stream probe into non-null technical fields (mock-shape regression)', async () => {
+    const paths = setupMergeSet(['01.m4b', '02.m4b']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'aac', bit_rate: '251000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    // A dispatcher returning the wrong callback shape makes every probe null, which silently
+    // disables the copy path — the copy decision below is only reachable from parsed fields.
+    expect(streamProbeCalls()).toHaveLength(2);
+    expect(encodeSpawnArgs()).toContain('copy');
+  });
+
+  it('copies an eligible .mp3 set into mp3, with no metadata input and no -map_chapters', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3' }, defaultContext,
+    );
+    expect(result.success).toBe(true);
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-c:a') + 1]).toBe('copy');
+    expect(args).not.toContain('-map_chapters');
+    expect(args).not.toContain('-map_metadata');
+    expect(args[args.length - 1]).toBe(MERGED_MP3);
+  });
+
+  it('emits -map_chapters 1 in encode mode on the m4b path too (AC3)', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-i', args.indexOf('-i') + 1) + 1]).toBe(join('/lib/book', '_metadata.txt'));
+    expect(args[args.indexOf('-map_metadata') + 1]).toBe('1');
+    expect(args[args.indexOf('-map_chapters') + 1]).toBe('1');
+    expect(args[args.indexOf('-c:a') + 1]).toBe('aac');
+    expect(args).toContain('-b:a');
+  });
+});
+
+describe('#2068 explicit -b:a on every encode (AC5–AC11)', () => {
+  it('re-encodes an all-MP3 set to m4b at the probed maximum', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo({
+      [paths[0]!]: { codec_name: 'mp3', bit_rate: '251000', sample_rate: '44100', channels: 2 },
+      [paths[1]!]: { codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2 },
+    });
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-c:a') + 1]).toBe('aac');
+    expect(args[args.indexOf('-b:a') + 1]).toBe('251k');
+  });
+
+  it('falls back to 192k for m4b with no usable probe or hint, reporting it once', async () => {
+    setupMergeSet(['01.mp3', '02.mp3']);
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('192k');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings![0]).toContain('192');
+  });
+
+  it('reports both the fallback and its MP3 legalization for unknown rates', async () => {
+    setupMergeSet(['01.mp3', '02.mp3']);
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3' }, defaultContext,
+    );
+
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('160k');
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings![0]).toContain('192');
+    expect(result.warnings![1]).toMatch(/192.*160/);
+  });
+
+  it('legalizes a 1411 kbps 44.1 kHz PCM set to 320k for mp3, and shapes nothing', async () => {
+    const paths = setupMergeSet(['01.wav', '02.wav']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'pcm_s16le', bit_rate: '1411000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3' }, defaultContext,
+    );
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-c:a') + 1]).toBe('libmp3lame');
+    expect(args[args.indexOf('-b:a') + 1]).toBe('320k');
+    expect(args).not.toContain('-ar');
+    expect(result.warnings!.some((w) => w.includes('1411') && w.includes('320'))).toBe(true);
+  });
+
+  it('caps a 22.05 kHz set at the MPEG-2 table maximum, never 320k', async () => {
+    const paths = setupMergeSet(['01.wav', '02.wav']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'pcm_s16le', bit_rate: '705000', sample_rate: '22050', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3' }, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-b:a') + 1]).toBe('160k');
+    expect(args).not.toContain('320k');
+    expect(args).not.toContain('-ar');
+  });
+
+  it('uses the rate-agnostic table when a probed sample rate is absent, without resampling', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, { codec_name: 'mp3', bit_rate: '256000', channels: 2 }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3' }, defaultContext);
+
+    const args = encodeSpawnArgs();
+    expect(args[args.indexOf('-b:a') + 1]).toBe('160k');
+    expect(args).not.toContain('-ar');
+  });
+
+  it.each(['m4b', 'mp3'] as const)(
+    'emits neither -ar nor -ac for an 11024 Hz 6-channel source (%s output)',
+    async (outputFormat) => {
+      const paths = setupMergeSet(['01.wav', '02.wav']);
+      setStreamInfo(streamInfoFor(paths, {
+        codec_name: 'pcm_s16le', bit_rate: '128000', sample_rate: '11024', channels: 6,
+      }));
+      mockSpawnSuccess();
+
+      await processAudioFiles('/lib/book', { ...KEEP_ORIGINAL, outputFormat }, defaultContext);
+
+      const args = encodeSpawnArgs();
+      expect(args).not.toContain('-ar');
+      expect(args).not.toContain('-ac');
+      expect(args).toContain('-b:a');
+    },
+  );
+
+  it.each([
+    ['44100', '320k'],
+    ['22050', '160k'],
+  ])('legalizes an explicit 512 kbps mp3 target at %s Hz to %s', async (sampleRate, expected) => {
+    const paths = setupMergeSet(['01.wav', '02.wav']);
+    setStreamInfo(streamInfoFor(paths, { codec_name: 'pcm_s16le', sample_rate: sampleRate, channels: 2 }));
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...MERGE_ALWAYS, outputFormat: 'mp3', bitrate: 512 }, defaultContext,
+    );
+
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe(expected);
+    expect(result.warnings!.some((w) => w.includes('512'))).toBe(true);
+  });
+
+  it('tells the operator when their explicit 200 kbps became 192 kbps', async () => {
+    const paths = setupMergeSet(['01.wav', '02.wav']);
+    setStreamInfo(streamInfoFor(paths, { codec_name: 'pcm_s16le', sample_rate: '44100', channels: 2 }));
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...MERGE_ALWAYS, outputFormat: 'mp3', bitrate: 200 }, defaultContext,
+    );
+
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('192k');
+    expect(result.warnings!.some((w) => w.includes('200') && w.includes('192'))).toBe(true);
+  });
+
+  it('records one evidence-cap notice when the source caps the operator target', async () => {
+    setupMergeSet(['01.mp3', '02.mp3']);
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...MERGE_ALWAYS, bitrate: 128, sourceBitrateKbps: 64 }, defaultContext,
+    );
+
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('64k');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings![0]).toMatch(/128.*64/);
+  });
+
+  it('records nothing when min() returns the operator target unchanged', async () => {
+    setupMergeSet(['01.mp3', '02.mp3']);
+    mockSpawnSuccess();
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...MERGE_ALWAYS, bitrate: 128, sourceBitrateKbps: 251 }, defaultContext,
+    );
+
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('128k');
+    expect(result.warnings).toBeUndefined();
+  });
+});
+
+describe('#2068 per-command resolution and probe cost (AC12)', () => {
+  it('resolves a strategy and a bitrate per file on a multi-file convert', async () => {
+    const paths = setupMergeSet(['a.m4a', 'b.mp3']);
+    setStreamInfo({
+      [paths[0]!]: { codec_name: 'aac', bit_rate: '64000', sample_rate: '44100', channels: 2 },
+      [paths[1]!]: { codec_name: 'mp3', bit_rate: '251000', sample_rate: '44100', channels: 2 },
+    });
+    mockSpawn.mockImplementation(() => {
+      const child = new MockChildProcess();
+      process.nextTick(() => child.emit('close', 0));
+      return child as never;
+    });
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, mergeBehavior: 'never' }, defaultContext,
+    );
+    expect(result.success).toBe(true);
+
+    // a.m4a is copy-eligible into m4b on its own; b.mp3 is not, and carries its own 251 kbps.
+    const first = encodeSpawnArgs(0);
+    const second = encodeSpawnArgs(1);
+    expect(first[first.indexOf('-c:a') + 1]).toBe('copy');
+    expect(first).not.toContain('-b:a');
+    expect(second[second.indexOf('-c:a') + 1]).toBe('aac');
+    expect(second[second.indexOf('-b:a') + 1]).toBe('251k');
+  });
+
+  it('probes each source exactly once on the keep-original merge path', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3', '03.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', KEEP_ORIGINAL, defaultContext);
+
+    const probed = streamProbeCalls().map((call) => (call[1] as string[]).at(-1));
+    expect(probed).toHaveLength(3);
+    expect(new Set(probed).size).toBe(3);
+  });
+
+  it('probes on the explicit-target path too — AC8 needs the source sample rates', async () => {
+    const paths = setupMergeSet(['01.mp3', '02.mp3']);
+    setStreamInfo(streamInfoFor(paths, {
+      codec_name: 'mp3', bit_rate: '128000', sample_rate: '44100', channels: 2,
+    }));
+    mockSpawnSuccess();
+
+    await processAudioFiles('/lib/book', { ...MERGE_ALWAYS, bitrate: 320 }, defaultContext);
+
+    expect(streamProbeCalls()).toHaveLength(2);
+  });
+
+  it('accumulates notices in command order across a multi-file convert', async () => {
+    const paths = setupMergeSet(['x.m4a', 'y.m4a']);
+    setStreamInfo({
+      [paths[0]!]: { codec_name: 'aac', bit_rate: '200000', sample_rate: '44100', channels: 2 },
+      [paths[1]!]: { codec_name: 'aac', bit_rate: '700000', sample_rate: '44100', channels: 2 },
+    });
+    mockSpawn.mockImplementation(() => {
+      const child = new MockChildProcess();
+      process.nextTick(() => child.emit('close', 0));
+      return child as never;
+    });
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3', mergeBehavior: 'never' }, defaultContext,
+    );
+    expect(result.success).toBe(true);
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings![0]).toMatch(/200.*192/);
+    expect(result.warnings![1]).toMatch(/700.*320/);
+  });
+
+  it('keeps earlier notices when a later convert command fails', async () => {
+    const paths = setupMergeSet(['x.m4a', 'y.m4a']);
+    setStreamInfo({
+      [paths[0]!]: { codec_name: 'aac', bit_rate: '200000', sample_rate: '44100', channels: 2 },
+      [paths[1]!]: { codec_name: 'aac', bit_rate: '700000', sample_rate: '44100', channels: 2 },
+    });
+    let spawnCount = 0;
+    mockSpawn.mockImplementation(() => {
+      spawnCount++;
+      const child = new MockChildProcess();
+      const code = spawnCount === 2 ? 1 : 0;
+      process.nextTick(() => child.emit('close', code));
+      return child as never;
+    });
+
+    const result = await processAudioFiles(
+      '/lib/book', { ...KEEP_ORIGINAL, outputFormat: 'mp3', mergeBehavior: 'never' }, defaultContext,
+    );
+    expect(result.success).toBe(false);
+    expect(result.warnings).toBeDefined();
+    expect(result.warnings!.some((w) => /200.*192/.test(w))).toBe(true);
+    expect(result.warnings!.some((w) => /700.*320/.test(w))).toBe(true);
+  });
+});
+
+describe('#2068 invariant — an encoder token never appears without -b:a (AC5)', () => {
+  const CONFIGS: Array<Partial<ProcessingConfig>> = [
+    {},
+    { bitrate: 128 },
+    { bitrate: 320, sourceBitrateKbps: 64 },
+    { bitrate: Number.NaN },
+    { bitrate: 0 },
+    { bitrate: -1 },
+    { bitrate: 7 },
+    { bitrate: 128.5 },
+    { sourceBitrateKbps: 0 },
+    { sourceBitrateKbps: 827 / 1000 },
+    { sourceBitrateKbps: 1411 },
+  ];
+  const PROBES: Array<StreamInfoFixture | null> = [
+    null,
+    { codec_name: 'aac', bit_rate: '251000', sample_rate: '44100', channels: 2 },
+    { codec_name: 'mp3', bit_rate: '64000', sample_rate: '22050', channels: 1 },
+    { codec_name: 'mp3' },
+  ];
+
+  it.each(['m4b', 'mp3'] as const)('holds for every config shape (%s output)', async (outputFormat) => {
+    for (const overrides of CONFIGS) {
+      for (const probe of PROBES) {
+        vi.clearAllMocks();
+        const paths = setupMergeSet(['01.m4b', '02.m4b']);
+        setStreamInfo(probe ? streamInfoFor(paths, probe) : {});
+        mockSpawnSuccess();
+
+        const { bitrate: _drop, ...base } = MERGE_ALWAYS;
+        await processAudioFiles('/lib/book', { ...base, outputFormat, ...overrides }, defaultContext);
+
+        const args = encodeSpawnArgs();
+        const codec = args[args.indexOf('-c:a') + 1]!;
+        if (codec === 'copy') {
+          expect(args).not.toContain('-b:a');
+          continue;
+        }
+        expect(['aac', 'libmp3lame']).toContain(codec);
+        const value = args[args.indexOf('-b:a') + 1]!;
+        const parsed = Number.parseInt(value.replace(/k$/, ''), 10);
+        expect(value).toMatch(/^\d+k$/);
+        expect(Number.isFinite(parsed)).toBe(true);
+        expect(parsed).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('#2068 the caller delivers the resolver notices verbatim (AC14)', () => {
+  it('surfaces exactly the notices the resolver produced, re-deriving no predicate', async () => {
+    setupMergeSet(['01.mp3', '02.mp3']);
+    mockSpawnSuccess();
+
+    const stubbed = ['first stubbed notice', 'second stubbed notice'];
+    vi.mocked(resolveCodecArgs).mockImplementation(async (_config, _paths, warnings) => {
+      warnings.push(...stubbed);
+      return ['-c:a', 'aac', '-b:a', '96k'];
+    });
+
+    const result = await processAudioFiles('/lib/book', MERGE_ALWAYS, defaultContext);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toEqual(stubbed);
+    expect(encodeSpawnArgs()[encodeSpawnArgs().indexOf('-b:a') + 1]).toBe('96k');
   });
 });

--- a/src/core/utils/audio-processor.ts
+++ b/src/core/utils/audio-processor.ts
@@ -246,6 +246,18 @@ function spawnFfmpeg(
 }
 
 /**
+ * The ffmpeg input index of the most recently pushed `-i` operand.
+ *
+ * The merge command's input layout differs by output format (m4b opens a generated-chapter
+ * input that mp3 does not), so every `-map*` operand is DERIVED from the argv being built
+ * rather than written as a literal — a hardcoded index silently points at the wrong file the
+ * moment an input is added or removed.
+ */
+function lastInputIndex(args: string[]): number {
+  return args.filter((token) => token === '-i').length - 1;
+}
+
+/**
  * Merge multiple audio files into a single output file with chapter markers.
  */
 async function mergeFiles(
@@ -293,15 +305,34 @@ async function mergeFiles(
 
     // Build chapter metadata for m4b
     let metadataPath: string | undefined;
+    let chapterInput: number | undefined;
     if (outputExt === 'm4b') {
       metadataPath = join(targetDir, '_metadata.txt');
       const metadataContent = buildChapterMetadata(chapterSources, durations);
       await writeFile(metadataPath, metadataContent, 'utf-8');
-      // -map_chapters 1 pins the GENERATED chapters over whatever the concat demuxer
-      // propagates from the source parts: ffmpeg's default picks the input with the most
-      // chapters, so source m4b parts carrying internal chapters could otherwise outvote
-      // the generated set. Emitted in both copy and encode modes.
-      args.push('-i', metadataPath, '-map_metadata', '1', '-map_chapters', '1');
+      args.push('-i', metadataPath);
+      chapterInput = lastInputIndex(args);
+    }
+
+    // #2078: open the first source purely as a metadata donor. The generated FFMETADATA1 file
+    // carries ONLY [CHAPTER] blocks, so the pre-#2078 `-map_metadata 1` overrode ffmpeg's
+    // default with an EMPTY global tag set — every merged output came out metadata-naked. The
+    // concat demuxer's own propagation of format-level metadata is version-dependent, so this
+    // maps the source explicitly rather than relying on `-map_metadata 0`.
+    args.push('-i', audioFiles[0]!);
+    const metadataInput = lastInputIndex(args);
+
+    // Mandatory, not cosmetic: with a second audio-bearing input open, ffmpeg's automatic
+    // stream selection is free to pick the donor's audio instead of the concat's — which
+    // would emit the first part alone as a file that still probes as valid.
+    args.push('-map', '0:a');
+    args.push('-map_metadata', String(metadataInput));
+    if (chapterInput !== undefined) {
+      // -map_chapters pins the GENERATED chapters over whatever the concat demuxer propagates
+      // from the source parts (and now over the metadata donor's own internal chapters):
+      // ffmpeg's default picks the input with the most chapters, so source m4b parts carrying
+      // internal chapters could otherwise outvote the generated set. Both copy and encode modes.
+      args.push('-map_chapters', String(chapterInput));
     }
 
     args.push(...await resolveCodecArgs(config, audioFiles, warnings, callbacks?.onStderr));

--- a/src/core/utils/audio-processor.ts
+++ b/src/core/utils/audio-processor.ts
@@ -15,6 +15,7 @@ import { deriveFfprobePath } from './ffprobe-path.js';
 // the Vite client build, and sanitizedEnv is Node-only. Mirrors the script
 // notifier / post-processing-script call sites.
 import { sanitizedEnv } from './sanitized-env.js';
+import { noticeMessages, resolveCodecArgs, resolveTargetBitrate } from './encode-strategy.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -24,7 +25,28 @@ const FFMPEG_STALL_TIMEOUT_MS = 60_000;
 export interface ProcessingConfig {
   ffmpegPath: string;
   outputFormat: 'm4b' | 'mp3';
-  /** Target bitrate in kbps. When omitted, the original bitrate is preserved (copy codec where possible). */
+  /**
+   * Target bitrate in **kbps** — never divided by this module. Two modes:
+   *
+   * - **Omitted (or present but unusable — see below): keep original.** A source set that
+   *   already matches the output container is stream-copied (`-c:a copy`, no re-encode).
+   *   Otherwise it is re-encoded at the highest target the source evidence supports that the
+   *   selected encoder will *accept*; with no usable evidence, at a conservative default.
+   * - **Present and usable: `min(source, target)`** — except where the encoder's lowest
+   *   accepted rate is higher than that, which is the one case an emitted value exceeds the
+   *   request.
+   *
+   * Both modes are legalized for the output encoder (MP3 snaps to a legal Layer III rate for
+   * the source sample rate; AAC caps at the settings maximum), and every adjustment this
+   * module makes is disclosed through `ProcessingResult.warnings`.
+   *
+   * The emitted value is a **request**, not a promise about the output: the encoder may
+   * normalize it further without this module observing it, so no relationship is claimed
+   * between the emitted bitrate and any source file's bitrate.
+   *
+   * An unusable value — non-integer, non-finite, or below the plausibility floor — is treated
+   * as absent (keep-original semantics) and reported as a warning.
+   */
   bitrate?: number | undefined;
   /** Source bitrate in kbps (converted from bps at the call site). When set, effective bitrate is min(source, target) to prevent upsampling. */
   sourceBitrateKbps?: number | undefined;
@@ -45,8 +67,10 @@ export interface ProcessingContext {
 }
 
 export type ProcessingResult =
+  // `warnings` is on BOTH variants on purpose: a run that adjusted a bitrate and then failed
+  // for an unrelated reason must still report the adjustment.
   | { success: true; outputFiles: string[]; warnings?: string[] }
-  | { success: false; error: string };
+  | { success: false; error: string; warnings?: string[] };
 
 /** Callbacks for streaming progress and stderr from ffmpeg. Keeps src/core/ adapter-agnostic. */
 export interface ProcessingCallbacks {
@@ -76,33 +100,42 @@ export async function processAudioFiles(
     return { success: true, outputFiles: [] };
   }
 
-  // Skip processing for single m4b (already ABS-ready) — but only when the configured
-  // target is also m4b. With outputFormat 'mp3', a single .m4b must fall through to the
-  // convert path so it is re-encoded to .mp3 rather than returned unchanged.
+  // Skip processing for single m4b (already ABS-ready) — but only when the configured target
+  // is also m4b AND no usable explicit bitrate is configured. With outputFormat 'mp3', or with
+  // a usable target, the file must fall through to the convert path instead of being returned
+  // unchanged; where the target is absent-or-unusable, returning it untouched IS the copy path
+  // with zero ffmpeg work. The unusable-target notice still has to surface here.
+  const target = resolveTargetBitrate(config.bitrate);
   if (
     audioFiles.length === 1 &&
     extname(audioFiles[0]!).toLowerCase() === '.m4b' &&
-    config.outputFormat === 'm4b'
+    config.outputFormat === 'm4b' &&
+    target.targetKbps === undefined
   ) {
-    return { success: true, outputFiles: audioFiles };
+    const noOpWarnings = noticeMessages(target.notices);
+    return { success: true, outputFiles: audioFiles, ...(noOpWarnings.length > 0 && { warnings: noOpWarnings }) };
   }
 
   const shouldMerge = config.mergeBehavior === 'always' ||
     (config.mergeBehavior === 'multi-file-only' && audioFiles.length > 1);
+
+  // Resolver notices, accumulated in command order so a multi-file convert keeps every earlier
+  // adjustment even when a later command fails.
+  const warnings: string[] = [];
 
   try {
     // Read chapter sources once — needed for merge (chapter markers) and convert (file naming)
     const chapterSources = await readChapterSources(audioFiles);
 
     if (shouldMerge && audioFiles.length > 1) {
-      return await mergeFiles(targetDir, chapterSources, config, context, callbacks, signal);
-    } else {
-      return await convertFiles(targetDir, audioFiles, config, context, chapterSources, callbacks, signal);
+      return await mergeFiles(targetDir, chapterSources, config, context, warnings, callbacks, signal);
     }
+    return await convertFiles(targetDir, audioFiles, config, context, chapterSources, warnings, callbacks, signal);
   } catch (error: unknown) {
     return {
       success: false,
       error: getErrorMessage(error),
+      ...(warnings.length > 0 && { warnings }),
     };
   }
 }
@@ -220,6 +253,7 @@ async function mergeFiles(
   chapterSources: ChapterSource[],
   config: ProcessingConfig,
   context: ProcessingContext,
+  warnings: string[],
   callbacks?: ProcessingCallbacks,
   signal?: AbortSignal,
 ): Promise<ProcessingResult> {
@@ -263,20 +297,14 @@ async function mergeFiles(
       metadataPath = join(targetDir, '_metadata.txt');
       const metadataContent = buildChapterMetadata(chapterSources, durations);
       await writeFile(metadataPath, metadataContent, 'utf-8');
-      args.push('-i', metadataPath, '-map_metadata', '1');
+      // -map_chapters 1 pins the GENERATED chapters over whatever the concat demuxer
+      // propagates from the source parts: ffmpeg's default picks the input with the most
+      // chapters, so source m4b parts carrying internal chapters could otherwise outvote
+      // the generated set. Emitted in both copy and encode modes.
+      args.push('-i', metadataPath, '-map_metadata', '1', '-map_chapters', '1');
     }
 
-    if (config.bitrate != null) {
-      const effectiveBitrate = config.sourceBitrateKbps != null
-        ? Math.min(config.sourceBitrateKbps, config.bitrate)
-        : config.bitrate;
-      args.push(
-        '-c:a', outputExt === 'm4b' ? 'aac' : 'libmp3lame',
-        '-b:a', `${effectiveBitrate}k`,
-      );
-    } else {
-      args.push('-c:a', outputExt === 'm4b' ? 'aac' : 'libmp3lame');
-    }
+    args.push(...await resolveCodecArgs(config, audioFiles, warnings, callbacks?.onStderr));
 
     args.push('-vn');
     args.push('-max_muxing_queue_size', '4096');
@@ -308,10 +336,11 @@ async function mergeFiles(
     await cleanupTempFiles(concatPath, join(targetDir, '_metadata.txt'));
     await removeSourceFiles(audioFiles, outputPath);
 
+    warnings.push(...result.warnings);
     return {
       success: true,
       outputFiles: result.outputFiles,
-      ...(result.warnings.length > 0 && { warnings: result.warnings }),
+      ...(warnings.length > 0 && { warnings }),
     };
   } catch (error: unknown) {
     await cleanupTempFiles(concatPath, join(targetDir, '_metadata.txt')).catch(() => {});
@@ -366,6 +395,7 @@ async function convertFiles(
   config: ProcessingConfig,
   context: ProcessingContext,
   chapterSources: ChapterSource[],
+  warnings: string[],
   callbacks?: ProcessingCallbacks,
   signal?: AbortSignal,
 ): Promise<ProcessingResult> {
@@ -387,14 +417,10 @@ async function convertFiles(
         ? dotPrefixBasename(join(targetDir, `${stem}_tmp.${config.outputFormat}`))
         : outputPath;
 
-      const args = ['-y', '-i', filePath, '-c:a', config.outputFormat === 'm4b' ? 'aac' : 'libmp3lame'];
+      // One resolution per constructed command: this file's own evidence, never the directory's.
+      const codecArgs = await resolveCodecArgs(config, [filePath], warnings, callbacks?.onStderr);
 
-      if (config.bitrate != null) {
-        const effectiveBitrate = config.sourceBitrateKbps != null
-          ? Math.min(config.sourceBitrateKbps, config.bitrate) : config.bitrate;
-        args.push('-b:a', `${effectiveBitrate}k`);
-      }
-
+      const args = ['-y', '-i', filePath, ...codecArgs];
       args.push('-vn', '-max_muxing_queue_size', '4096');
       if (config.outputFormat === 'm4b') args.push('-f', 'mp4');
       args.push('-progress', 'pipe:1', writePath);
@@ -418,10 +444,11 @@ async function convertFiles(
     config.ffmpegPath, audioFiles, targetDir, config.outputFormat, encodeFn, spawnFfmpeg,
   );
   for (const w of result.warnings) callbacks?.onStderr?.(w);
+  warnings.push(...result.warnings);
   return {
     success: true,
     outputFiles: result.outputFiles,
-    ...(result.warnings.length > 0 && { warnings: result.warnings }),
+    ...(warnings.length > 0 && { warnings }),
   };
 }
 

--- a/src/core/utils/cover-art.test.ts
+++ b/src/core/utils/cover-art.test.ts
@@ -1,12 +1,20 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { detectCoverArtSource } from './cover-art.js';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { detectCoverArtSource, withCoverArtPipeline } from './cover-art.js';
 
 // Mock at the OS boundary (node:child_process) so the env passed to ffprobe is captured.
 vi.mock('node:child_process', () => ({
   execFile: vi.fn(),
 }));
 
+vi.mock('node:fs/promises', () => ({
+  rename: vi.fn(),
+  rm: vi.fn(),
+  stat: vi.fn(),
+}));
+
 import { execFile } from 'node:child_process';
+import { rename, rm, stat } from 'node:fs/promises';
+import { join } from 'node:path';
 
 const mockExecFile = vi.mocked(execFile);
 
@@ -47,5 +55,108 @@ describe('detectCoverArtSource', () => {
     expect(opts.env).toBeDefined();
     expect(opts.env).not.toHaveProperty('NARRATORR_SECRET_KEY');
     expect(opts.env).toHaveProperty('PATH');
+  });
+});
+
+// ============================================================================
+// #2078 — the extract/reattach remuxes must survive the 60 s stall timer, and
+// the reattach must not undo the metadata/chapters the merge just preserved.
+// ============================================================================
+
+const FFMPEG = '/usr/bin/ffmpeg';
+const TARGET_DIR = '/lib/book';
+const SOURCE = join(TARGET_DIR, '01.m4b');
+const OUTPUT = join(TARGET_DIR, 'Book.m4b');
+const COVER = join(TARGET_DIR, '_cover.jpg');
+
+/** Every spawn argv the pipeline issued, in call order: [extract, ...reattach]. */
+function spawnArgvs(spawn: ReturnType<typeof vi.fn>): string[][] {
+  return spawn.mock.calls.map((call) => call[1] as string[]);
+}
+
+/** The argv whose last operand is `output` — identifies a command without pinning call order. */
+function argvWriting(spawn: ReturnType<typeof vi.fn>, output: string): string[] {
+  const found = spawnArgvs(spawn).find((args) => args[args.length - 1] === output);
+  if (!found) throw new Error(`no spawn wrote ${output} (saw ${JSON.stringify(spawnArgvs(spawn))})`);
+  return found;
+}
+
+describe('withCoverArtPipeline (#2078)', () => {
+  beforeEach(() => {
+    // A source carrying an embedded picture, so the extract arm runs.
+    mockExecFileStdout('audio\nvideo\n');
+    vi.mocked(stat).mockResolvedValue({ size: 12_345 } as never);
+    vi.mocked(rm).mockResolvedValue(undefined);
+    vi.mocked(rename).mockResolvedValue(undefined);
+  });
+
+  function runPipeline(spawn: ReturnType<typeof vi.fn>, outputFormat: 'm4b' | 'mp3' = 'm4b') {
+    return withCoverArtPipeline(
+      FFMPEG, [SOURCE], TARGET_DIR, outputFormat, async () => [OUTPUT], spawn as never,
+    );
+  }
+
+  it('feeds the stall timer: extract and reattach both request -progress pipe:1 (AC6)', async () => {
+    const spawn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runPipeline(spawn);
+    expect(result.warnings).toEqual([]);
+
+    // spawnFfmpeg's 60 s stall timer only resets on STDOUT activity. A `-c copy` remux of a
+    // multi-GB merged audiobook emits nothing on stdout without this flag, so it was killed at
+    // 60 s and the reattach silently degraded to the warning arm.
+    for (const args of spawnArgvs(spawn)) {
+      const idx = args.indexOf('-progress');
+      expect(idx).toBeGreaterThan(-1);
+      expect(args[idx + 1]).toBe('pipe:1');
+    }
+    expect(spawnArgvs(spawn)).toHaveLength(2); // extract + reattach
+  });
+
+  it('reattach maps global metadata and chapters from the audio input (AC7)', async () => {
+    const spawn = vi.fn().mockResolvedValue(undefined);
+
+    await runPipeline(spawn);
+
+    // The reattach is a second remux over the just-merged file. Without these it can drop the
+    // source tags Layer 1 preserved and the generated chapter set #2068 pinned.
+    const reattach = spawnArgvs(spawn).find((args) => args.includes('-disposition:v:0'))!;
+    expect(reattach).toBeDefined();
+    const inputs = reattach.reduce<string[]>((acc, a, i) => (a === '-i' ? [...acc, reattach[i + 1]!] : acc), []);
+    expect(inputs[0]).toBe(OUTPUT);
+    expect(reattach[reattach.indexOf('-map_metadata') + 1]).toBe('0');
+    expect(reattach[reattach.indexOf('-map_chapters') + 1]).toBe('0');
+  });
+
+  it('extraction failure degrades with its own warning and never throws', async () => {
+    const spawn = vi.fn().mockRejectedValue(new Error('ffmpeg stalled: no progress for 60s'));
+
+    const result = await runPipeline(spawn);
+
+    expect(result.outputFiles).toEqual([OUTPUT]);
+    expect(result.warnings).toEqual(['Cover art extraction failed — output will not contain embedded cover art']);
+  });
+
+  it('reattach failure degrades with its own distinct warning and never throws', async () => {
+    // Extract succeeds, reattach fails — the production symptom this issue diagnosed.
+    const spawn = vi.fn()
+      .mockImplementationOnce(() => Promise.resolve())
+      .mockImplementationOnce(() => Promise.reject(new Error('ffmpeg stalled: no progress for 60s')));
+
+    const result = await runPipeline(spawn);
+
+    expect(result.outputFiles).toEqual([OUTPUT]);
+    expect(result.warnings).toEqual(['Cover art reattach failed — output will not contain embedded cover art']);
+    expect(rm).toHaveBeenCalledWith(COVER, { force: true });
+  });
+
+  it('mp3 output extracts but never reattaches — the deliberate AC8b gap', async () => {
+    const spawn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runPipeline(spawn, 'mp3');
+
+    expect(spawnArgvs(spawn)).toHaveLength(1);
+    expect(argvWriting(spawn, COVER)).toContain('-an');
+    expect(result.warnings).toEqual([]);
   });
 });

--- a/src/core/utils/cover-art.ts
+++ b/src/core/utils/cover-art.ts
@@ -94,7 +94,9 @@ async function extractCoverArt(
 ): Promise<string | null> {
   const coverPath = join(targetDir, '_cover.jpg');
   try {
-    await spawnFfmpeg(ffmpegPath, ['-y', '-i', sourceFile, '-an', '-vcodec', 'copy', coverPath]);
+    // `-progress pipe:1` is load-bearing, not diagnostic (#2078): spawnFfmpeg's 60 s stall timer
+    // only resets on STDOUT activity, and a `-c copy` remux emits nothing there on its own.
+    await spawnFfmpeg(ffmpegPath, ['-y', '-i', sourceFile, '-an', '-vcodec', 'copy', '-progress', 'pipe:1', coverPath]);
     const info = await stat(coverPath);
     if (info.size === 0) {
       await rm(coverPath, { force: true });
@@ -127,8 +129,16 @@ async function reattachCoverArt(
       '-map', '0:a',
       '-map', '1:v',
       '-c', 'copy',
+      // Explicit (#2078): this is a second remux over the just-merged file, so it must carry
+      // forward the global tags the merge preserved and the generated chapter set #2068 pinned.
+      // ffmpeg's chapter default picks the input with the most chapters — a cover JPEG has none
+      // today, but relying on that is a silent dependency on the other input's shape.
+      '-map_metadata', '0',
+      '-map_chapters', '0',
       '-disposition:v:0', 'attached_pic',
       '-f', 'mp4',
+      // Same stall-timer reason as the extract above — this is the long one (multi-GB remux).
+      '-progress', 'pipe:1',
       tempOutput,
     ]);
     await rename(tempOutput, audioFile);

--- a/src/core/utils/encode-strategy.test.ts
+++ b/src/core/utils/encode-strategy.test.ts
@@ -1,0 +1,503 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveEncodeStrategy,
+  resolveTargetBitrate,
+  buildCodecArgs,
+  selectMp3Table,
+  isUsableBitrateKbps,
+  MIN_PLAUSIBLE_SOURCE_BITRATE_KBPS,
+  MAX_AAC_TARGET_KBPS,
+  KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS,
+  MP3_BITRATES_MPEG1,
+  MP3_BITRATES_MPEG2,
+  MP3_BITRATES_RATE_AGNOSTIC,
+  type SourceEvidence,
+  type EncodeStrategy,
+  type EncodeStrategyInput,
+} from './encode-strategy.js';
+
+/** A fully-probed, copy-eligible AAC/m4b source. Override one field per rejection case. */
+function aacSource(overrides: Partial<SourceEvidence> = {}): SourceEvidence {
+  return { extension: '.m4b', codec: 'aac', bitrateKbps: 128, sampleRate: 44_100, channels: 2, ...overrides };
+}
+
+/** A fully-probed, copy-eligible MP3 source. */
+function mp3Source(overrides: Partial<SourceEvidence> = {}): SourceEvidence {
+  return { extension: '.mp3', codec: 'mp3', bitrateKbps: 128, sampleRate: 44_100, channels: 2, ...overrides };
+}
+
+function resolve(input: Partial<EncodeStrategyInput> & { sources: SourceEvidence[] }): EncodeStrategy {
+  return resolveEncodeStrategy({ outputFormat: 'm4b', ...input });
+}
+
+function encodeOf(strategy: EncodeStrategy): Extract<EncodeStrategy, { mode: 'encode' }> {
+  if (strategy.mode !== 'encode') throw new Error(`expected an encode strategy, got ${strategy.mode}`);
+  return strategy;
+}
+
+function kinds(strategy: EncodeStrategy): string[] {
+  return strategy.notices.map((n) => n.kind);
+}
+
+describe('resolveEncodeStrategy — stream-copy selection (AC1, AC2)', () => {
+  it('copies a homogeneous .m4b / aac set into m4b', () => {
+    const strategy = resolve({ sources: [aacSource(), aacSource(), aacSource()] });
+    expect(strategy.mode).toBe('copy');
+    expect(buildCodecArgs(strategy)).toEqual(['-c:a', 'copy']);
+    expect(buildCodecArgs(strategy)).not.toContain('-b:a');
+    expect(buildCodecArgs(strategy)).not.toContain('aac');
+  });
+
+  it('copies a homogeneous .m4a / aac set into m4b', () => {
+    const sources = [aacSource({ extension: '.m4a' }), aacSource({ extension: '.m4a' }), aacSource({ extension: '.m4a' })];
+    expect(resolve({ sources }).mode).toBe('copy');
+  });
+
+  it('copies a mixed .m4a + .m4b AAC set into m4b (both MP4-family)', () => {
+    const sources = [aacSource({ extension: '.m4a' }), aacSource({ extension: '.m4b' })];
+    expect(resolve({ sources }).mode).toBe('copy');
+  });
+
+  it('copies a homogeneous .mp3 / mp3 set into mp3', () => {
+    const strategy = resolve({ outputFormat: 'mp3', sources: [mp3Source(), mp3Source(), mp3Source()] });
+    expect(strategy.mode).toBe('copy');
+  });
+
+  it('compares extensions case-insensitively', () => {
+    const sources = [aacSource({ extension: '.M4B' }), aacSource({ extension: '.M4A' })];
+    expect(resolve({ sources }).mode).toBe('copy');
+  });
+
+  it.each<[string, Partial<EncodeStrategyInput>]>([
+    ['mixed codec (aac + mp3)', { sources: [aacSource(), aacSource({ codec: 'mp3' })] }],
+    ['mixed sample rate', { sources: [aacSource(), aacSource({ sampleRate: 22_050 })] }],
+    ['mixed channel count', { sources: [aacSource(), aacSource({ channels: 1 })] }],
+    ['absent sample rate', { sources: [aacSource({ sampleRate: undefined }), aacSource()] }],
+    ['absent channel count', { sources: [aacSource({ channels: undefined }), aacSource()] }],
+    ['one probe returned null', { sources: [aacSource(), { extension: '.m4b' }] }],
+    ['raw ADTS .aac source into m4b', { sources: [aacSource({ extension: '.aac' })] }],
+    ['aac source into mp3 output', { outputFormat: 'mp3', sources: [aacSource()] }],
+    ['.m4a/aac source into mp3 output', { outputFormat: 'mp3', sources: [aacSource({ extension: '.m4a' })] }],
+    ['empty source set', { sources: [] }],
+  ])('rejects the copy path: %s', (_label, input) => {
+    const strategy = resolveEncodeStrategy({ outputFormat: 'm4b', sources: [], ...input });
+    expect(strategy.mode).toBe('encode');
+  });
+
+  it('never copies when a usable explicit target is configured, even for a homogeneous AAC set', () => {
+    const strategy = resolve({ targetBitrateKbps: 128, sources: [aacSource(), aacSource()] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(128);
+  });
+});
+
+describe('resolveEncodeStrategy — explicit target (AC11)', () => {
+  it('caps the target at the resolved source (min)', () => {
+    const strategy = resolve({ targetBitrateKbps: 128, hintBitrateKbps: 64, sources: [{ extension: '.mp3' }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(64);
+  });
+
+  it('keeps the target at the equal-value boundary and records no step', () => {
+    const strategy = resolve({ targetBitrateKbps: 128, hintBitrateKbps: 128, sources: [{ extension: '.mp3' }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(128);
+    expect(kinds(strategy)).toEqual([]);
+  });
+
+  it('uses the target as-is when no evidence exists', () => {
+    const strategy = resolve({ targetBitrateKbps: 128, sources: [{ extension: '.mp3' }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(128);
+    expect(kinds(strategy)).toEqual([]);
+  });
+});
+
+describe('AC6 — one unit, one validity predicate', () => {
+  it('resolves a 251000 bps probe and a 251 kbps hint to the same 251 (never divided twice)', () => {
+    // The resolver's input is probe-collector output: a bps value is floored to kbps exactly
+    // once, before it reaches here. Both spellings of "251" must land on the same request.
+    const fromProbe = resolve({ outputFormat: 'mp3', sources: [{ extension: '.wav', bitrateKbps: Math.floor(251_000 / 1000) }] });
+    const fromHint = resolve({ outputFormat: 'mp3', hintBitrateKbps: 251, sources: [{ extension: '.wav' }] });
+    expect(encodeOf(fromProbe).bitrateKbps).toBe(encodeOf(fromHint).bitrateKbps);
+    // 251 legalized against the rate-agnostic MP3 table (no sample rate known) → 160.
+    expect(encodeOf(fromProbe).notices.find((n) => n.kind === 'mp3-table')?.from).toBe(251);
+  });
+
+  const USABILITY: Array<[unknown, boolean]> = [
+    [0, false], [1, false], [7, false], [8, true], [9, true],
+    [-1, false], [Number.NaN, false], [Number.POSITIVE_INFINITY, false], [128.5, false],
+    [1411, true], [5000, true],
+  ];
+
+  it.each(USABILITY)('isUsableBitrateKbps(%s) === %s', (value, expected) => {
+    expect(isUsableBitrateKbps(value as number)).toBe(expected);
+  });
+
+  it.each(USABILITY)('applies the same predicate to a probe value (%s → usable %s)', (value, expected) => {
+    const strategy = resolve({ sources: [{ extension: '.wav', bitrateKbps: value as number }] });
+    // Unusable → the AC9 fallback; usable → the value itself (AAC never snaps below 512).
+    const expectedKbps = expected ? Math.min(value as number, MAX_AAC_TARGET_KBPS) : KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS;
+    expect(encodeOf(strategy).bitrateKbps).toBe(expectedKbps);
+  });
+
+  it.each(USABILITY)('applies the same predicate to sourceBitrateKbps (%s → usable %s)', (value, expected) => {
+    const strategy = resolve({ hintBitrateKbps: value as number, sources: [{ extension: '.wav' }] });
+    const expectedKbps = expected ? Math.min(value as number, MAX_AAC_TARGET_KBPS) : KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS;
+    expect(encodeOf(strategy).bitrateKbps).toBe(expectedKbps);
+  });
+
+  it('discards a rejected value rather than raising it to the floor', () => {
+    const strategy = resolve({ sources: [{ extension: '.mp3', bitrateKbps: 7 }] });
+    expect(encodeOf(strategy).bitrateKbps).not.toBe(MIN_PLAUSIBLE_SOURCE_BITRATE_KBPS);
+    expect(kinds(strategy)).toContain('no-usable-evidence');
+  });
+
+  it.each([[Number.NaN], [0], [-1], [7], [128.5]])(
+    'treats an unusable config.bitrate (%s) as absent, with an unusable-target notice',
+    (bitrate) => {
+      const strategy = resolve({ targetBitrateKbps: bitrate, sources: [{ extension: '.mp3' }] });
+      const encode = encodeOf(strategy);
+      // No evidence either → the AC9 fallback, never `-b:a NaNk` / `0k` / `7k`.
+      expect(encode.bitrateKbps).toBe(KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS);
+      expect(buildCodecArgs(strategy)).toContain(`${KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS}k`);
+      const notice = strategy.notices.find((n) => n.kind === 'unusable-target');
+      expect(notice).toBeDefined();
+      expect(notice!.rejectedValue).toBe(String(bitrate));
+      expect(notice!.outcome).toBe('treated-as-absent');
+      expect(notice).not.toHaveProperty('bitrateKbps');
+      expect(notice!.message).not.toMatch(/\dk\b/);
+    },
+  );
+
+  it('lets an unusable config.bitrate fall through to the copy path, carrying its notice', () => {
+    const strategy = resolve({ targetBitrateKbps: Number.NaN, sources: [aacSource(), aacSource()] });
+    expect(strategy.mode).toBe('copy');
+    expect(kinds(strategy)).toEqual(['unusable-target']);
+  });
+});
+
+describe('AC7 — requested source bitrate is the max over all usable evidence', () => {
+  it('takes the highest probe when the probes win', () => {
+    const sources = [
+      { extension: '.mp3', bitrateKbps: 128 },
+      { extension: '.mp3', bitrateKbps: 251 },
+      { extension: '.mp3', bitrateKbps: 192 },
+    ];
+    const strategy = resolve({ hintBitrateKbps: 96, sources });
+    expect(encodeOf(strategy).bitrateKbps).toBe(251);
+    expect(kinds(strategy)).not.toContain('hint-overrode-probes');
+  });
+
+  it('takes the hint when the hint wins, and discloses it', () => {
+    const strategy = resolve({ hintBitrateKbps: 251, sources: [{ extension: '.mp3', bitrateKbps: 64 }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(251);
+    const notice = strategy.notices.find((n) => n.kind === 'hint-overrode-probes');
+    expect(notice).toMatchObject({ from: 251, to: 64 });
+  });
+
+  it('uses a partial probe success rather than dropping to the one probed value', () => {
+    const sources = [{ extension: '.mp3', bitrateKbps: 64 }, { extension: '.mp3' }];
+    expect(encodeOf(resolve({ hintBitrateKbps: 251, sources })).bitrateKbps).toBe(251);
+  });
+
+  it('falls back to the hint when every probe is invalid', () => {
+    const sources = [{ extension: '.mp3', bitrateKbps: 0 }, { extension: '.mp3', bitrateKbps: 827 / 1000 }];
+    expect(encodeOf(resolve({ hintBitrateKbps: 251, sources })).bitrateKbps).toBe(251);
+  });
+
+  it('rejects a garbage 827-bps probe without letting it become or drag down the max', () => {
+    const sources = [
+      { extension: '.mp3', bitrateKbps: Math.floor(827 / 1000) },
+      { extension: '.mp3', bitrateKbps: 128 },
+    ];
+    const strategy = resolve({ sources });
+    expect(encodeOf(strategy).bitrateKbps).toBe(128);
+  });
+
+  it('uses the AC9 fallback with a notice when the evidence set is empty', () => {
+    const strategy = resolve({ sources: [{ extension: '.mp3' }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS);
+    expect(strategy.notices.find((n) => n.kind === 'no-usable-evidence')?.bitrateKbps).toBe(192);
+  });
+
+  it('is a request, not a promise: complete low probes lose to a higher stale hint', () => {
+    const sources = [64, 64, 64].map((bitrateKbps) => ({ extension: '.mp3', bitrateKbps }));
+    const strategy = resolve({ hintBitrateKbps: 251, sources });
+    expect(encodeOf(strategy).bitrateKbps).toBe(251);
+    expect(strategy.notices.find((n) => n.kind === 'hint-overrode-probes')).toMatchObject({ from: 251, to: 64 });
+  });
+
+  it('resolves merge evidence jointly and convert evidence per file', () => {
+    const low = { extension: '.mp3', bitrateKbps: 64 };
+    const high = { extension: '.mp3', bitrateKbps: 251 };
+    expect(encodeOf(resolve({ sources: [low, high] })).bitrateKbps).toBe(251);
+    expect(encodeOf(resolve({ sources: [low] })).bitrateKbps).toBe(64);
+    expect(encodeOf(resolve({ sources: [high] })).bitrateKbps).toBe(251);
+  });
+
+  it.each([[8, 8], [24, 24], [31, 31]])(
+    'never raises a requested %s kbps on the AAC path',
+    (requested, expected) => {
+      expect(encodeOf(resolve({ hintBitrateKbps: requested, sources: [{ extension: '.mp3' }] })).bitrateKbps).toBe(expected);
+    },
+  );
+
+  it('min(8, 128) stays 8 on the explicit AAC path', () => {
+    const strategy = resolve({ targetBitrateKbps: 128, hintBitrateKbps: 8, sources: [{ extension: '.mp3' }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(8);
+  });
+
+  it('a 7 kbps candidate is absent from the evidence set, not raised to 8', () => {
+    const strategy = resolve({ hintBitrateKbps: 7, sources: [{ extension: '.mp3' }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS);
+  });
+});
+
+describe('hint-overrode-probes — the arithmetic predicate boundary', () => {
+  it('fires with operands 251 → 64 when the hint beats the only probe', () => {
+    const strategy = resolve({ hintBitrateKbps: 251, sources: [{ extension: '.mp3', bitrateKbps: 64 }] });
+    expect(strategy.notices.find((n) => n.kind === 'hint-overrode-probes')).toMatchObject({ from: 251, to: 64 });
+  });
+
+  it.each([
+    [[251, 64]],
+    [[64, 251]],
+  ])('does not fire on a tie, in evidence order %j', (probes) => {
+    const sources = probes.map((bitrateKbps) => ({ extension: '.mp3', bitrateKbps }));
+    const strategy = resolve({ hintBitrateKbps: 251, sources });
+    expect(encodeOf(strategy).bitrateKbps).toBe(251);
+    expect(kinds(strategy)).not.toContain('hint-overrode-probes');
+  });
+
+  it('does not fire when every probe is invalid (no probe maximum exists)', () => {
+    const strategy = resolve({ hintBitrateKbps: 251, sources: [{ extension: '.mp3', bitrateKbps: 0 }] });
+    expect(encodeOf(strategy).bitrateKbps).toBe(251);
+    expect(kinds(strategy)).not.toContain('hint-overrode-probes');
+  });
+
+  it('does not fire when the hint lost', () => {
+    const sources = [128, 251, 192].map((bitrateKbps) => ({ extension: '.mp3', bitrateKbps }));
+    expect(kinds(resolve({ hintBitrateKbps: 96, sources }))).not.toContain('hint-overrode-probes');
+  });
+
+  it('never emits a notice with equal operands', () => {
+    const inputs: EncodeStrategyInput[] = [];
+    for (const hint of [undefined, 8, 64, 128, 251]) {
+      for (const probe of [undefined, 8, 64, 128, 251]) {
+        for (const outputFormat of ['m4b', 'mp3'] as const) {
+          inputs.push({
+            outputFormat,
+            ...(hint !== undefined && { hintBitrateKbps: hint }),
+            sources: [{ extension: '.mp3', ...(probe !== undefined && { bitrateKbps: probe }) }],
+          });
+        }
+      }
+    }
+    for (const input of inputs) {
+      for (const notice of resolveEncodeStrategy(input).notices) {
+        if (notice.from !== undefined) expect(notice.from).not.toBe(notice.to);
+      }
+    }
+  });
+});
+
+describe('AC8 — AAC legalization', () => {
+  it.each([[700, 512], [512, 512], [513, 512], [192, 192]])(
+    'requested %s → %s',
+    (requested, expected) => {
+      const strategy = resolve({ hintBitrateKbps: requested, sources: [{ extension: '.mp3' }] });
+      expect(encodeOf(strategy).bitrateKbps).toBe(expected);
+    },
+  );
+
+  it('does not model the 6144 x channels frame clamp: a mono 44.1 kHz source still requests 512', () => {
+    const sources = [{ extension: '.wav', bitrateKbps: 512, sampleRate: 44_100, channels: 1 }];
+    const strategy = resolve({ sources });
+    expect(encodeOf(strategy).bitrateKbps).toBe(MAX_AAC_TARGET_KBPS);
+    expect(kinds(strategy)).toEqual([]);
+  });
+
+  it('reports the aac-max step as a requested value, never an achieved one', () => {
+    const sources = [{ extension: '.wav', bitrateKbps: 705, sampleRate: 44_100, channels: 1 }];
+    const notice = resolve({ sources }).notices.find((n) => n.kind === 'aac-max');
+    expect(notice).toMatchObject({ from: 705, to: 512 });
+    expect(notice!.message).toMatch(/requested/i);
+    expect(notice!.message).not.toMatch(/achiev/i);
+  });
+});
+
+describe('AC8 — MP3 table selection by set-wide sample-rate agreement', () => {
+  function mp3At(rate: number | undefined, bitrateKbps: number): SourceEvidence {
+    return { extension: '.mp3', bitrateKbps, ...(rate !== undefined && { sampleRate: rate }) };
+  }
+
+  function requestMp3(requested: number, rates: Array<number | undefined>): EncodeStrategy {
+    // Drive the request through the hint so the sources only carry the rate dimension.
+    return resolveEncodeStrategy({
+      outputFormat: 'mp3',
+      hintBitrateKbps: requested,
+      sources: rates.map((r) => mp3At(r, 8)),
+    });
+  }
+
+  it.each([[700, 320], [320, 320], [200, 192], [130, 128], [33, 32]])(
+    'MPEG-1 arm (all 44.1 kHz): %s → %s',
+    (requested, expected) => {
+      const strategy = requestMp3(requested, [44_100, 44_100]);
+      expect(encodeOf(strategy).bitrateKbps).toBe(expected);
+      expect(MP3_BITRATES_MPEG1).toContain(encodeOf(strategy).bitrateKbps);
+    },
+  );
+
+  it('MPEG-1 arm: a requested 8 is raised to the table minimum of 32 as a single step', () => {
+    const strategy = resolveEncodeStrategy({
+      outputFormat: 'mp3',
+      targetBitrateKbps: 8,
+      sources: [mp3At(44_100, 8)],
+    });
+    expect(encodeOf(strategy).bitrateKbps).toBe(32);
+    expect(kinds(strategy)).toEqual(['mp3-table-minimum']);
+    expect(strategy.notices[0]).toMatchObject({ from: 8, to: 32, operatorTargetKbps: 8 });
+  });
+
+  it.each([[700, 160], [200, 160], [24, 24], [8, 8]])(
+    'MPEG-2 arm (all 22.05 kHz): %s → %s',
+    (requested, expected) => {
+      const strategy = requestMp3(requested, [22_050, 22_050]);
+      expect(encodeOf(strategy).bitrateKbps).toBe(expected);
+      expect(MP3_BITRATES_MPEG2).toContain(encodeOf(strategy).bitrateKbps);
+    },
+  );
+
+  it.each<[string, Array<number | undefined>]>([
+    ['mixed 44.1 + 22.05 kHz', [44_100, 22_050]],
+    ['partially missing', [44_100, undefined]],
+    ['all missing', [undefined, undefined]],
+    ['non-MPEG rate', [11_024, 11_024]],
+  ])('rate-agnostic arm (%s): 200 → 160', (_label, rates) => {
+    const strategy = requestMp3(200, rates);
+    expect(encodeOf(strategy).bitrateKbps).toBe(160);
+    expect(MP3_BITRATES_RATE_AGNOSTIC).toContain(encodeOf(strategy).bitrateKbps);
+  });
+
+  it('MP3_BITRATES_RATE_AGNOSTIC really is the intersection of the two generation tables', () => {
+    const intersection = MP3_BITRATES_MPEG1.filter((b) => MP3_BITRATES_MPEG2.includes(b));
+    expect([...MP3_BITRATES_RATE_AGNOSTIC]).toEqual(intersection);
+    for (const rate of MP3_BITRATES_RATE_AGNOSTIC) {
+      expect(MP3_BITRATES_MPEG1).toContain(rate);
+      expect(MP3_BITRATES_MPEG2).toContain(rate);
+    }
+  });
+
+  it('selects the table from the set, not from one member', () => {
+    expect(selectMp3Table([mp3At(48_000, 8), mp3At(32_000, 8)])).toBe(MP3_BITRATES_RATE_AGNOSTIC);
+    expect(selectMp3Table([mp3At(48_000, 8)])).toBe(MP3_BITRATES_MPEG1);
+    expect(selectMp3Table([mp3At(24_000, 8)])).toBe(MP3_BITRATES_MPEG2);
+    expect(selectMp3Table([])).toBe(MP3_BITRATES_RATE_AGNOSTIC);
+  });
+});
+
+describe('AC14 — notices are derived from the chain', () => {
+  it('reports the AC9 fallback and its later legalization as two ordered notices', () => {
+    const strategy = resolveEncodeStrategy({ outputFormat: 'mp3', sources: [{ extension: '.mp3' }] });
+    expect(kinds(strategy)).toEqual(['no-usable-evidence', 'mp3-table']);
+    expect(strategy.notices[0]).toMatchObject({ bitrateKbps: 192 });
+    expect(strategy.notices[1]).toMatchObject({ from: 192, to: 160 });
+    expect(encodeOf(strategy).bitrateKbps).toBe(160);
+  });
+
+  it('records an evidence-cap step only when the source is lower than the target', () => {
+    const capped = resolve({ targetBitrateKbps: 128, hintBitrateKbps: 64, sources: [{ extension: '.mp3' }] });
+    expect(capped.notices).toHaveLength(1);
+    expect(capped.notices[0]).toMatchObject({ kind: 'evidence-cap', from: 128, to: 64, operatorTargetKbps: 128 });
+
+    const unmoved = resolve({ targetBitrateKbps: 128, hintBitrateKbps: 251, sources: [{ extension: '.mp3' }] });
+    expect(unmoved.notices).toEqual([]);
+  });
+
+  it('carries a notice on the AC13-shaped no-op input (copy decision, unusable target)', () => {
+    const strategy = resolve({ targetBitrateKbps: 0, sources: [aacSource(), aacSource()] });
+    expect(strategy.mode).toBe('copy');
+    expect(kinds(strategy)).toEqual(['unusable-target']);
+  });
+
+  it('resolveTargetBitrate single-homes the usable/unusable decision', () => {
+    expect(resolveTargetBitrate(undefined)).toEqual({ notices: [] });
+    expect(resolveTargetBitrate(128)).toEqual({ targetKbps: 128, notices: [] });
+    const unusable = resolveTargetBitrate(7);
+    expect(unusable.targetKbps).toBeUndefined();
+    expect(unusable.notices.map((n) => n.kind)).toEqual(['unusable-target']);
+  });
+
+  it('never claims what the encoder achieved', () => {
+    const strategy = resolveEncodeStrategy({
+      outputFormat: 'mp3',
+      targetBitrateKbps: 512,
+      sources: [{ extension: '.wav', bitrateKbps: 1411, sampleRate: 44_100, channels: 2 }],
+    });
+    for (const notice of strategy.notices) {
+      expect(notice.message).not.toMatch(/achiev|deliver|actual/i);
+    }
+  });
+});
+
+describe('AC5/AC8 — exhaustive matrix invariant', () => {
+  const OUTPUT_FORMATS = ['m4b', 'mp3'] as const;
+  const TARGETS = [undefined, 128, Number.NaN];
+  const HINTS = [undefined, 251, 0];
+  const PROBE_SETS: Array<Array<number | undefined>> = [[128, 251], [128, undefined], [undefined, undefined]];
+  const RATE_SETS: Array<Array<number | undefined>> = [
+    [44_100, 44_100], [22_050, 22_050], [44_100, 22_050], [44_100, undefined], [undefined, undefined], [11_024, 11_024],
+  ];
+  const CHANNEL_SETS = [1, 2, 6, 9, undefined];
+  const EXTENSIONS = ['.m4b', '.mp3'];
+
+  it('always yields either a copy or a legal, fully-specified encode — and never shapes the output', () => {
+    let cases = 0;
+    for (const outputFormat of OUTPUT_FORMATS) {
+      for (const targetBitrateKbps of TARGETS) {
+        for (const hintBitrateKbps of HINTS) {
+          for (const probes of PROBE_SETS) {
+            for (const rates of RATE_SETS) {
+              for (const channels of CHANNEL_SETS) {
+                for (const extension of EXTENSIONS) {
+                  const sources: SourceEvidence[] = probes.map((bitrateKbps, i) => ({
+                    extension,
+                    codec: extension === '.mp3' ? 'mp3' : 'aac',
+                    ...(bitrateKbps !== undefined && { bitrateKbps }),
+                    ...(rates[i] !== undefined && { sampleRate: rates[i] }),
+                    ...(channels !== undefined && { channels }),
+                  }));
+                  const strategy = resolveEncodeStrategy({
+                    outputFormat,
+                    ...(targetBitrateKbps !== undefined && { targetBitrateKbps }),
+                    ...(hintBitrateKbps !== undefined && { hintBitrateKbps }),
+                    sources,
+                  });
+                  cases++;
+                  const args = buildCodecArgs(strategy);
+                  expect(args).not.toContain('-ar');
+                  expect(args).not.toContain('-ac');
+                  for (const notice of strategy.notices) {
+                    if (notice.from !== undefined) expect(notice.from).not.toBe(notice.to);
+                  }
+                  if (strategy.mode === 'copy') {
+                    expect(args).toEqual(['-c:a', 'copy']);
+                    continue;
+                  }
+                  const { bitrateKbps, codec } = strategy;
+                  expect(Number.isInteger(bitrateKbps)).toBe(true);
+                  expect(bitrateKbps).toBeGreaterThanOrEqual(MIN_PLAUSIBLE_SOURCE_BITRATE_KBPS);
+                  if (codec === 'aac') {
+                    expect(bitrateKbps).toBeLessThanOrEqual(MAX_AAC_TARGET_KBPS);
+                  } else {
+                    expect(selectMp3Table(sources)).toContain(bitrateKbps);
+                  }
+                  expect(args).toEqual(['-c:a', codec, '-b:a', `${bitrateKbps}k`]);
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    expect(cases).toBeGreaterThan(1000);
+  });
+});

--- a/src/core/utils/encode-strategy.ts
+++ b/src/core/utils/encode-strategy.ts
@@ -1,0 +1,386 @@
+import { extname } from 'node:path';
+import { deriveFfprobePath } from './ffprobe-path.js';
+// Imported by path, not via the core/utils barrel — the collector below reaches
+// node:child_process through audio-probe, and the barrel feeds the Vite client build.
+// Mirrors how audio-processor.ts imports sanitized-env.js.
+import { getFFprobeStreamInfo } from './audio-probe.js';
+
+/**
+ * The lowest kbps value this module treats as real evidence or a real target.
+ *
+ * Sub-8 kbps numbers are not audiobook streams, they are the documented lie class: an MP3
+ * whose Xing/Info header reports 827 bps floors to 0 kbps, its 1000–7999 bps neighbours to
+ * 1–7. 8 kbps is also the lowest rate either target encoder can represent. This is the kbps
+ * twin of `MIN_PLAUSIBLE_BITRATE_BPS` in audio-probe.ts, which guards a different decision
+ * (implied-duration plausibility) and is deliberately given the same threshold.
+ *
+ * A rejected value is DISCARDED. Nothing is ever raised to this floor.
+ */
+export const MIN_PLAUSIBLE_SOURCE_BITRATE_KBPS = 8;
+
+/** Ceiling for an AAC target — the operator-settable maximum in the processing settings schema. */
+export const MAX_AAC_TARGET_KBPS = 512;
+
+/**
+ * Used only when no usable bitrate evidence exists at all. Above the common audiobook range
+ * (32–128 kbps) so a wholly unknown source is not gratuitously downgraded, and deliberately
+ * NOT the settings default of 128, so an emitted `-b:a 192k` proves the unused fallback value
+ * never leaked into the keep-original path.
+ */
+export const KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS = 192;
+
+/**
+ * ITU-T / ISO 11172-3 Layer III bitrate tables, ascending. Transcribed data, not tuning
+ * knobs — never edit a value to make a test pass.
+ */
+export const MP3_BITRATES_MPEG1: readonly number[] =
+  [32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320];
+/** ISO 13818-3 / MPEG-2.5 Layer III table (the lower sample-rate generations). */
+export const MP3_BITRATES_MPEG2: readonly number[] =
+  [8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160];
+/**
+ * Every rate legal at EVERY MPEG sample rate. Derived from the two tables above at module
+ * load so it cannot drift out of being a true intersection.
+ */
+export const MP3_BITRATES_RATE_AGNOSTIC: readonly number[] =
+  MP3_BITRATES_MPEG1.filter((b) => MP3_BITRATES_MPEG2.includes(b));
+
+const MPEG1_SAMPLE_RATES = new Set([32_000, 44_100, 48_000]);
+const MPEG2_SAMPLE_RATES = new Set([8000, 11_025, 12_000, 16_000, 22_050, 24_000]);
+const MP4_FAMILY_EXTENSIONS = new Set(['.m4b', '.m4a']);
+
+/**
+ * Why the two encoders are treated asymmetrically, since that is the first question the code
+ * raises: FFmpeg's native `aac` encoder ACCEPTS any bitrate and normalizes internally (it
+ * clamps to 6144 x channels bits per 1024-sample frame), so only the achieved rate is at
+ * stake — and achieved rates are outside this module's guarantees. `libmp3lame` rejects or
+ * silently re-rates an off-table or wrong-generation value, so the COMMAND itself is at
+ * stake, which is why only MP3 gets a snap-to-table step.
+ */
+
+export type EncodeNoticeKind =
+  /** AC11's min(resolved source, configured target) reduced the operator's number. */
+  | 'evidence-cap'
+  /** Snapped down to the highest legal MP3 rate at or below the request. */
+  | 'mp3-table'
+  /** Raised to the MP3 table minimum — the encoder has no legal rate below it. */
+  | 'mp3-table-minimum'
+  /** Capped at the operator-settable AAC maximum. */
+  | 'aac-max'
+  /** The book-level hint exceeded every usable probe and won the max. */
+  | 'hint-overrode-probes'
+  /** No usable evidence existed; the fallback started the chain. */
+  | 'no-usable-evidence'
+  /** A configured target was present but unusable, so it was treated as absent. */
+  | 'unusable-target';
+
+/**
+ * One operator-visible fact about how the bitrate was decided.
+ *
+ * Chain steps (`evidence-cap`, `mp3-table`, `mp3-table-minimum`, `aac-max`) are recorded as
+ * they are applied, so a step cannot exist without its notice and a notice cannot exist
+ * without its step — and a step that moves nothing is not a step, which is why there is no
+ * suppression rule. Every message describes what this module REQUESTED or EMITTED; none
+ * claims what the encoder achieved.
+ */
+export interface EncodeNotice {
+  kind: EncodeNoticeKind;
+  /** The line delivered to ProcessingResult.warnings and onStderr. */
+  message: string;
+  /** Chain steps and `hint-overrode-probes` carry both operands; they are never equal. */
+  from?: number;
+  to?: number;
+  /** `no-usable-evidence` only: the fallback value that started the chain. */
+  bitrateKbps?: number;
+  /** Present on a chain step whose chain started at the operator's configured target. */
+  operatorTargetKbps?: number;
+  /** `unusable-target` only: the rejected raw value, rendered safely (may be NaN/Infinity). */
+  rejectedValue?: string;
+  /** `unusable-target` only. */
+  outcome?: 'treated-as-absent';
+}
+
+/** One source file's probe result, normalized to kbps at this boundary and nowhere else. */
+export interface SourceEvidence {
+  /** File extension including the dot; compared case-insensitively. */
+  extension: string;
+  /** ffprobe `codec_name`, lowercased. Absent when the probe returned null. */
+  codec?: string | undefined;
+  /** Source bitrate in **kbps** — floored from the probe's bps exactly once, in the collector. */
+  bitrateKbps?: number | undefined;
+  sampleRate?: number | undefined;
+  channels?: number | undefined;
+}
+
+export interface EncodeStrategyInput {
+  outputFormat: 'm4b' | 'mp3';
+  /** `ProcessingConfig.bitrate` verbatim — kbps, raw and unvalidated. Never divided here. */
+  targetBitrateKbps?: number | undefined;
+  /** `ProcessingConfig.sourceBitrateKbps` verbatim — kbps, raw and unvalidated. */
+  hintBitrateKbps?: number | undefined;
+  /** Evidence for the sources feeding THIS one output command. */
+  sources: SourceEvidence[];
+}
+
+export type EncodeStrategy =
+  | { mode: 'copy'; notices: EncodeNotice[] }
+  | { mode: 'encode'; codec: 'aac' | 'libmp3lame'; bitrateKbps: number; notices: EncodeNotice[] };
+
+/**
+ * The one validity predicate, applied to every numeric input in kbps: probe-derived values,
+ * the book-level hint, and the configured target alike. Finite integer at or above the floor.
+ */
+export function isUsableBitrateKbps(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= MIN_PLAUSIBLE_SOURCE_BITRATE_KBPS;
+}
+
+/**
+ * Classify a configured target. Single-homed so the single-m4b short circuit and the resolver
+ * agree on what "no usable target" means without either re-deriving the other's predicate.
+ */
+export function resolveTargetBitrate(
+  raw: number | undefined,
+): { targetKbps?: number; notices: EncodeNotice[] } {
+  if (isUsableBitrateKbps(raw)) return { targetKbps: raw, notices: [] };
+  if (raw === undefined) return { notices: [] };
+  return {
+    notices: [{
+      kind: 'unusable-target',
+      rejectedValue: String(raw),
+      outcome: 'treated-as-absent',
+      message: `Configured target bitrate "${String(raw)}" is not a usable kbps value; treated as absent, keeping the original bitrate.`,
+    }],
+  };
+}
+
+/**
+ * Copy eligibility: a pure remux is only safe when the whole set already matches the output
+ * container's codec and agrees on stream layout. Any unprobeable, mixed-codec, mixed-container,
+ * mixed-sample-rate or mixed-channel file disqualifies the WHOLE set. Raw ADTS `.aac` is never
+ * eligible into m4b — that needs `-bsf:a aac_adtstoasc`, deliberately not implemented here.
+ *
+ * The rate/channel equality requirements are defense in depth, not a rescue: a set that fails
+ * them is likely to fail in the concat demuxer whichever codec strategy is chosen, and falling
+ * back to an explicit-bitrate re-encode is the loss-averse choice.
+ */
+function isCopyEligible(outputFormat: 'm4b' | 'mp3', sources: SourceEvidence[]): boolean {
+  const first = sources[0];
+  if (first === undefined || first.sampleRate === undefined || first.channels === undefined) return false;
+  return sources.every((s) => {
+    if (s.codec === undefined || s.sampleRate !== first.sampleRate || s.channels !== first.channels) return false;
+    const ext = s.extension.toLowerCase();
+    return outputFormat === 'm4b'
+      ? MP4_FAMILY_EXTENSIONS.has(ext) && s.codec === 'aac'
+      : ext === '.mp3' && s.codec === 'mp3';
+  });
+}
+
+/**
+ * Pick the Layer III table from the sample rate the WHOLE set agrees on. Rates that disagree,
+ * any missing rate, or a rate in neither generation fall back to the intersection table, every
+ * member of which is legal at every MPEG sample rate.
+ */
+export function selectMp3Table(sources: SourceEvidence[]): readonly number[] {
+  const rates = sources.map((s) => s.sampleRate);
+  if (rates.length === 0 || rates.some((r) => r === undefined)) return MP3_BITRATES_RATE_AGNOSTIC;
+  if (new Set(rates).size !== 1) return MP3_BITRATES_RATE_AGNOSTIC;
+  const rate = rates[0]!;
+  if (MPEG1_SAMPLE_RATES.has(rate)) return MP3_BITRATES_MPEG1;
+  if (MPEG2_SAMPLE_RATES.has(rate)) return MP3_BITRATES_MPEG2;
+  return MP3_BITRATES_RATE_AGNOSTIC;
+}
+
+const STEP_MESSAGES: Record<'evidence-cap' | 'mp3-table' | 'mp3-table-minimum' | 'aac-max', (from: number, to: number) => string> = {
+  'evidence-cap': (from, to) =>
+    `Requested bitrate reduced from ${from} kbps to ${to} kbps — that is the highest the source evidence supports (no upsampling).`,
+  'mp3-table': (from, to) =>
+    `Requested bitrate rounded down from ${from} kbps to ${to} kbps — the highest legal MP3 rate at or below it for this source.`,
+  'mp3-table-minimum': (from, to) =>
+    `Requested bitrate raised from ${from} kbps to ${to} kbps — MP3 has no legal rate below that for this source.`,
+  'aac-max': (from, to) =>
+    `Requested bitrate capped from ${from} kbps to ${to} kbps — the maximum this setting allows. The encoder may adjust it further.`,
+};
+
+/** Record one adjustment as it is applied and return its result. */
+function recordStep(
+  notices: EncodeNotice[],
+  kind: 'evidence-cap' | 'mp3-table' | 'mp3-table-minimum' | 'aac-max',
+  from: number,
+  to: number,
+  operatorTargetKbps: number | undefined,
+): number {
+  notices.push({
+    kind,
+    from,
+    to,
+    message: STEP_MESSAGES[kind](from, to)
+      + (operatorTargetKbps !== undefined ? ` (configured target: ${operatorTargetKbps} kbps)` : ''),
+    ...(operatorTargetKbps !== undefined && { operatorTargetKbps }),
+  });
+  return to;
+}
+
+/** Move the requested target to a value the selected encoder accepts, disclosing every move. */
+function legalize(
+  codec: 'aac' | 'libmp3lame',
+  requested: number,
+  sources: SourceEvidence[],
+  notices: EncodeNotice[],
+  operatorTargetKbps: number | undefined,
+): number {
+  if (codec === 'aac') {
+    return requested > MAX_AAC_TARGET_KBPS
+      ? recordStep(notices, 'aac-max', requested, MAX_AAC_TARGET_KBPS, operatorTargetKbps)
+      : requested;
+  }
+  const table = selectMp3Table(sources);
+  const minimum = table[0]!;
+  if (requested < minimum) {
+    return recordStep(notices, 'mp3-table-minimum', requested, minimum, operatorTargetKbps);
+  }
+  const snapped = [...table].reverse().find((b) => b <= requested)!;
+  return snapped === requested
+    ? requested
+    : recordStep(notices, 'mp3-table', requested, snapped, operatorTargetKbps);
+}
+
+/**
+ * Resolve the codec strategy for ONE constructed ffmpeg command.
+ *
+ * Either a stream copy (no encoder token, no `-b:a`) or an encode carrying an explicit,
+ * encoder-legal `-b:a` — ffmpeg's implicit default bitrate is unreachable from every path.
+ * The emitted value is a REQUEST: the encoder may normalize it further, which this module
+ * neither predicts nor observes.
+ */
+export function resolveEncodeStrategy(input: EncodeStrategyInput): EncodeStrategy {
+  const { outputFormat, sources } = input;
+  const { targetKbps, notices } = resolveTargetBitrate(input.targetBitrateKbps);
+
+  // A usable explicit target always re-encodes, regardless of source codec.
+  if (targetKbps === undefined && isCopyEligible(outputFormat, sources)) {
+    return { mode: 'copy', notices };
+  }
+
+  const codec = outputFormat === 'm4b' ? 'aac' : 'libmp3lame';
+  const probes = sources.map((s) => s.bitrateKbps).filter(isUsableBitrateKbps);
+  const hint = isUsableBitrateKbps(input.hintBitrateKbps) ? input.hintBitrateKbps : undefined;
+  const highestProbe = probes.length > 0 ? Math.max(...probes) : undefined;
+  // Arithmetic, not prose: with no hint or no probe maximum there is no left or right operand,
+  // so the predicate is false. A tie is false too — the request is the same either way, so the
+  // result cannot depend on which origin an iteration order happened to tag.
+  if (hint !== undefined && highestProbe !== undefined && hint > highestProbe) {
+    notices.push({
+      kind: 'hint-overrode-probes',
+      from: hint,
+      to: highestProbe,
+      message: `Stored source bitrate ${hint} kbps exceeds every probed part (highest ${highestProbe} kbps) and was used as the request.`,
+    });
+  }
+
+  // No precedence ladder: whichever value is higher wins. Over-estimating a source wastes
+  // bytes; under-estimating destroys audio irreversibly.
+  const evidence = hint === undefined ? probes : [...probes, hint];
+  const resolvedSource = evidence.length > 0 ? Math.max(...evidence) : undefined;
+
+  let requested: number;
+  if (targetKbps !== undefined) {
+    requested = resolvedSource !== undefined && resolvedSource < targetKbps
+      ? recordStep(notices, 'evidence-cap', targetKbps, resolvedSource, targetKbps)
+      : targetKbps;
+  } else if (resolvedSource !== undefined) {
+    requested = resolvedSource;
+  } else {
+    requested = KEEP_ORIGINAL_FALLBACK_BITRATE_KBPS;
+    notices.push({
+      kind: 'no-usable-evidence',
+      bitrateKbps: requested,
+      message: `No usable source bitrate evidence — requesting the ${requested} kbps default.`,
+    });
+  }
+
+  return {
+    mode: 'encode',
+    codec,
+    bitrateKbps: legalize(codec, requested, sources, notices, targetKbps),
+    notices,
+  };
+}
+
+/** The operator-visible lines for a resolved strategy, in chain order. */
+export function noticeMessages(notices: EncodeNotice[]): string[] {
+  return notices.map((n) => n.message);
+}
+
+/**
+ * The codec arguments for one command. Exactly one of `-c:a copy` or
+ * `-c:a <encoder> -b:a <n>k` — an encoder token is never emitted without a bitrate.
+ */
+export function buildCodecArgs(strategy: EncodeStrategy): string[] {
+  return strategy.mode === 'copy'
+    ? ['-c:a', 'copy']
+    : ['-c:a', strategy.codec, '-b:a', `${strategy.bitrateKbps}k`];
+}
+
+/**
+ * Probe every source for this command and normalize to the resolver's kbps evidence type.
+ *
+ * Reuses `getFFprobeStreamInfo` unchanged (sanitized env, 10 s timeout, graceful null). This
+ * is the single place a probe's bps bitrate becomes kbps — nothing downstream divides again.
+ */
+export async function collectSourceEvidence(
+  ffmpegPath: string,
+  filePaths: string[],
+): Promise<SourceEvidence[]> {
+  const ffprobePath = deriveFfprobePath(ffmpegPath);
+  const evidence: SourceEvidence[] = [];
+  for (const filePath of filePaths) {
+    const info = await getFFprobeStreamInfo(ffprobePath, filePath);
+    const source: SourceEvidence = { extension: extname(filePath).toLowerCase() };
+    if (info) {
+      source.codec = info.codec.toLowerCase();
+      if (info.bitrate !== undefined) source.bitrateKbps = Math.floor(info.bitrate / 1000);
+      if (info.sampleRate !== undefined) source.sampleRate = info.sampleRate;
+      if (info.channels !== undefined) source.channels = info.channels;
+    }
+    evidence.push(source);
+  }
+  return evidence;
+}
+
+/** A one-line diagnostic naming the decision this module made (never what the encoder achieved). */
+function describeStrategy(strategy: EncodeStrategy): string {
+  return strategy.mode === 'copy'
+    ? 'Encode strategy: stream copy (no re-encode).'
+    : `Encode strategy: re-encode with ${strategy.codec} at a requested ${strategy.bitrateKbps} kbps.`;
+}
+
+/**
+ * The seam both processor paths call, once per constructed command: probe, resolve, drain the
+ * resolver's notices into the caller's accumulator (in command order), and return the codec
+ * arguments. Callers never re-derive a resolver predicate to reconstruct a diagnostic.
+ */
+export async function resolveCodecArgs(
+  config: {
+    ffmpegPath: string;
+    outputFormat: 'm4b' | 'mp3';
+    bitrate?: number | undefined;
+    sourceBitrateKbps?: number | undefined;
+  },
+  filePaths: string[],
+  warnings: string[],
+  onStderr?: ((line: string) => void) | undefined,
+): Promise<string[]> {
+  const sources = await collectSourceEvidence(config.ffmpegPath, filePaths);
+  const strategy = resolveEncodeStrategy({
+    outputFormat: config.outputFormat,
+    targetBitrateKbps: config.bitrate,
+    hintBitrateKbps: config.sourceBitrateKbps,
+    sources,
+  });
+  for (const message of noticeMessages(strategy.notices)) {
+    warnings.push(message);
+    onStderr?.(message);
+  }
+  onStderr?.(describeStrategy(strategy));
+  return buildCodecArgs(strategy);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -87,6 +87,20 @@ export const books = sqliteTable('books', {
   // candidate query can cap unresolvable rows (they rest as terminal `failed`,
   // recoverable via manual Fix Match which resets the row to `pending`).
   enrichmentAttempts: integer('enrichment_attempts').notNull().default(0),
+  // Operator-asserted absences (#2069) — a JSON-encoded array of the clearable
+  // field names the operator explicitly emptied through Edit Metadata, so
+  // fill-empty enrichment and the provider display fallback can tell "deliberately
+  // removed" from "never had a value". SQL NULL means "no tombstones".
+  //
+  // Declared PLAIN TEXT, deliberately NOT `{ mode: 'json' }`: Drizzle's JSON-mode
+  // mapper `JSON.parse`s unconditionally inside the driver, so one corrupt row
+  // would throw on EVERY whole-row `books` select (download/quality-gate/discovery
+  // included), not just the readers that care. Keeping the value inert until a
+  // reader opts in is the same shape `import_jobs.phase_history` uses; the only
+  // behavioral reader is `parseClearedFields` (src/server/utils/cleared-fields.ts),
+  // which warn-and-degrades. Every in-app write goes through
+  // `serializeClearedFields` (canonical: sorted, deduped, empty set → NULL).
+  userClearedFields: text('user_cleared_fields'),
   path: text('path'),
   size: integer('size'),
   // Audio technical info (populated by file-based enrichment)

--- a/src/db/user-cleared-fields-schema.integration.test.ts
+++ b/src/db/user-cleared-fields-schema.integration.test.ts
@@ -1,0 +1,635 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { eq, sql } from 'drizzle-orm';
+import type { FastifyBaseLogger } from 'fastify';
+import { createDb, runMigrations, type Db } from './index.js';
+import { books, bookNarrators, series, seriesMembers, unmatchedGenres } from './schema.js';
+import { generatePublicId } from '../server/utils/public-id.js';
+import { BookService } from '../server/services/book.service.js';
+import { runEnrichment } from '../server/jobs/enrichment.js';
+import { applyAudnexusEnrichment } from '../server/services/enrichment-orchestration.helpers.js';
+import type { MetadataService } from '../server/services/metadata.service.js';
+
+// Real-DB coverage for `books.user_cleared_fields` (#2069). These cases CANNOT be
+// pure unit tests: a parser unit test feeds the parser a string directly and so
+// never crosses the driver-decode boundary AC1 exists to avoid. Everything below
+// inserts the raw column value with raw SQL into a migrated database and then
+// exercises the real read/write paths.
+//
+// The suite also proves the column survives migrate-from-scratch: `runMigrations`
+// builds the schema from an empty file, and every assertion goes through Drizzle
+// rather than raw DDL strings.
+
+function createLog(): FastifyBaseLogger {
+  return {
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    trace: vi.fn(), fatal: vi.fn(), child: vi.fn().mockReturnThis(),
+    level: 'debug', silent: vi.fn(),
+  } as unknown as FastifyBaseLogger;
+}
+
+describe('books.user_cleared_fields — persisted shape (DB-backed, #2069)', () => {
+  let dir: string;
+  let db: Db;
+  let log: FastifyBaseLogger;
+  let bookService: BookService;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'cleared-fields-'));
+    const dbFile = join(dir, 'narratorr.db');
+    await runMigrations(dbFile);
+    db = createDb(dbFile);
+    log = createLog();
+    bookService = new BookService(db, log);
+  });
+
+  afterEach(() => {
+    db.$client.close();
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  async function seedBook(overrides?: Partial<typeof books.$inferInsert>): Promise<number> {
+    const [row] = await db
+      .insert(books)
+      .values({
+        publicId: generatePublicId('bk'),
+        title: 'Tress of the Emerald Sea',
+        status: 'imported',
+        ...overrides,
+      })
+      .returning();
+    return row!.id;
+  }
+
+  /** Write the column OUT OF BAND, the only way it can become non-canonical. */
+  async function writeRawColumn(bookId: number, raw: string): Promise<void> {
+    await db.run(sql`UPDATE books SET user_cleared_fields = ${raw} WHERE id = ${bookId}`);
+  }
+
+  async function readRawColumn(bookId: number): Promise<string | null> {
+    const rows = await db.select({ raw: books.userClearedFields }).from(books).where(eq(books.id, bookId));
+    return rows[0]!.raw;
+  }
+
+  /**
+   * A scheduled enrichment pass over a single `pending` candidate whose provider
+   * result fills every clearable scalar. Returns nothing — assert on the row.
+   */
+  async function runOneEnrichmentPass(): Promise<void> {
+    const metadataService = {
+      resolveBook: vi.fn().mockResolvedValue({
+        title: 'Tress of the Emerald Sea',
+        authors: [{ name: 'Brandon Sanderson' }],
+        subtitle: 'A Cosmere Novel',
+        description: 'Provider description',
+        publisher: 'Dragonsteel',
+        publishedDate: '2023-01-10',
+        genres: ['Fantasy'],
+        seriesPrimary: { name: 'Secret Projects', position: 1 },
+        duration: 600,
+      }),
+    } as unknown as MetadataService;
+    await runEnrichment(db, metadataService, bookService, log);
+  }
+
+  describe('AC1 — the column is inert plain text', () => {
+    it('accepts a syntactically invalid value and still hydrates the book through getById', async () => {
+      const bookId = await seedBook();
+      await writeRawColumn(bookId, '{oops');
+
+      const book = await bookService.getById(bookId);
+
+      expect(book).not.toBeNull();
+      expect(book!.userClearedFields).toEqual([]);
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ bookId }),
+        expect.stringContaining('Unparseable userClearedFields'),
+      );
+    });
+
+    it('lets an internal whole-row consumer select the same invalid row without throwing', async () => {
+      // This is the guard that the PLAIN-TEXT column — not the parser — is what keeps
+      // one corrupt row from breaking unrelated queries. A `{ mode: 'json' }` column
+      // would `JSON.parse` in Drizzle's driver mapper and throw here, on a query that
+      // has nothing to do with tombstones (quality gate, discovery, download service).
+      const bookId = await seedBook();
+      await writeRawColumn(bookId, '{oops');
+
+      const rows = await db.select().from(books).where(eq(books.id, bookId));
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.userClearedFields).toBe('{oops');
+    });
+
+    it('a scheduled enrichment pass over the invalid row completes normally', async () => {
+      const bookId = await seedBook({ asin: 'B0BXXXXXXX' });
+      await writeRawColumn(bookId, '{oops');
+
+      await runOneEnrichmentPass();
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.enrichmentStatus).toBe('enriched');
+      // Degraded to "no tombstones", so every fill lands.
+      expect(row!.publisher).toBe('Dragonsteel');
+      expect(row!.seriesName).toBe('Secret Projects');
+    });
+  });
+
+  describe('AC4 — a sanitizing read, with the rest of the write still landing', () => {
+    it('recognized-plus-unknown suppresses only the recognized field and does not strand the row', async () => {
+      const bookId = await seedBook({ asin: 'B0BYYYYYYY' });
+      await writeRawColumn(bookId, '["genres","futureField"]');
+
+      await runOneEnrichmentPass();
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.genres).toBeNull();
+      expect(row!.enrichmentStatus).toBe('enriched');
+      expect(row!.publisher).toBe('Dragonsteel');
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ bookId, dropped: ['futureField'] }),
+        expect.stringContaining('Unknown userClearedFields'),
+      );
+    });
+
+    it('a non-canonical but valid value is sanitized on read and the write otherwise proceeds', async () => {
+      const bookId = await seedBook({ asin: 'B0BZZZZZZZ' });
+      await writeRawColumn(bookId, '["subtitle","genres","subtitle"]');
+
+      await runOneEnrichmentPass();
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.subtitle).toBeNull();
+      expect(row!.genres).toBeNull();
+      expect(row!.publisher).toBe('Dragonsteel');
+      expect(row!.enrichmentStatus).toBe('enriched');
+    });
+  });
+
+  describe('AC3 — canonical stored form after an in-app write', () => {
+    it('stores the set sorted and deduplicated', async () => {
+      const bookId = await seedBook();
+
+      await bookService.update(bookId, { subtitle: null, genres: null, publisher: null }, { userAsserted: true });
+
+      expect(await readRawColumn(bookId)).toBe('["genres","publisher","subtitle"]');
+    });
+
+    it('normalizes a non-canonical stored value on the next in-app write', async () => {
+      const bookId = await seedBook();
+      await writeRawColumn(bookId, '["subtitle","genres","subtitle"]');
+
+      await bookService.update(bookId, { publisher: null }, { userAsserted: true });
+
+      expect(await readRawColumn(bookId)).toBe('["genres","publisher","subtitle"]');
+    });
+
+    it('persists the empty set as SQL NULL, never "[]"', async () => {
+      const bookId = await seedBook();
+      await bookService.update(bookId, { seriesName: null }, { userAsserted: true });
+      expect(await readRawColumn(bookId)).toBe('["seriesName"]');
+
+      await bookService.update(bookId, { seriesName: 'Mistborn' }, { userAsserted: true });
+
+      const raw = await readRawColumn(bookId);
+      expect(raw).toBeNull();
+      expect(raw).not.toBe('[]');
+    });
+  });
+
+  describe('AC7 — blank input normalizes the stored value', () => {
+    it("stores NULL (not '') for a whitespace-only publisher and records the tombstone", async () => {
+      const bookId = await seedBook({ publisher: 'Tor' });
+
+      await bookService.update(bookId, { publisher: '   ' }, { userAsserted: true });
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.publisher).toBeNull();
+      expect(row!.userClearedFields).toBe('["publisher"]');
+    });
+
+    it('drops blank genre elements and removes the tombstone', async () => {
+      const bookId = await seedBook();
+      await writeRawColumn(bookId, '["genres"]');
+
+      await bookService.update(bookId, { genres: ['Fantasy', '  ', 'Epic'] }, { userAsserted: true });
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.genres).toEqual(['Fantasy', 'Epic']);
+      expect(row!.userClearedFields).toBeNull();
+    });
+
+    it('an internal (non-userAsserted) caller keeps verbatim behavior and touches no tombstone', async () => {
+      const bookId = await seedBook({ publisher: 'Tor' });
+
+      await bookService.update(bookId, { publisher: '' });
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.publisher).toBe('');
+      expect(row!.userClearedFields).toBeNull();
+    });
+  });
+
+  describe('AC14 — series membership residue', () => {
+    async function seedSeriesWithMember(bookId: number, source: 'local' | 'hardcover'): Promise<number> {
+      const [seriesRow] = await db
+        .insert(series)
+        .values({ publicId: generatePublicId('sr'), name: 'The Cosmere', normalizedName: 'the cosmere' })
+        .returning();
+      const [member] = await db
+        .insert(seriesMembers)
+        .values({
+          seriesId: seriesRow!.id,
+          bookId,
+          title: 'Tress of the Emerald Sea',
+          normalizedTitle: 'tress of the emerald sea',
+          position: 29,
+          source,
+          ...(source === 'hardcover' ? { hardcoverBookId: 4242 } : {}),
+        })
+        .returning();
+      return member!.id;
+    }
+
+    it("deletes a 'local' member row when the operator clears seriesName", async () => {
+      const bookId = await seedBook({ seriesName: 'The Cosmere' });
+      const memberId = await seedSeriesWithMember(bookId, 'local');
+
+      await bookService.update(bookId, { seriesName: null, seriesPosition: null }, { userAsserted: true });
+
+      const remaining = await db.select().from(seriesMembers).where(eq(seriesMembers.id, memberId));
+      expect(remaining).toHaveLength(0);
+    });
+
+    it("keeps a 'hardcover' member row and only nulls its book link", async () => {
+      const bookId = await seedBook({ seriesName: 'The Cosmere' });
+      const memberId = await seedSeriesWithMember(bookId, 'hardcover');
+
+      await bookService.update(bookId, { seriesName: null, seriesPosition: null }, { userAsserted: true });
+
+      const [member] = await db.select().from(seriesMembers).where(eq(seriesMembers.id, memberId));
+      expect(member).toBeDefined();
+      expect(member!.bookId).toBeNull();
+      expect(member!.hardcoverBookId).toBe(4242);
+      expect(member!.title).toBe('Tress of the Emerald Sea');
+    });
+
+    it('does NOT reconcile membership when the same PUT sets a series instead of clearing it', async () => {
+      const bookId = await seedBook({ seriesName: 'The Cosmere' });
+      const memberId = await seedSeriesWithMember(bookId, 'local');
+
+      await bookService.update(bookId, { seriesName: 'Mistborn' }, { userAsserted: true });
+
+      const remaining = await db.select().from(seriesMembers).where(eq(seriesMembers.id, memberId));
+      expect(remaining).toHaveLength(1);
+    });
+
+    it('an internal caller passing seriesName: null leaves membership and tombstones alone', async () => {
+      const bookId = await seedBook({ seriesName: 'The Cosmere' });
+      const memberId = await seedSeriesWithMember(bookId, 'local');
+
+      await bookService.update(bookId, { seriesName: null });
+
+      const remaining = await db.select().from(seriesMembers).where(eq(seriesMembers.id, memberId));
+      expect(remaining).toHaveLength(1);
+      expect(await readRawColumn(bookId)).toBeNull();
+    });
+
+    it('rolls the clear back when membership reconciliation fails — no half-applied residue (F23)', async () => {
+      const bookId = await seedBook({ seriesName: 'The Cosmere', publisher: 'Tor' });
+      const memberId = await seedSeriesWithMember(bookId, 'local');
+
+      // Fail AFTER the book scalar/tombstone write, inside the same transaction.
+      const link = await import('../server/services/book-series-link.js');
+      const spy = vi.spyOn(link, 'detachBookFromSeriesMembers').mockRejectedValueOnce(new Error('reconcile boom'));
+
+      await expect(
+        bookService.update(bookId, { seriesName: null }, { userAsserted: true }),
+      ).rejects.toThrow('reconcile boom');
+      spy.mockRestore();
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.seriesName).toBe('The Cosmere');
+      expect(row!.userClearedFields).toBeNull();
+      const remaining = await db.select().from(seriesMembers).where(eq(seriesMembers.id, memberId));
+      expect(remaining).toHaveLength(1);
+    });
+  });
+
+  describe('AC11 / F20 / F21 — the caller-owned transaction arm, against a real DB', () => {
+    it('runs on the caller handle, reads its own uncommitted write, and commits with the owner', async () => {
+      const bookId = await seedBook({ publisher: 'Tor' });
+      const offHandleSelect = vi.spyOn(db, 'select');
+
+      const detail = await db.transaction(async (tx) => {
+        const inside = await bookService.update(bookId, { publisher: null }, { userAsserted: true, tx });
+        // The hydration read is ON the handle, so it observes the still-uncommitted
+        // write — a `this.db` read could not, and `db.transaction` nesting throws.
+        expect(inside!.publisher).toBeNull();
+        expect(inside!.userClearedFields).toEqual(['publisher']);
+        return inside;
+      });
+
+      expect(detail).not.toBeNull();
+      expect(offHandleSelect).not.toHaveBeenCalled();
+      offHandleSelect.mockRestore();
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.publisher).toBeNull();
+      expect(row!.userClearedFields).toBe('["publisher"]');
+    });
+
+    it('F21: an owner rollback strands no write, no success log, and no genre telemetry', async () => {
+      const bookId = await seedBook({ publisher: 'Tor' });
+
+      await expect(
+        db.transaction(async (tx) => {
+          await bookService.update(bookId, { publisher: null, genres: ['Zzzz Unmatched Genre'] }, { userAsserted: true, tx });
+          throw new Error('owner rolled back');
+        }),
+      ).rejects.toThrow('owner rolled back');
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.publisher).toBe('Tor');
+      expect(row!.userClearedFields).toBeNull();
+      expect(log.info).not.toHaveBeenCalledWith(expect.anything(), 'Book updated');
+      const tracked = await db.select().from(unmatchedGenres);
+      expect(tracked).toHaveLength(0);
+    });
+
+    it('the self-managed arm still returns the COMMITTED parsed detail', async () => {
+      const bookId = await seedBook();
+
+      const detail = await bookService.update(bookId, { seriesName: null }, { userAsserted: true });
+
+      expect(detail!.userClearedFields).toEqual(['seriesName']);
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.userClearedFields).toBe('["seriesName"]');
+    });
+  });
+
+  // ─── AC11 / F14: post-import atomicity, against a REAL migrated DB ───
+  //
+  // This proof cannot live in `enrichment-orchestration.helpers.test.ts`: there the
+  // root `db` and the transaction handle are the SAME mock object, so a regression
+  // that moved the scalar write BEFORE `db.transaction` produces identical
+  // observations (same update chain, one transaction call, same rejected promise).
+  // Only committed state distinguishes the two shapes — so the observation point is
+  // the row itself after the failure.
+  describe('AC11 / F14 — post-import atomicity, against a real DB', () => {
+    const providerData = { subtitle: 'A Cosmere Novel', publisher: 'Dragonsteel', genres: ['Fantasy'], narrators: ['Michael Kramer'] };
+
+    function enrichmentDeps(bookId: number, failOnGenres: boolean) {
+      const metadataService = {
+        enrichBook: vi.fn().mockResolvedValue(providerData),
+        resolveBook: vi.fn().mockResolvedValue(null),
+      } as unknown as MetadataService;
+
+      // Fail the GENRES write specifically — after the scalar write has been issued
+      // and after the narrator write has succeeded, so the failure lands squarely in
+      // the window the atomicity claim is about.
+      const realUpdate = bookService.update.bind(bookService);
+      vi.spyOn(bookService, 'update').mockImplementation(async (id, data, options) => {
+        if (failOnGenres && data && 'genres' in data) throw new Error('genre write boom');
+        return realUpdate(id, data, options);
+      });
+      void bookId;
+      return { db, log, bookService, metadataService };
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('leaves the row NOT enriched when the array write fails after the scalar write', async () => {
+      const bookId = await seedBook({ asin: 'B0BATOMIC1' });
+
+      await applyAudnexusEnrichment(
+        bookId,
+        { primaryAsin: 'B0BATOMIC1', existingNarrator: null, existingGenres: null, existingSubtitle: null, existingPublisher: null },
+        enrichmentDeps(bookId, true),
+      );
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      // The whole transaction rolled back: status did NOT advance, and neither did
+      // the scalar fills that were issued inside it. A row left at `enriched` with
+      // the later write missing would be permanently outside the scheduled
+      // candidate selector (which only picks pending/skipped/retryable-failed).
+      expect(row!.enrichmentStatus).toBe('pending');
+      expect(row!.subtitle).toBeNull();
+      expect(row!.publisher).toBeNull();
+      expect(row!.genres).toBeNull();
+      // The narrator write that SUCCEEDED inside the same transaction rolled back too.
+      const narratorLinks = await db.select().from(bookNarrators).where(eq(bookNarrators.bookId, bookId));
+      expect(narratorLinks).toHaveLength(0);
+    });
+
+    it('negative control: with no failure the same call commits everything', async () => {
+      const bookId = await seedBook({ asin: 'B0BATOMIC2' });
+
+      await applyAudnexusEnrichment(
+        bookId,
+        { primaryAsin: 'B0BATOMIC2', existingNarrator: null, existingGenres: null, existingSubtitle: null, existingPublisher: null },
+        enrichmentDeps(bookId, false),
+      );
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.enrichmentStatus).toBe('enriched');
+      expect(row!.subtitle).toBe('A Cosmere Novel');
+      expect(row!.publisher).toBe('Dragonsteel');
+      expect(row!.genres).toEqual(['Fantasy']);
+      const narratorLinks = await db.select().from(bookNarrators).where(eq(bookNarrators.bookId, bookId));
+      expect(narratorLinks).toHaveLength(1);
+    });
+
+    it('COUNTERFACTUAL: the same two writes in SEPARATE transactions strand an enriched row', async () => {
+      // The pre-#2069 shape, executed against this same DB so the defect is
+      // demonstrated rather than asserted about. If the production code ever
+      // regresses to two transactions, the first test above flips to this outcome.
+      const bookId = await seedBook({ asin: 'B0BSPLIT' });
+
+      await db.transaction(async (tx) => {
+        await tx.update(books)
+          .set({ enrichmentStatus: 'enriched', subtitle: 'A Cosmere Novel', updatedAt: new Date() })
+          .where(eq(books.id, bookId));
+      });
+      await expect(
+        db.transaction(async () => { throw new Error('genre write boom'); }),
+      ).rejects.toThrow('genre write boom');
+
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      // Exactly the stranding the single-transaction shape prevents: `enriched` with
+      // the later write missing, and now invisible to the scheduled selector.
+      expect(row!.enrichmentStatus).toBe('enriched');
+      expect(row!.genres).toBeNull();
+    });
+  });
+
+  // ─── F21 / F5: the DEFERRED unmatched-genre telemetry, against a real DB ───
+  //
+  // `bookService.update`'s caller-owned-tx arm emits no post-commit side effects,
+  // so a rollback cannot strand them — which makes running the telemetry the
+  // OWNER's job, after its own commit. Before #2069 both genre-fill paths used the
+  // self-managed arm and recorded unmatched genres; the deferred hand-back restores
+  // that. `unmatched_genres` is the observation point, so these see the committed
+  // effect rather than a call on a mock.
+  describe('F21 / F5 — enrichment owners resume genre telemetry after commit', () => {
+    /** Survives `normalizeGenres` and is in no synonym/known list, so it lands. */
+    const UNMATCHED = 'Zzzz Unmatched Genre';
+
+    async function readTrackedGenres(): Promise<string[]> {
+      return (await db.select().from(unmatchedGenres)).map((r) => r.genre);
+    }
+
+    /** A scheduled pass whose provider result carries the unmatched genre. */
+    async function runScheduledPass(): Promise<void> {
+      const metadataService = {
+        resolveBook: vi.fn().mockResolvedValue({
+          title: 'Tress of the Emerald Sea',
+          authors: [{ name: 'Brandon Sanderson' }],
+          genres: [UNMATCHED],
+        }),
+      } as unknown as MetadataService;
+      await runEnrichment(db, metadataService, bookService, log);
+    }
+
+    async function runPostImportPass(bookId: number, asin: string): Promise<void> {
+      const metadataService = {
+        enrichBook: vi.fn().mockResolvedValue({ genres: [UNMATCHED] }),
+        resolveBook: vi.fn().mockResolvedValue(null),
+      } as unknown as MetadataService;
+      await applyAudnexusEnrichment(
+        bookId,
+        { primaryAsin: asin, existingNarrator: 'Someone', existingGenres: null },
+        { db, log, bookService, metadataService },
+      );
+    }
+
+    it('scheduled: a committed genre fill records the unmatched genre', async () => {
+      const bookId = await seedBook({ asin: 'B0BGENRE01' });
+
+      await runScheduledPass();
+
+      expect(await readTrackedGenres()).toEqual([UNMATCHED]);
+      // The write it is telemetry FOR actually landed — so this is not recording a
+      // fill that never happened.
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.genres).toEqual([UNMATCHED]);
+    });
+
+    it('scheduled: a TOMBSTONED genre fill is suppressed, so nothing is recorded', async () => {
+      const bookId = await seedBook({ asin: 'B0BGENRE02' });
+      await writeRawColumn(bookId, '["genres"]');
+
+      await runScheduledPass();
+
+      expect(await readTrackedGenres()).toEqual([]);
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.genres).toBeNull();
+      // …while the pass itself still succeeded, so the empty table is about the
+      // suppressed write, not a failed run.
+      expect(row!.enrichmentStatus).toBe('enriched');
+    });
+
+    it('scheduled: a stale-dropped candidate records nothing', async () => {
+      const bookId = await seedBook({ asin: 'B0BGENRE03' });
+      // A Fix Match commits during the provider fetch, so the write transaction
+      // aborts on its identity re-read.
+      const metadataService = {
+        resolveBook: vi.fn().mockImplementation(async () => {
+          await db.update(books).set({ asin: 'B0BREIDENT' }).where(eq(books.id, bookId));
+          return { title: 'Tress of the Emerald Sea', authors: [], genres: [UNMATCHED] };
+        }),
+      } as unknown as MetadataService;
+
+      await runEnrichment(db, metadataService, bookService, log);
+
+      expect(await readTrackedGenres()).toEqual([]);
+    });
+
+    it('post-import: a committed genre fill records the unmatched genre', async () => {
+      const bookId = await seedBook({ asin: 'B0BGENRE04' });
+
+      await runPostImportPass(bookId, 'B0BGENRE04');
+
+      expect(await readTrackedGenres()).toEqual([UNMATCHED]);
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.genres).toEqual([UNMATCHED]);
+    });
+
+    it('post-import: a TOMBSTONED genre fill is suppressed, so nothing is recorded', async () => {
+      const bookId = await seedBook({ asin: 'B0BGENRE05' });
+      await writeRawColumn(bookId, '["genres"]');
+
+      await runPostImportPass(bookId, 'B0BGENRE05');
+
+      expect(await readTrackedGenres()).toEqual([]);
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.genres).toBeNull();
+      expect(row!.enrichmentStatus).toBe('enriched');
+    });
+
+    it('post-import: a rolled-back transaction records nothing (the effect is DEFERRED, not pre-commit)', async () => {
+      const bookId = await seedBook({ asin: 'B0BGENRE06' });
+      // Fail the narrators write, which runs BEFORE the genres write inside the same
+      // transaction — so the genre write is issued-then-rolled-back rather than never
+      // attempted, which is the case a pre-commit effect would leak on.
+      const realUpdate = bookService.update.bind(bookService);
+      vi.spyOn(bookService, 'update').mockImplementation(async (id, data, options) => {
+        if (data && 'narrators' in data) throw new Error('narrator write boom');
+        return realUpdate(id, data, options);
+      });
+
+      const metadataService = {
+        enrichBook: vi.fn().mockResolvedValue({ genres: [UNMATCHED], narrators: ['Michael Kramer'] }),
+        resolveBook: vi.fn().mockResolvedValue(null),
+      } as unknown as MetadataService;
+      await applyAudnexusEnrichment(
+        bookId,
+        { primaryAsin: 'B0BGENRE06', existingNarrator: null, existingGenres: null },
+        { db, log, bookService, metadataService },
+      );
+      vi.restoreAllMocks();
+
+      expect(await readTrackedGenres()).toEqual([]);
+      const [row] = await db.select().from(books).where(eq(books.id, bookId));
+      expect(row!.enrichmentStatus).toBe('pending');
+      expect(row!.genres).toBeNull();
+    });
+
+    it('the operator-facing self-managed PUT arm still records genres itself', async () => {
+      // The wrapper keeps owning its own post-commit effects — the deferred hand-back
+      // is only for callers that supply a transaction.
+      const bookId = await seedBook();
+
+      await bookService.update(bookId, { genres: [UNMATCHED] }, { userAsserted: true });
+
+      expect(await readTrackedGenres()).toEqual([UNMATCHED]);
+    });
+  });
+
+  describe('AC16 — the hydrated detail exposes the parsed set', () => {
+    it('returns [] for a NULL column and the parsed array for a populated one', async () => {
+      const emptyId = await seedBook();
+      const setId = await seedBook({ title: 'Other' });
+      await writeRawColumn(setId, '["genres","seriesName"]');
+
+      expect((await bookService.getById(emptyId))!.userClearedFields).toEqual([]);
+      expect((await bookService.getById(setId))!.userClearedFields).toEqual(['genres', 'seriesName']);
+    });
+
+    it('update() echoes the recomputed set back as a parsed array', async () => {
+      const bookId = await seedBook();
+
+      const updated = await bookService.update(bookId, { seriesName: null }, { userAsserted: true });
+
+      expect(updated!.userClearedFields).toEqual(['seriesName']);
+    });
+  });
+});

--- a/src/server/__tests__/factories.ts
+++ b/src/server/__tests__/factories.ts
@@ -39,6 +39,7 @@ export function createMockDbBook(overrides?: Record<string, unknown>) {
     productionType: 'unknown' as const,
     editionLabel: null as string | null,
     enrichmentAttempts: 0,
+    userClearedFields: null as string | null,
     path: null as string | null,
     size: null as number | null,
     audioCodec: null as string | null,

--- a/src/server/__tests__/metadata-clear-flow.e2e.test.ts
+++ b/src/server/__tests__/metadata-clear-flow.e2e.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { createE2EApp, type E2EApp } from './e2e-helpers.js';
+import { books } from '@db/schema.js';
+import { generatePublicId } from '../utils/public-id.js';
+import { runEnrichment } from '../jobs/enrichment.js';
+import type { MetadataService } from '../services/metadata.service.js';
+
+/**
+ * The SERVER half of the #2069 provider-only clear workflow (AC20/AC22/AC25), end
+ * to end through the real Fastify app, the real services, and a real migrated DB.
+ *
+ * The fixture is the exact state the issue names as the common case and the reason
+ * the feature exists: a post-import book sitting at `enrichmentStatus: 'enriched'`
+ * with `series_name = NULL` forever, whose series the operator only ever sees as a
+ * provider fallback. `applyEnrichmentData` writes `enriched` while writing no series
+ * field, and the scheduled selector only picks pending/skipped/retryable-failed — so
+ * nothing ever revisits the row.
+ *
+ * The client half — modal pre-fill, the payload this suite consumes, cache
+ * invalidation and the refetched header — is
+ * `src/client/pages/book/metadata-clear-flow.test.tsx`. The two meet at the PUT
+ * payload, which both sides assert on literally (`{ seriesName: null }`), so a
+ * change on either side of that seam breaks a test rather than silently diverging.
+ * They cannot be one test: client suites run in jsdom and server suites in node.
+ */
+describe('Provider-only metadata clear — server E2E (#2069)', () => {
+  let e2e: E2EApp;
+
+  beforeEach(async () => {
+    e2e = await createE2EApp();
+  });
+
+  afterEach(async () => {
+    await e2e.cleanup();
+  });
+
+  /** A book in the exact "enriched, no stored series, provider-only display" state. */
+  async function seedEnrichedProviderOnlyBook(): Promise<number> {
+    const [row] = await e2e.db
+      .insert(books)
+      .values({
+        publicId: generatePublicId('bk'),
+        title: 'Tress of the Emerald Sea',
+        status: 'imported',
+        // The state that makes the clear inexpressible without AC25: already
+        // `enriched`, so no future pass revisits it, and no stored series.
+        enrichmentStatus: 'enriched',
+        seriesName: null,
+        seriesPosition: null,
+        asin: 'B0BTRESS01',
+      })
+      .returning();
+    return row!.id;
+  }
+
+  async function readRow(bookId: number) {
+    const [row] = await e2e.db.select().from(books).where(eq(books.id, bookId));
+    return row!;
+  }
+
+  /** One scheduled enrichment pass whose provider result carries the series. */
+  async function runEnrichmentPass(): Promise<void> {
+    const metadataService = {
+      resolveBook: vi.fn().mockResolvedValue({
+        title: 'Tress of the Emerald Sea',
+        authors: [{ name: 'Brandon Sanderson' }],
+        seriesPrimary: { name: 'Secret Projects', position: 1 },
+        publisher: 'Dragonsteel',
+      }),
+    } as unknown as MetadataService;
+    await runEnrichment(e2e.db, metadataService, e2e.services.book, e2e.app.log);
+  }
+
+  it('PUT { seriesName: null } persists the tombstone and echoes the parsed set', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+
+    // The EXACT payload the modal emits for a provider-only clear — see the client
+    // half's assertion on `onSave`.
+    const res = await e2e.app.inject({
+      method: 'PUT',
+      url: `/api/books/${bookId}`,
+      payload: { seriesName: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().userClearedFields).toEqual(['seriesName']);
+    const row = await readRow(bookId);
+    expect(row.userClearedFields).toBe('["seriesName"]');
+    expect(row.seriesName).toBeNull();
+  });
+
+  it('GET /api/books/:id returns the parsed array and never the raw string', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+    await e2e.app.inject({ method: 'PUT', url: `/api/books/${bookId}`, payload: { seriesName: null } });
+
+    const res = await e2e.app.inject({ method: 'GET', url: `/api/books/${bookId}` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().userClearedFields).toEqual(['seriesName']);
+    // The stored form must not appear anywhere in the serialized body.
+    expect(res.payload).not.toContain('"[\\"seriesName\\"]"');
+  });
+
+  it('the series card resolves to null once the clear is persisted', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+    await e2e.app.inject({ method: 'PUT', url: `/api/books/${bookId}`, payload: { seriesName: null } });
+
+    const res = await e2e.app.inject({ method: 'GET', url: `/api/books/${bookId}/series` });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().series).toBeNull();
+  });
+
+  it('AC20: a full enrichment cycle after the clear does NOT resurrect the provider series', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+    await e2e.app.inject({ method: 'PUT', url: `/api/books/${bookId}`, payload: { seriesName: null } });
+    // The clear resets nothing about enrichment, so make the row a candidate the way
+    // a real re-pick/refresh would.
+    await e2e.db.update(books).set({ enrichmentStatus: 'pending' }).where(eq(books.id, bookId));
+
+    await runEnrichmentPass();
+
+    const row = await readRow(bookId);
+    expect(row.seriesName).toBeNull();
+    expect(row.seriesPosition).toBeNull();
+    expect(row.userClearedFields).toBe('["seriesName"]');
+    // The pass still ran and still filled everything untombstoned.
+    expect(row.enrichmentStatus).toBe('enriched');
+    expect(row.publisher).toBe('Dragonsteel');
+  });
+
+  it('AC21 control: an untouched book DOES get its series filled by the same pass', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+    await e2e.db.update(books).set({ enrichmentStatus: 'pending' }).where(eq(books.id, bookId));
+
+    await runEnrichmentPass();
+
+    const row = await readRow(bookId);
+    expect(row.seriesName).toBe('Secret Projects');
+    expect(row.seriesPosition).toBe(1);
+  });
+
+  it('AC22: setting a new series removes the tombstone and enrichment treats it normally again', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+    await e2e.app.inject({ method: 'PUT', url: `/api/books/${bookId}`, payload: { seriesName: null } });
+
+    const res = await e2e.app.inject({
+      method: 'PUT',
+      url: `/api/books/${bookId}`,
+      payload: { seriesName: 'Cosmere', seriesPosition: 3 },
+    });
+
+    expect(res.json().userClearedFields).toEqual([]);
+    const row = await readRow(bookId);
+    expect(row.userClearedFields).toBeNull();
+    expect(row.seriesName).toBe('Cosmere');
+  });
+
+  // #2069 AC16 / F4 — the list endpoint's raw-column projection, at the route.
+  // `GET /api/books` declares no response schema, so nothing downstream strips
+  // extra keys; `BookListService.getAll` spreads whole rows and casts, and the cast
+  // is erased at runtime. Only a seeded row proves the strip happened.
+  it('GET /api/books never serializes the raw tombstone column', async () => {
+    const bookId = await seedEnrichedProviderOnlyBook();
+    await e2e.app.inject({ method: 'PUT', url: `/api/books/${bookId}`, payload: { seriesName: null } });
+    // Confirm the row really does carry a stored value, so absence below is a strip
+    // and not an empty column.
+    expect((await readRow(bookId)).userClearedFields).toBe('["seriesName"]');
+
+    const res = await e2e.app.inject({ method: 'GET', url: '/api/books' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.payload).not.toContain('userClearedFields');
+    const [listed] = res.json().data as Record<string, unknown>[];
+    expect(listed).toBeDefined();
+    expect('userClearedFields' in listed!).toBe(false);
+    expect(listed!.title).toBe('Tress of the Emerald Sea');
+  });
+});

--- a/src/server/jobs/enrichment.test.ts
+++ b/src/server/jobs/enrichment.test.ts
@@ -27,13 +27,13 @@ function whereParams(expr: unknown): unknown[] {
 describe('enrichment job', () => {
   let db: ReturnType<typeof createMockDb>;
   let metadataService: { resolveBook: ReturnType<typeof vi.fn> };
-  let bookService: { update: ReturnType<typeof vi.fn>; findAsinCollision: ReturnType<typeof vi.fn> };
+  let bookService: { update: ReturnType<typeof vi.fn>; findAsinCollision: ReturnType<typeof vi.fn>; trackUnmatchedGenres: ReturnType<typeof vi.fn> };
   let log: ReturnType<typeof createMockLogger>;
 
   beforeEach(() => {
     db = createMockDb();
     metadataService = { resolveBook: vi.fn().mockResolvedValue(null) };
-    bookService = { update: vi.fn().mockResolvedValue(null), findAsinCollision: vi.fn().mockResolvedValue(null) };
+    bookService = { update: vi.fn().mockResolvedValue(null), findAsinCollision: vi.fn().mockResolvedValue(null), trackUnmatchedGenres: vi.fn().mockResolvedValue(undefined) };
     log = createMockLogger();
   });
 
@@ -80,7 +80,7 @@ describe('enrichment job', () => {
       .mockReturnValueOnce(mockDbChain([{ duration: null, genres: null, title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]));  // existing book fields
 
     metadataService.resolveBook.mockResolvedValueOnce(enrichedData);
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -122,7 +122,7 @@ describe('enrichment job', () => {
       .mockReturnValueOnce(mockDbChain([{ duration: 1234, genres: null, title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]));  // existing
 
     metadataService.resolveBook.mockResolvedValueOnce(enrichedData);
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -155,7 +155,7 @@ describe('enrichment job', () => {
       narrators: ['Jim Dale'],
       // no duration field
     });
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -176,7 +176,7 @@ describe('enrichment job', () => {
       duration: 480,
       // no narrators field
     });
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -197,7 +197,7 @@ describe('enrichment job', () => {
       narrators: [],  // empty array — should not set narrator
       duration: 300,
     });
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -212,7 +212,7 @@ describe('enrichment job', () => {
     db.select
       .mockReturnValueOnce(mockDbChain([]));  // candidates (empty)
 
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -231,7 +231,7 @@ describe('enrichment job', () => {
       // narrators key entirely absent → undefined
       duration: 600,
     });
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -254,7 +254,7 @@ describe('enrichment job', () => {
       narrators: ['Some Narrator'],
       duration: 500,
     });
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -278,7 +278,7 @@ describe('enrichment job', () => {
       narrators: undefined,
       duration: undefined,
     });
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -309,7 +309,7 @@ describe('enrichment job', () => {
       .mockRejectedValueOnce(new RateLimitError(30000, 'Audnexus'));
 
     db.select.mockReturnValueOnce(mockDbChain([{ duration: null, genres: null, title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]));  // existing book fields for book 1
-    db.update.mockReturnValue(mockDbChain());
+    db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
     await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -336,7 +336,7 @@ describe('enrichment job', () => {
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'Book', authors: [{ name: 'Author' }], duration: 600,
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -356,7 +356,7 @@ describe('enrichment job', () => {
         narrators: ['Jim Dale'],
         duration: 600,
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
       db.insert.mockReturnValue(mockDbChain([]));
       // narrator lookup: no existing narrators
       db.select.mockReturnValueOnce(mockDbChain([]));
@@ -381,7 +381,7 @@ describe('enrichment job', () => {
         narrators: ['Failing Narrator', 'Good Narrator'],
         duration: 600,
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       // narrator lookup: no existing narrators in junction table
       db.select.mockReturnValueOnce(mockDbChain([]));
@@ -426,34 +426,34 @@ describe('enrichment job', () => {
       db.select
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_GENRE' }]))  // candidates
         .mockReturnValueOnce(mockDbChain([{ duration: 600, genres: null, title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]))  // existing: genres null
-        .mockReturnValueOnce(mockDbChain([{ asin: 'B_GENRE' }]));  // isStillSameAsin (genres) — #1129
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_GENRE' }]));  // in-tx precondition re-read (#2069 AC11)
 
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'Genre Book', authors: [{ name: 'Author' }],
         genres: ['Fantasy', 'Science Fiction'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
-      expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Fantasy', 'Science Fiction'] });
+      expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Fantasy', 'Science Fiction'] }, { tx: expect.anything() });
     });
 
     it('persists genres via bookService.update() when book has empty array genres in DB', async () => {
       db.select
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_GENRE_EMPTY' }]))  // candidates
         .mockReturnValueOnce(mockDbChain([{ duration: 600, genres: [], title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]))  // existing: genres empty array
-        .mockReturnValueOnce(mockDbChain([{ asin: 'B_GENRE_EMPTY' }]));  // isStillSameAsin (genres) — #1129
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_GENRE_EMPTY' }]));  // in-tx precondition re-read (#2069 AC11)
 
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'Genre Book', authors: [{ name: 'Author' }],
         genres: ['Mystery'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
-      expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Mystery'] });
+      expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Mystery'] }, { tx: expect.anything() });
     });
 
     it('does NOT update genres when book already has non-empty genres', async () => {
@@ -465,7 +465,7 @@ describe('enrichment job', () => {
         title: 'Genre Book', authors: [{ name: 'Author' }],
         genres: ['New Genre'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -482,7 +482,7 @@ describe('enrichment job', () => {
         duration: 600,
         // genres undefined
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -498,7 +498,7 @@ describe('enrichment job', () => {
         title: 'Empty Genre Book', authors: [{ name: 'Author' }],
         genres: [],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -512,13 +512,14 @@ describe('enrichment job', () => {
           { id: 2, asin: 'B_SKIP' },
         ]))  // candidates
         .mockReturnValueOnce(mockDbChain([{ duration: 600, genres: null, title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]))  // book 1: no genres
-        .mockReturnValueOnce(mockDbChain([{ asin: 'B_FILL' }]))  // isStillSameAsin (book 1 genres) — #1129
-        .mockReturnValueOnce(mockDbChain([{ duration: 600, genres: ['Existing'], title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]));  // book 2: has genres
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_FILL', userClearedFields: null }]))  // book 1: in-tx precondition re-read (#2069 AC11)
+        .mockReturnValueOnce(mockDbChain([{ duration: 600, genres: ['Existing'], title: 'Some Book', description: null, coverUrl: null, publishedDate: null, seriesName: null, seriesPosition: null }]))  // book 2: has genres
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_SKIP', userClearedFields: null }]));  // book 2: in-tx precondition re-read
 
       metadataService.resolveBook
         .mockResolvedValueOnce({ title: 'Book 1', authors: [], genres: ['Fantasy'] })
         .mockResolvedValueOnce({ title: 'Book 2', authors: [], genres: ['New Genre'] });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -536,7 +537,7 @@ describe('enrichment job', () => {
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'Book', authors: [{ name: 'Author' }], duration: 600,
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -597,7 +598,7 @@ describe('enrichment job', () => {
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_TITLE' }]))  // candidates
         .mockReturnValueOnce(mockDbChain([{ ...allFields, ...existingFields }]));  // existing
       metadataService.resolveBook.mockResolvedValueOnce({ title: 'Enriched', authors: [{ name: 'Author' }], ...enrichedData });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
     }
 
     it('overwrites ALL CAPS title with enrichment proper case', async () => {
@@ -663,7 +664,7 @@ describe('enrichment job', () => {
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_DESC' }]))
         .mockReturnValueOnce(mockDbChain([{ ...allFields, ...existingFields }]));
       metadataService.resolveBook.mockResolvedValueOnce({ title: 'Book', authors: [{ name: 'Author' }], ...enrichedData });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
     }
 
     it('fills description when currently null', async () => {
@@ -697,7 +698,7 @@ describe('enrichment job', () => {
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_COVER' }]))
         .mockReturnValueOnce(mockDbChain([{ ...allFields, ...existingFields }]));
       metadataService.resolveBook.mockResolvedValueOnce({ title: 'Book', authors: [{ name: 'Author' }], ...enrichedData });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
     }
 
     it('fills coverUrl when currently null', async () => {
@@ -751,7 +752,7 @@ describe('enrichment job', () => {
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_DATE' }]))
         .mockReturnValueOnce(mockDbChain([{ ...allFields, ...existingFields }]));
       metadataService.resolveBook.mockResolvedValueOnce({ title: 'Book', authors: [{ name: 'Author' }], ...enrichedData });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
     }
 
     it('fills publishedDate when currently null', async () => {
@@ -778,7 +779,7 @@ describe('enrichment job', () => {
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_SERIES' }]))
         .mockReturnValueOnce(mockDbChain([{ ...allFields, ...existingFields }]));
       metadataService.resolveBook.mockResolvedValueOnce({ title: 'Book', authors: [{ name: 'Author' }], ...enrichedData });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
     }
 
     it('fills seriesName and seriesPosition from series[0]', async () => {
@@ -901,12 +902,14 @@ describe('enrichment job', () => {
           { id: 2, asin: 'B_T2' },
         ]))
         .mockReturnValueOnce(mockDbChain([{ ...allFields, title: 'PROJECT HAIL MARY' }]))  // book 1: ALL CAPS
-        .mockReturnValueOnce(mockDbChain([{ ...allFields, title: 'Already Good' }]));  // book 2: mixed case
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_T1', userClearedFields: null }]))  // book 1: in-tx precondition re-read (#2069 AC11)
+        .mockReturnValueOnce(mockDbChain([{ ...allFields, title: 'Already Good' }]))  // book 2: mixed case
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_T2', userClearedFields: null }]));  // book 2: in-tx precondition re-read
 
       metadataService.resolveBook
         .mockResolvedValueOnce({ title: 'Project Hail Mary', authors: [] })
         .mockResolvedValueOnce({ title: 'Already Good', authors: [] });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -923,12 +926,14 @@ describe('enrichment job', () => {
           { id: 2, asin: 'B_D2' },
         ]))
         .mockReturnValueOnce(mockDbChain([{ ...allFields, description: null }]))
-        .mockReturnValueOnce(mockDbChain([{ ...allFields, description: 'Existing' }]));
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_D1', userClearedFields: null }]))  // book 1: in-tx precondition re-read (#2069 AC11)
+        .mockReturnValueOnce(mockDbChain([{ ...allFields, description: 'Existing' }]))
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_D2', userClearedFields: null }]));  // book 2: in-tx precondition re-read
 
       metadataService.resolveBook
         .mockResolvedValueOnce({ title: 'Book 1', authors: [], description: 'New desc' })
         .mockResolvedValueOnce({ title: 'Book 2', authors: [], description: 'Another desc' });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -941,8 +946,7 @@ describe('enrichment job', () => {
     it('existing filledDuration/filledNarrators/filledGenres still work', async () => {
       db.select
         .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_ALL' }]))
-        .mockReturnValueOnce(mockDbChain([{ ...allFields, duration: null }]))
-        .mockReturnValueOnce(mockDbChain([{ asin: 'B_ALL' }]));  // isStillSameAsin (genres) — #1129
+        .mockReturnValueOnce(mockDbChain([{ ...allFields, duration: null }]));
 
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'Book', authors: [{ name: 'Author' }],
@@ -950,7 +954,7 @@ describe('enrichment job', () => {
         genres: ['Fantasy'],
         narrators: ['Jim Dale'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
       db.insert.mockReturnValue(mockDbChain([]));
       // narrator lookup: no existing narrators
       db.select.mockReturnValueOnce(mockDbChain([]));
@@ -958,6 +962,9 @@ describe('enrichment job', () => {
       db.select.mockReturnValueOnce(mockDbChain([{ asin: 'B_ALL' }]));
       // findOrCreateNarrator: not found, insert
       db.select.mockReturnValueOnce(mockDbChain([]));
+      // in-tx precondition re-read — LAST, the write transaction runs after the
+      // narrator block (#2069 AC11)
+      db.select.mockReturnValueOnce(mockDbChain([{ asin: 'B_ALL', userClearedFields: null }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -990,7 +997,7 @@ describe('enrichment job', () => {
         series: [{ name: 'Standalone', position: 1 }],
         duration: 970,
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -1012,7 +1019,7 @@ describe('enrichment job', () => {
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'Project Hail Mary', authors: [{ name: 'Author' }],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -1047,7 +1054,7 @@ describe('enrichment job', () => {
         series: [{ name: 'New Series', position: 1 }],
         duration: 970,
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -1074,22 +1081,25 @@ describe('enrichment job', () => {
           duration: null, genres: null, title: 'Some Book', description: null, coverUrl: null,
           publishedDate: null, seriesName: null, seriesPosition: null,
         }]))
-        .mockReturnValueOnce(mockDbChain([{ asin: 'B_NEW' }]));                                // isStillSameAsin (genres)
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_NEW', userClearedFields: null }]));       // in-tx precondition re-read (#2069 AC11)
 
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'X',
         authors: [{ name: 'A' }],
         genres: ['Fantasy'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
+      // The whole write transaction aborts now, not just the genres arm — and the
+      // candidate is NOT counted or logged as enriched (#2069 AC11).
       expect(bookService.update).not.toHaveBeenCalled();
       expect(log.debug).toHaveBeenCalledWith(
         expect.objectContaining({ bookId: 1, asin: 'B_OLD' }),
-        'stale enrichment dropped (genres)',
+        'stale enrichment dropped (identity re-read)',
       );
+      expect(log.info).not.toHaveBeenCalledWith(expect.anything(), 'Book enriched successfully');
     });
 
     it('genres path: writes when row asin still matches captured asin', async () => {
@@ -1099,18 +1109,18 @@ describe('enrichment job', () => {
           duration: null, genres: null, title: 'Some Book', description: null, coverUrl: null,
           publishedDate: null, seriesName: null, seriesPosition: null,
         }]))
-        .mockReturnValueOnce(mockDbChain([{ asin: 'B_SAME' }]));                               // isStillSameAsin (genres)
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_SAME', userClearedFields: null }]));      // in-tx precondition re-read (#2069 AC11)
 
       metadataService.resolveBook.mockResolvedValueOnce({
         title: 'X',
         authors: [{ name: 'A' }],
         genres: ['Fantasy'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
-      expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Fantasy'] });
+      expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Fantasy'] }, { tx: expect.anything() });
     });
 
     it('narrators path: drops inserts when row asin no longer matches captured asin', async () => {
@@ -1129,7 +1139,7 @@ describe('enrichment job', () => {
         authors: [{ name: 'A' }],
         narrators: ['Some Narrator'],
       });
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
       db.insert.mockReturnValue(mockDbChain());
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
@@ -1456,7 +1466,7 @@ describe('enrichment job', () => {
         ]));  // candidates
 
       metadataService.resolveBook.mockRejectedValueOnce(new RateLimitError(30000, 'Audible.com'));
-      db.update.mockReturnValue(mockDbChain());
+      db.update.mockReturnValue(mockDbChain([{ id: 1 }]));
 
       await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
 
@@ -1583,4 +1593,243 @@ describe('enrichment job', () => {
     });
   });
 
+});
+
+// ─── #2069: scheduled enrichment honors the operator's explicit clears ───
+//
+// Every case below observes the `.set(...)` argument the write transaction
+// ACTUALLY issued, not the payload built beforehand — the suppression happens
+// inside the transaction, after the tombstone re-read, so an assertion on the
+// pre-transaction object would pass against an implementation that never
+// suppressed anything.
+describe('enrichment job — user-cleared fields (#2069)', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let metadataService: { resolveBook: ReturnType<typeof vi.fn> };
+  let bookService: { update: ReturnType<typeof vi.fn>; findAsinCollision: ReturnType<typeof vi.fn>; trackUnmatchedGenres: ReturnType<typeof vi.fn> };
+  let log: ReturnType<typeof createMockLogger>;
+  let updateChain: ReturnType<typeof mockDbChain>;
+
+  /** Every clearable scalar empty, so each fill is reachable. */
+  const emptyExisting = {
+    duration: null, genres: null, title: 'Tress of the Emerald Sea', subtitle: null,
+    description: null, publisher: null, coverUrl: null, publishedDate: null,
+    seriesName: null, seriesPosition: null,
+  };
+
+  /** A provider result that fills every clearable field plus the carve-outs. */
+  const fullResult = {
+    title: 'Tress of the Emerald Sea',
+    authors: [{ name: 'Brandon Sanderson' }],
+    subtitle: 'A Cosmere Novel',
+    description: 'Provider description',
+    publisher: 'Dragonsteel',
+    publishedDate: '2023-01-10',
+    coverUrl: 'https://example.test/cover.jpg',
+    duration: 600,
+    genres: ['Fantasy'],
+    seriesPrimary: { name: 'Secret Projects', position: 1 },
+  };
+
+  /**
+   * Drive one candidate through the pass with the given stored tombstone column.
+   * Returns the `.set(...)` payload the scalar UPDATE was issued with.
+   */
+  async function runWithTombstones(raw: string | null, existing = emptyExisting): Promise<Record<string, unknown>> {
+    db.select
+      .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_CLEARED' }]))            // candidates
+      .mockReturnValueOnce(mockDbChain([existing]))                                // existing fill-empty inputs
+      .mockReturnValueOnce(mockDbChain([{ asin: 'B_CLEARED', userClearedFields: raw }])); // in-tx precondition re-read
+    metadataService.resolveBook.mockResolvedValueOnce(fullResult);
+
+    await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
+
+    return updateChain.set.mock.calls[0]![0] as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    db = createMockDb();
+    metadataService = { resolveBook: vi.fn().mockResolvedValue(null) };
+    bookService = { update: vi.fn().mockResolvedValue(null), findAsinCollision: vi.fn().mockResolvedValue(null), trackUnmatchedGenres: vi.fn().mockResolvedValue(undefined) };
+    log = createMockLogger();
+    updateChain = mockDbChain([{ id: 1 }]);
+    db.update.mockReturnValue(updateChain);
+  });
+
+  it('a seriesName tombstone writes NEITHER seriesName nor seriesPosition (the pair rule)', async () => {
+    const set = await runWithTombstones('["seriesName"]');
+
+    expect(set).not.toHaveProperty('seriesName');
+    expect(set).not.toHaveProperty('seriesPosition');
+    expect(set.enrichmentStatus).toBe('enriched');
+  });
+
+  it('suppresses only the tombstoned scalars while untombstoned siblings still fill in the same pass', async () => {
+    const set = await runWithTombstones('["description","publisher"]');
+
+    expect(set).not.toHaveProperty('description');
+    expect(set).not.toHaveProperty('publisher');
+    // The over-broad-filter guard: these are in the same fill list and must land.
+    expect(set.subtitle).toBe('A Cosmere Novel');
+    expect(set.publishedDate).toBe('2023-01-10');
+    expect(set.seriesName).toBe('Secret Projects');
+  });
+
+  it('suppresses subtitle and publishedDate independently', async () => {
+    const set = await runWithTombstones('["publishedDate","subtitle"]');
+
+    expect(set).not.toHaveProperty('subtitle');
+    expect(set).not.toHaveProperty('publishedDate');
+    expect(set.description).toBe('Provider description');
+    expect(set.publisher).toBe('Dragonsteel');
+  });
+
+  it('a genres tombstone skips the genres write entirely', async () => {
+    await runWithTombstones('["genres"]');
+
+    expect(bookService.update).not.toHaveBeenCalled();
+  });
+
+  it('keeps the coverUrl overwrite and the duration fill for a seriesName-tombstoned book (carve-outs intact)', async () => {
+    const set = await runWithTombstones('["seriesName"]');
+
+    expect(set.coverUrl).toBe('https://example.test/cover.jpg');
+    expect(set.duration).toBe(600);
+    expect(set.title).toBeUndefined(); // not ALL CAPS, so no title rewrite — unchanged behavior
+  });
+
+  it('a malformed persisted set degrades to "no tombstones" and the pass fills normally', async () => {
+    const set = await runWithTombstones('{oops');
+
+    expect(set.seriesName).toBe('Secret Projects');
+    expect(set.publisher).toBe('Dragonsteel');
+    expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Fantasy'] }, { tx: expect.anything() });
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ bookId: 1 }),
+      expect.stringContaining('Unparseable userClearedFields'),
+    );
+  });
+
+  it('a recognized-plus-unknown set suppresses the recognized field and still lands the rest (AC4)', async () => {
+    const set = await runWithTombstones('["genres","futureField"]');
+
+    expect(bookService.update).not.toHaveBeenCalled();
+    expect(set.enrichmentStatus).toBe('enriched');
+    expect(set.publisher).toBe('Dragonsteel');
+  });
+
+  it('AC12: a book with no tombstones fills exactly as today', async () => {
+    const set = await runWithTombstones(null);
+
+    expect(set.seriesName).toBe('Secret Projects');
+    expect(set.seriesPosition).toBe(1);
+    expect(set.subtitle).toBe('A Cosmere Novel');
+    expect(bookService.update).toHaveBeenCalledWith(1, { genres: ['Fantasy'] }, { tx: expect.anything() });
+  });
+
+  it('a suppressed fill is a DECISION, not a failure — the candidate is still counted enriched', async () => {
+    await runWithTombstones('["description","genres","publisher","publishedDate","seriesName","subtitle"]');
+
+    expect(log.info).toHaveBeenCalledWith(
+      { bookId: 1, asin: 'B_CLEARED' },
+      'Book enriched successfully',
+    );
+    // …and a suppressed fill is not REPORTED as filled.
+    expect(log.info).toHaveBeenCalledWith(
+      expect.objectContaining({ enrichedCount: 1, filledGenres: 0, filledDescription: 0 }),
+      'Enrichment batch completed',
+    );
+  });
+
+  describe('F21 / F5 — the genre telemetry is a DEFERRED post-commit effect', () => {
+    it('runs the telemetry with the written payload, AFTER the write transaction resolves', async () => {
+      const order: string[] = [];
+      db.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => {
+        const result = await cb(db);
+        order.push('tx-committed');
+        return result;
+      });
+      bookService.trackUnmatchedGenres.mockImplementation(async () => { order.push('telemetry'); });
+
+      await runWithTombstones(null);
+
+      expect(bookService.trackUnmatchedGenres).toHaveBeenCalledWith(['Fantasy']);
+      // The ordering is the whole point: `update`'s caller-owned-tx arm emits no
+      // post-commit effects, so running this BEFORE the commit would strand it on a
+      // rollback. Observing the transaction's own resolution — not statement
+      // issuance — is what makes this assertion able to fail.
+      expect(order).toEqual(['tx-committed', 'telemetry']);
+    });
+
+    it('records nothing when the genre fill was suppressed by a tombstone', async () => {
+      await runWithTombstones('["genres"]');
+
+      expect(bookService.update).not.toHaveBeenCalled();
+      expect(bookService.trackUnmatchedGenres).not.toHaveBeenCalled();
+    });
+
+    it('records nothing when the candidate is stale-dropped', async () => {
+      db.select
+        .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_CLEARED' }]))
+        .mockReturnValueOnce(mockDbChain([emptyExisting]))
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B_REIDENTIFIED', userClearedFields: null }]));
+      metadataService.resolveBook.mockResolvedValueOnce(fullResult);
+
+      await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
+
+      expect(bookService.trackUnmatchedGenres).not.toHaveBeenCalled();
+    });
+
+    it('a telemetry failure is non-fatal — the candidate still counts as enriched', async () => {
+      bookService.trackUnmatchedGenres.mockRejectedValueOnce(new Error('telemetry boom'));
+
+      await runWithTombstones(null);
+
+      expect(log.info).toHaveBeenCalledWith(
+        { bookId: 1, asin: 'B_CLEARED' },
+        'Book enriched successfully',
+      );
+    });
+  });
+
+  describe('AC11 — the tombstone read and the writes share one transaction', () => {
+    it('sees a clear that commits after the provider fetch but before the write transaction opens', async () => {
+      // The pre-transaction `existing` read still shows an empty series; the clear
+      // lands as the transaction opens. Reading the set before the transaction (or
+      // reusing the `existing` row) would write the provider series back.
+      let stored: string | null = null;
+      db.select
+        .mockReturnValueOnce(mockDbChain([{ id: 1, asin: 'B_RACE' }]))
+        .mockReturnValueOnce(mockDbChain([emptyExisting]))
+        .mockImplementation(() => mockDbChain([{ asin: 'B_RACE', userClearedFields: stored }]));
+      db.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => {
+        stored = '["seriesName"]';
+        return cb(db);
+      });
+      metadataService.resolveBook.mockResolvedValueOnce(fullResult);
+
+      await runEnrichment(inject<Db>(db), inject<MetadataService>(metadataService), inject<BookService>(bookService), inject<FastifyBaseLogger>(log));
+
+      const set = updateChain.set.mock.calls[0]![0] as Record<string, unknown>;
+      expect(set).not.toHaveProperty('seriesName');
+      expect(set).not.toHaveProperty('seriesPosition');
+      // A suppressed field is a decision, not a failure — the status still advances.
+      expect(set.enrichmentStatus).toBe('enriched');
+    });
+
+    it('the genres write runs on the transaction handle, never opening a nested one', async () => {
+      await runWithTombstones(null);
+
+      const [, , options] = bookService.update.mock.calls[0] as [number, unknown, { tx: unknown }];
+      expect(options.tx).toBeDefined();
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('negative control: with nothing committing in the window the write lands normally', async () => {
+      const set = await runWithTombstones('["subtitle"]');
+
+      expect(set).not.toHaveProperty('subtitle');
+      expect(set.description).toBe('Provider description');
+      expect(set.enrichmentStatus).toBe('enriched');
+    });
+  });
 });

--- a/src/server/jobs/enrichment.ts
+++ b/src/server/jobs/enrichment.ts
@@ -10,6 +10,8 @@ import { canonicalizeAsin } from '@shared/asin.js';
 import type { MetadataService } from '../services/metadata.service.js';
 import type { BookService } from '../services/book.service.js';
 import { pickPrimarySeries } from '@shared/pick-primary-series.js';
+import { parseClearedFields } from '../utils/cleared-fields.js';
+import type { ClearableBookField } from '@shared/schemas/book.js';
 
 
 const BATCH_LIMIT = 5;
@@ -110,34 +112,112 @@ async function markFailedGuarded(
   return true;
 }
 
+/** The clearable fields this fill surface writes as plain scalars. */
+const TOMBSTONABLE_SCALAR_FILLS = ['subtitle', 'description', 'publisher', 'publishedDate'] as const;
+
 /**
- * Apply the success scalar UPDATE, scoped `WHERE id = ? AND asin <matches
- * captured>` so a Fix Match that swapped the row's identity between fetch and
- * writeback drops the stale write atomically (null-safe via `asinMatches`).
+ * Drop the writes a live tombstone suppresses (#2069 AC9). Mutates `updates` in
+ * place, so the counters the caller derives from it are already post-suppression.
  *
- * On a UNIQUE violation — a concurrent writer (Fix Match / import-list create)
- * took the resolved ASIN between `findAsinCollision` and this write — run the
- * guarded recovery write to mark the candidate `failed` instead of letting the
- * throw abort the rest of the batch, and return true so the caller `continue`s.
- * Non-unique errors are genuine faults and rethrow, preserving existing
- * crash/log behavior. Returns false on the normal path (including a scalar
- * stale-drop) so the caller falls through to the success log.
+ * `duration`, the all-caps `title` rewrite, `coverUrl`, `asin`, `enrichmentStatus`
+ * and every technical/audio field are deliberately unaffected — none of them is
+ * clearable through Edit Metadata, so none can carry a tombstone.
  */
-async function applyScalarWrite(
+function suppressTombstonedUpdates(
+  updates: Record<string, unknown>,
+  cleared: ReadonlySet<ClearableBookField>,
+): void {
+  for (const field of TOMBSTONABLE_SCALAR_FILLS) {
+    if (cleared.has(field)) delete updates[field];
+  }
+  // The series pair is single-source (#1927 AC10): the `seriesName` tombstone
+  // suppresses BOTH halves, never grafting a provider position onto a cleared name.
+  if (cleared.has('seriesName')) {
+    delete updates.seriesName;
+    delete updates.seriesPosition;
+  }
+}
+
+type EnrichmentWriteOutcome = 'applied' | 'stale' | 'unique-conflict';
+
+/**
+ * The candidate's whole durable write, in ONE transaction (#2069 AC11).
+ *
+ * Inside the transaction, in order: re-select `{ asin, user_cleared_fields }` on
+ * the handle, abort on an identity change, drop every tombstoned key from the
+ * already-prepared `updates`, then issue the scalar UPDATE and the genres write
+ * together. The provider fetch and the fill-empty decisions for non-tombstone
+ * reasons stay OUTSIDE, as they are today (`src/db/serial-transactions.ts`: keep
+ * the surrounding work outside the transaction, re-read only the preconditions
+ * inside). Re-reading is why there is no fence and no observation token — the
+ * window a fence would narrow is closed entirely.
+ *
+ * A field dropped because it is tombstoned is a DECISION, not a failure: the rest
+ * of the write proceeds and `enrichmentStatus` advances normally. Only an identity
+ * mismatch yields `'stale'`, and the caller then emits no success counters or log.
+ *
+ * `genresWritten` carries the genre payload back OUT as a DEFERRED EFFECT (#2069
+ * F21/F5): `bookService.update`'s caller-owned-tx arm deliberately emits no
+ * post-commit side effects, because a rollback the owner may still perform would
+ * strand them — so the owner is the one that must run the unmatched-genre telemetry,
+ * and only after this transaction has committed. It is `null` whenever no genre
+ * write landed (nothing to fill, or the field is tombstoned).
+ *
+ * On a UNIQUE violation — a concurrent writer took the resolved ASIN between
+ * `findAsinCollision` and this write — the throw rolls the transaction back and the
+ * guarded recovery write marks the candidate `failed` OUTSIDE it, so the rest of
+ * the batch continues. Non-unique errors are genuine faults and rethrow.
+ */
+async function applyEnrichmentWrites(
   db: Db,
+  bookService: BookService,
   log: FastifyBaseLogger,
   bookId: number,
   capturedAsin: string | null,
   updates: Record<string, unknown>,
   resolvedAsin: string | null,
-): Promise<boolean> {
-  let scalarResult;
+  genresToFill: string[] | null,
+): Promise<{ outcome: EnrichmentWriteOutcome; filledGenres: number; genresWritten: string[] | null }> {
   try {
-    scalarResult = await db
-      .update(books)
-      .set(updates)
-      .where(and(eq(books.id, bookId), asinMatches(capturedAsin)))
-      .returning({ id: books.id });
+    return await db.transaction(async (tx) => {
+      const rows = await tx
+        .select({ asin: books.asin, userClearedFields: books.userClearedFields })
+        .from(books)
+        .where(eq(books.id, bookId))
+        .limit(1);
+      const row = rows[0];
+
+      // Identity guard, same meaning as today's `asinMatches` predicate — just
+      // observed early enough to skip the write. A MISSING row needs no branch of
+      // its own: it cannot satisfy that predicate either, so it drops below.
+      if (row && (row.asin ?? null) !== capturedAsin) {
+        log.debug({ bookId, asin: capturedAsin }, 'stale enrichment dropped (identity re-read)');
+        return { outcome: 'stale' as const, filledGenres: 0, genresWritten: null };
+      }
+
+      const cleared = new Set(parseClearedFields(row?.userClearedFields ?? null, log, bookId));
+      suppressTombstonedUpdates(updates, cleared);
+
+      const scalarResult = await tx
+        .update(books)
+        .set(updates)
+        .where(and(eq(books.id, bookId), asinMatches(capturedAsin)))
+        .returning({ id: books.id });
+
+      if (scalarResult.length === 0) {
+        log.debug({ bookId, asin: capturedAsin }, 'stale enrichment dropped (scalar update)');
+        return { outcome: 'stale' as const, filledGenres: 0, genresWritten: null };
+      }
+
+      // The genres write commits through `bookService.update`, which has no
+      // captured-ASIN scope of its own — it inherits this transaction's guard, and
+      // runs on the handle so it does not open a second (nested) transaction.
+      if (genresToFill && !cleared.has('genres')) {
+        await bookService.update(bookId, { genres: genresToFill }, { tx });
+        return { outcome: 'applied' as const, filledGenres: 1, genresWritten: genresToFill };
+      }
+      return { outcome: 'applied' as const, filledGenres: 0, genresWritten: null };
+    });
   } catch (error: unknown) {
     if (!isUniqueViolation(error, ASIN_UNIQUE_VIOLATION)) throw error;
     log.warn(
@@ -145,12 +225,8 @@ async function applyScalarWrite(
       'Resolved ASIN hit a unique-constraint race — marking failed',
     );
     await markFailedGuarded(db, log, bookId, capturedAsin, 'unique recovery');
-    return true;
+    return { outcome: 'unique-conflict', filledGenres: 0, genresWritten: null };
   }
-  if (scalarResult.length === 0) {
-    log.debug({ bookId, asin: capturedAsin }, 'stale enrichment dropped (scalar update)');
-  }
-  return false;
 }
 
 /** Fill empty scalar fields from enrichment result. Returns only non-empty entries. */
@@ -206,33 +282,29 @@ function fillSeriesFields(
   return updates;
 }
 
-/** Build the scalar updates and return fill counts for batch logging. */
+/**
+ * Build the scalar updates for a candidate. Counts are NOT derived here: the
+ * write transaction may still drop tombstoned keys (#2069 AC9), so the batch
+ * counters are read off the surviving `updates` object after the write lands.
+ */
 function buildMetadataUpdates(
   book: ExistingBookFields,
   result: { title?: string | null | undefined; subtitle?: string | null | undefined; description?: string | null | undefined; publisher?: string | null | undefined; coverUrl?: string | null | undefined; publishedDate?: string | null | undefined; duration?: number | null | undefined; seriesPrimary?: { name?: string | undefined; position?: number | undefined } | undefined; series?: Array<{ name?: string | undefined; position?: number | undefined }> | undefined },
 ) {
   const updates: Record<string, unknown> = {};
-  let filledDuration = 0;
-  let filledTitle = 0;
-  let filledDescription = 0;
 
   if (!book.duration && result.duration) {
     updates.duration = result.duration;
-    filledDuration++;
   }
 
   if (result.title && isAllCaps(book.title) && result.title !== book.title) {
     updates.title = result.title;
-    filledTitle++;
   }
 
-  const scalarFills = fillEmptyFields(book, result as Record<string, unknown>);
-  if (scalarFills.description) filledDescription++;
-  Object.assign(updates, scalarFills);
-
+  Object.assign(updates, fillEmptyFields(book, result as Record<string, unknown>));
   Object.assign(updates, fillSeriesFields(book, result));
 
-  return { updates, filledDuration, filledTitle, filledDescription };
+  return { updates };
 }
 
 // eslint-disable-next-line complexity -- linear enrichment pipeline with null guards per category
@@ -358,25 +430,16 @@ export async function runEnrichment(db: Db, metadataService: MetadataService, bo
         .where(eq(books.id, candidate.id))
         .limit(1);
 
+      // Genres fill when the stored list is null or empty. The tombstone check and
+      // the write both live in the write transaction below (#2069 AC11) — this only
+      // decides whether there is anything to fill.
+      let genresToFill: string[] | null = null;
+
       if (existing.length > 0) {
         const book = existing[0]!;
-        const filled = buildMetadataUpdates(book, result);
-        Object.assign(updates, filled.updates);
-        filledDuration += filled.filledDuration;
-        filledTitle += filled.filledTitle;
-        filledDescription += filled.filledDescription;
-
-        // Fill genres via bookService.update() when existing genres are null or empty.
-        // Re-check the row's ASIN before mutating to drop writes for books whose
-        // identity was swapped under us (Fix Match). The genres path commits
-        // through bookService.update(), which has no capturedAsin scope.
+        Object.assign(updates, buildMetadataUpdates(book, result).updates);
         if (result.genres?.length && (!book.genres || book.genres.length === 0)) {
-          if (await isStillSameAsin(db, candidate.id, capturedAsin)) {
-            await bookService.update(candidate.id, { genres: result.genres });
-            filledGenres++;
-          } else {
-            log.debug({ bookId: candidate.id, asin: capturedAsin }, 'stale enrichment dropped (genres)');
-          }
+          genresToFill = result.genres;
         }
       }
 
@@ -411,13 +474,36 @@ export async function runEnrichment(db: Db, metadataService: MetadataService, bo
         }
       }
 
-      // Scalar UPDATE: scope `WHERE id = ? AND asin <matches captured>` so a Fix
-      // Match that swapped the row's identity between fetch and writeback drops
-      // the stale write atomically. Null-safe: a captured-null row matches via
+      // One transaction for the scalar UPDATE + the genres write, with the
+      // tombstone set and the row identity re-read inside it (#2069 AC11). The
+      // scalar write keeps its `WHERE id = ? AND asin <matches captured>` scope so
+      // a Fix Match that swapped the row's identity between fetch and writeback
+      // still drops atomically. Null-safe: a captured-null row matches via
       // `asin IS NULL` (a plain `asin = NULL` predicate never matches, which
       // would silently drop the writeback for a search-rescued null-ASIN book).
-      if (await applyScalarWrite(db, log, candidate.id, capturedAsin, updates, resolvedAsin)) {
-        continue; // unique-constraint race recovered → candidate marked failed
+      const written = await applyEnrichmentWrites(
+        db, bookService, log, candidate.id, capturedAsin, updates, resolvedAsin, genresToFill,
+      );
+      // A stale drop is NOT a success: no fill counters, no 'Book enriched
+      // successfully' line. Only fields that actually landed are counted, so a
+      // tombstone-suppressed fill is not reported as filled either.
+      if (written.outcome !== 'applied') continue;
+
+      if ('duration' in updates) filledDuration++;
+      if ('title' in updates) filledTitle++;
+      if ('description' in updates) filledDescription++;
+      filledGenres += written.filledGenres;
+
+      // Deferred effect, run only now that the write transaction has COMMITTED
+      // (#2069 F21/F5). The genres write goes through `bookService.update`'s
+      // caller-owned-tx arm, which emits no post-commit side effects of its own
+      // precisely so a rollback cannot strand them — which makes running this the
+      // owner's job. Awaited rather than fire-and-forget so a batch cannot outlive
+      // its own telemetry; still non-fatal, matching the `update()` wrapper.
+      if (written.genresWritten) {
+        await bookService.trackUnmatchedGenres(written.genresWritten).catch((error: unknown) => {
+          log.debug({ error: serializeError(error) }, 'Failed to track unmatched genres');
+        });
       }
 
       enrichedCount++;

--- a/src/server/routes/activity.test.ts
+++ b/src/server/routes/activity.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi, type Mock } from 'vitest';
-import { createTestApp, createMockServices, resetMockServices } from '../__tests__/helpers.js';
+import { createTestApp, createMockServices, resetMockServices, createMockDb, createMockLogger, inject, mockDbChain } from '../__tests__/helpers.js';
+import { createMockDbBook } from '../__tests__/factories.js';
+import { DownloadService } from '../services/download.service.js';
+import type { DownloadClientService } from '../services/download-client.service.js';
+import type { Db } from '@db/index.js';
+import type { FastifyBaseLogger } from 'fastify';
 import type { Services } from './index.js';
 import { QualityGateServiceError } from '../services/quality-gate.service.js';
 import { DownloadError } from '../services/download.service.js';
@@ -824,5 +829,51 @@ describe('activity routes', () => {
 
       expect(res.statusCode).toBe(409);
     });
+  });
+});
+
+// ─── #2069 AC16: no raw tombstone column in a schema-less activity response ───
+//
+// `GET /api/activity` declares only a querystring schema, so nothing strips extra
+// keys off the serialized download rows — whatever `DownloadService` puts on
+// `.book` is what ships. This drives the REAL service (over a mock db) rather than
+// the service mock, so the assertion watches the object the projection acts on.
+//
+// Counterfactual: revert `DownloadWithBook.book` to `BookRow` (drop the
+// `stripClearedFields` calls) and this goes red alongside the service-level cases
+// in `download.service.test.ts`.
+describe('GET /api/activity — user_cleared_fields never reaches the response (#2069)', () => {
+  it('serializes the joined book without the raw column', async () => {
+    const db = createMockDb();
+    const seededBook = createMockDbBook({ userClearedFields: '["genres"]' });
+    db.select
+      .mockReturnValueOnce(mockDbChain([{ value: 1 }]))
+      .mockReturnValueOnce(mockDbChain([{ download: mockDownload, book: seededBook, indexer: null }]));
+
+    const realDownloadService = new DownloadService(
+      inject<Db>(db),
+      inject<DownloadClientService>({} as DownloadClientService),
+      inject<FastifyBaseLogger>(createMockLogger()),
+    );
+    // `createMockServices` spreads its overrides into a plain object, so bind the
+    // real method rather than handing it the instance.
+    const localServices = createMockServices({
+      download: { getAll: realDownloadService.getAll.bind(realDownloadService) },
+    });
+    const localApp = await createTestApp(localServices);
+
+    try {
+      const res = await localApp.inject({ method: 'GET', url: '/api/activity' });
+
+      expect(res.statusCode, res.payload).toBe(200);
+      expect(res.payload).not.toContain('userClearedFields');
+      const body = JSON.parse(res.payload);
+      expect(body.data[0].book).toBeDefined();
+      expect('userClearedFields' in body.data[0].book).toBe(false);
+      // The rest of the row still ships, so this is not passing on an empty response.
+      expect(body.data[0].book.title).toBe(seededBook.title);
+    } finally {
+      await localApp.close();
+    }
   });
 });

--- a/src/server/routes/books.test.ts
+++ b/src/server/routes/books.test.ts
@@ -890,7 +890,7 @@ describe('books routes', () => {
       });
 
       expect(res.statusCode).toBe(200);
-      expect(services.book.update).toHaveBeenCalledWith(1, { seriesName: 'Stormlight', seriesPosition: 1 });
+      expect(services.book.update).toHaveBeenCalledWith(1, { seriesName: 'Stormlight', seriesPosition: 1 }, { userAsserted: true });
     });
 
     it('rejects empty title', async () => {
@@ -2722,7 +2722,7 @@ describe('PUT /api/books/:id — array update contract (#71)', () => {
 
     expect(res.statusCode).toBe(200);
     // Service called without authors — junction rows left unchanged
-    expect(services.book.update).toHaveBeenCalledWith(1, { title: 'Updated Title' });
+    expect(services.book.update).toHaveBeenCalledWith(1, { title: 'Updated Title' }, { userAsserted: true });
   });
 
   it('narrators: [] → clears all narrator junction rows', async () => {
@@ -2740,7 +2740,7 @@ describe('PUT /api/books/:id — array update contract (#71)', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(services.book.update).toHaveBeenCalledWith(1, { narrators: [] });
+    expect(services.book.update).toHaveBeenCalledWith(1, { narrators: [] }, { userAsserted: true });
   });
 
   it('authors: [] → 400 error (min(1))', async () => {
@@ -2779,7 +2779,7 @@ describe('PUT /api/books/:id — array update contract (#71)', () => {
       description: 'New description',
       authors: [{ name: 'Brandon Sanderson', asin: 'B001IGFHW6' }],
       narrators: ['Michael Kramer'],
-    }));
+    }), { userAsserted: true });
   });
 
   it('accepts the extended metadata body (publishedDate/genres/nullable description+coverUrl) and delegates to the service (#1609)', async () => {
@@ -2807,7 +2807,7 @@ describe('PUT /api/books/:id — array update contract (#71)', () => {
       coverUrl: null,
       publishedDate: '2010-08-31',
       genres: ['Fantasy', 'Epic'],
-    });
+    }, { userAsserted: true });
   });
 
   it('passes null clears for publishedDate and genres through to the service (#1609)', async () => {
@@ -2825,7 +2825,7 @@ describe('PUT /api/books/:id — array update contract (#71)', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(services.book.update).toHaveBeenCalledWith(1, { publishedDate: null, genres: null });
+    expect(services.book.update).toHaveBeenCalledWith(1, { publishedDate: null, genres: null }, { userAsserted: true });
   });
 
   it('rejects an invalid publishedDate type (number) with 400 (#1609)', async () => {

--- a/src/server/routes/books.ts
+++ b/src/server/routes/books.ts
@@ -321,7 +321,11 @@ export async function booksRoutes(app: FastifyInstance, deps: BookRouteDeps) {
       const { id } = request.params;
       const body = request.body;
 
-      const book = await bookService.update(id, body);
+      // `userAsserted` is the ONLY path that adds a tombstone (#2069 AC5): this is
+      // the operator-facing edit route, so a blanked clearable field is a deliberate
+      // removal rather than "no value yet". Internal callers of `update()` pass
+      // `null`s of their own and deliberately do NOT opt in.
+      const book = await bookService.update(id, body, { userAsserted: true });
 
       if (!book) {
         return reply.status(404).send({ error: 'Book not found' });

--- a/src/server/routes/index.test.ts
+++ b/src/server/routes/index.test.ts
@@ -683,6 +683,43 @@ describe('createServices', () => {
     expect(mergeServiceArg).toBe(mergeInstances[0]);
   });
 
+  // #2078 (F3) — MergeService receives the composed TaggingService as its 8th constructor
+  // argument so the post-merge re-tag is live in production. The parameter is OPTIONAL and
+  // TRAILING by design (existing construction sites must keep compiling), which means dropping
+  // it here compiles cleanly AND leaves every merge.service test green — those inject their own
+  // tagger. Only a composition assertion catches the silent regression.
+  it('injects the composed TaggingService instance into MergeService as its 8th constructor arg (#2078)', async () => {
+    const { SettingsService, TaggingService } = await import('../services/index.js');
+    const { MergeService } = await import('../services/merge.service.js');
+
+    vi.mocked(SettingsService).mockImplementation(function(this: Record<string, unknown>) {
+      this.get = vi.fn().mockResolvedValue({ audibleRegion: 'us' });
+      this.bootstrapProcessingDefaults = vi.fn().mockResolvedValue(undefined);
+      this.migrateLanguageSettings = vi.fn().mockResolvedValue(undefined);
+      this.migrateRejectWordsDefault = vi.fn().mockResolvedValue(undefined);
+      this.migrateRejectWordsAbridgedDefault = vi.fn().mockResolvedValue(undefined);
+      this.migrateMaxConcurrentProcessingDefaults = vi.fn().mockResolvedValue(undefined);
+    } as never);
+
+    const { createServices } = await import('./index.js');
+    const db = {} as unknown as Db;
+    const log = {
+      info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(),
+      child: vi.fn().mockReturnThis(), trace: vi.fn(), fatal: vi.fn(),
+    } as unknown as FastifyBaseLogger;
+
+    await createServices(db, log);
+
+    // MergeService ctor signature: db, bookService, settings, log, eventHistory,
+    // eventBroadcaster, connector, taggingService — taggingService is index 7.
+    const mergeCalls = vi.mocked(MergeService).mock.calls;
+    expect(mergeCalls).toHaveLength(1);
+    const taggingArg = mergeCalls[0]![7];
+    const taggingInstances = vi.mocked(TaggingService).mock.instances;
+    expect(taggingInstances).toHaveLength(1);
+    expect(taggingArg).toBe(taggingInstances[0]);
+  });
+
   // F29: the composition root must wire the winning-finalize nudge to the SAME
   // ImportSubmissionRunner instance it returns, and the accepted-item nudge to the
   // SAME ImportQueueWorker instance — passing no-op/reversed callbacks would compile

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -140,7 +140,10 @@ export async function createServices(db: Db, log: FastifyBaseLogger): Promise<Se
   const importService = new ImportService(db, downloadClient, settings, log, remotePathMapping, book);
   // MergeService is constructed before the orchestrator so the download-import path can enqueue
   // opt-in auto-merges (#1836) into the same bounded merge queue as the manual Merge button.
-  const mergeService = new MergeService(db, book, settings, log, eventHistory, eventBroadcaster, connector);
+  // taggingService is the 8th argument (#2078): with Tag Embedding on, the merge re-tags its
+  // own output from canonical DB state after committing, so an auto-merged file is not left
+  // carrying only the source parts' tags.
+  const mergeService = new MergeService(db, book, settings, log, eventHistory, eventBroadcaster, connector, taggingService);
   const importOrchestrator = new ImportOrchestrator(importService, settings, log, notifier, taggingService, eventHistory, eventBroadcaster, connector, book, mergeService);
   const seriesCard = new SeriesCardService(db, log, settings);
   const libraryScan = new LibraryScanService(db, book, bookImport, metadata, settings, log, eventHistory, eventBroadcaster, connector);

--- a/src/server/services/book-fix-match.integration.test.ts
+++ b/src/server/services/book-fix-match.integration.test.ts
@@ -186,6 +186,47 @@ describe('BookService.fixMatch — integration (#1129 F2)', () => {
     expect(members).toHaveLength(0);
   });
 
+  // #2069 AC13 — re-identifying a book is a NEW operator assertion, so the prior
+  // clears (which described the OLD record) are reset rather than honored.
+  it('resets user_cleared_fields to SQL NULL in the same transaction as the scalar replacement', async () => {
+    const svc = new BookService(db, log);
+    const bookId = await seedBookA(svc);
+    await db.update(books).set({ userClearedFields: '["genres","seriesName"]' }).where(eq(books.id, bookId));
+
+    await svc.fixMatch(bookId, {
+      asin: 'B_NEW',
+      title: 'New Title',
+      authors: [{ name: 'New Author' }],
+      seriesName: 'New Series',
+      seriesPosition: 3,
+    });
+
+    const [row] = await db.select().from(books).where(eq(books.id, bookId));
+    expect(row!.userClearedFields).toBeNull();
+    // Asserted from the same read as the replacement itself, so a reset that lands
+    // without the scalar rewrite (or vice versa) cannot pass.
+    expect(row!.seriesName).toBe('New Series');
+    expect(row!.enrichmentStatus).toBe('pending');
+  });
+
+  it('leaves the reset rolled back when the transaction fails', async () => {
+    const svc = new BookService(db, log);
+    const bookId = await seedBookA(svc);
+    await db.update(books).set({ userClearedFields: '["genres"]' }).where(eq(books.id, bookId));
+
+    const link = await import('./book-series-link.js');
+    const spy = vi.spyOn(link, 'replaceSeriesLink').mockRejectedValueOnce(new Error('link boom'));
+
+    await expect(
+      svc.fixMatch(bookId, { asin: 'B_NEW', title: 'New Title', authors: [{ name: 'New Author' }] }),
+    ).rejects.toThrow('link boom');
+    spy.mockRestore();
+
+    const [row] = await db.select().from(books).where(eq(books.id, bookId));
+    expect(row!.userClearedFields).toBe('["genres"]');
+    expect(row!.title).toBe('Old Title');
+  });
+
   it('returns null when the book id does not exist', async () => {
     const svc = new BookService(db, log);
     const result = await svc.fixMatch(99999, {

--- a/src/server/services/book-library-status.ts
+++ b/src/server/services/book-library-status.ts
@@ -1,0 +1,99 @@
+import { and, inArray, isNotNull, sql } from 'drizzle-orm';
+import type { Db } from '@db/index.js';
+import { books } from '@db/schema.js';
+import type { BookStatus } from '@shared/schemas/book.js';
+import type { CompanionEbookRow } from './types.js';
+import type { LibraryStatusByAsin } from './book.service.js';
+import { findCompanionEbooksByBookIds } from './companion-ebook.repository.js';
+import { toCompanionEbookV1 } from '@shared/schemas/v1/companion-ebook.js';
+
+/**
+ * Batch ASIN → library-status lookup for the v1 metadata-search cross-reference
+ * (#1537). Given the result ASINs of a metadata search, returns a Map keyed by
+ * the UPPERCASED ASIN with `{ bookId: <bk_ publicId>, status, companionEbook }`
+ * for each owned book — so the caller does a plain
+ * `.get(result.asin?.toUpperCase())`.
+ *
+ * Case-insensitive by design: ASINs are NOT globally normalized in narratorr
+ * (the parser uppercases, but API validators only `.trim()` and add-by-ASIN
+ * stores as-is), so an exact `IN` would silently miss a case-drifted stored
+ * ASIN and wrongly show every such book as "not owned". We match on
+ * `upper(asin)` — matching `idx_books_asin_unique`, which is
+ * `upper("asin") WHERE asin IS NOT NULL`, and matching what `:367` and `:484`
+ * already do. (An earlier revision used `lower(asin)` and cited a
+ * `book-list.service` precedent; that was the wrong precedent, and it made this
+ * query unable to use the index at all.)
+ *
+ * **`asin IS NOT NULL` in the predicate is NOT redundant.** SQLite will only use a
+ * PARTIAL index when the query restates its condition, even where the condition is
+ * logically implied. Measured with EXPLAIN QUERY PLAN against the real schema:
+ * `lower(asin) IN (…)` → `SCAN books`; `upper(asin) IN (…)` → **still** `SCAN books`;
+ * `upper(asin) IN (…) AND asin IS NOT NULL` → `SEARCH books USING INDEX
+ * idx_books_asin_unique`. Dropping either half silently returns this to a full scan
+ * of `books` on every metadata search.
+ *
+ * The query is bounded by the small search result set (currently ≤10), so no
+ * chunking is needed — but guard the empty list so we never emit `IN ()`.
+ *
+ * Null-ASIN owned books cannot match (the index is partial); that limitation is
+ * accepted and documented in #1537, so the added predicate encodes an existing
+ * invariant rather than changing behaviour.
+ *
+ * **Companion ebooks (#1961).** `companionEnabled` is supplied BY THE CALLER —
+ * this service takes no `SettingsService`, matching the convention
+ * `isCompanionEbookEligible` already sets. When it is false, or when no row
+ * matched, NO companion query is issued and every value carries
+ * `companionEbook: null`. Otherwise observations are batch-loaded by numeric
+ * `books.id` through `findCompanionEbooksByBookIds` (already chunked at 480),
+ * so the whole annotation costs one books select plus
+ * `ceil(matched / 480)` companion selects — never one per result.
+ *
+ * The select therefore also projects the numeric `books.id` (the companion FK).
+ * It does NOT project `books.path`: the exposure predicate takes exactly
+ * `{ enabled, bookStatus, observationStatus }` and must never grow a live/path
+ * term (see `src/shared/companion-ebook-exposure.ts`). The projection is built
+ * inside this method body, never as a module-level constant
+ * (`drizzle-schema-toplevel-deref-breaks-partial-mocks`).
+ */
+export async function findLibraryStatusByAsins(
+  db: Db,
+  asins: string[],
+  options: { companionEnabled: boolean },
+): Promise<Map<string, LibraryStatusByAsin>> {
+  const map = new Map<string, LibraryStatusByAsin>();
+  if (asins.length === 0) return map;
+
+  const uppered = asins.map((a) => a.toUpperCase());
+  const rows = await db
+    .select({ id: books.id, bookId: books.publicId, status: books.status, asin: books.asin })
+    .from(books)
+    // `upper()`, and the redundant-looking `asin IS NOT NULL`, are BOTH required to hit
+    // `idx_books_asin_unique` — see the note above the method. Measured with
+    // EXPLAIN QUERY PLAN: `lower(asin) IN (…)` and `upper(asin) IN (…)` both SCAN;
+    // only `upper(asin) IN (…) AND asin IS NOT NULL` produces
+    // `SEARCH books USING INDEX idx_books_asin_unique`.
+    .where(and(inArray(sql`upper(${books.asin})`, uppered), isNotNull(books.asin)));
+
+  const matchedIds = rows.filter((r) => r.asin != null).map((r) => r.id);
+  const companionByBookId: Map<number, CompanionEbookRow> =
+    options.companionEnabled && matchedIds.length > 0
+      ? await findCompanionEbooksByBookIds(db, matchedIds)
+      : new Map();
+
+  for (const row of rows) {
+    if (row.asin == null) continue;
+    const status = row.status as BookStatus;
+    map.set(row.asin.toUpperCase(), {
+      bookId: row.bookId,
+      status,
+      // The exposure→DTO decision lives in exactly one place (#1961 AC 10a) —
+      // no term, no size guard, and no `'epub'` literal is re-spelled here.
+      companionEbook: toCompanionEbookV1({
+        enabled: options.companionEnabled,
+        bookStatus: status,
+        observation: companionByBookId.get(row.id),
+      }),
+    });
+  }
+  return map;
+}

--- a/src/server/services/book-list.service.test.ts
+++ b/src/server/services/book-list.service.test.ts
@@ -1328,3 +1328,64 @@ describe('getIdentifiers() — authorSlug field (#133)', () => {
     expect(result[0]!.authorSlug).toBe('jk-rowling');
   });
 });
+
+// ─── #2069 AC16: the raw tombstone column must not reach GET /api/books ───
+//
+// `getAll` spreads whole `books` rows into its result and casts to
+// `BookWithAuthor`. That declared type omits the column, but the cast is erased at
+// runtime — the strip has to happen in the service, and only a seeded row can prove
+// it did. The download/activity assertions exercise DIFFERENT builders and cannot
+// fail if this list-specific strip is removed.
+//
+// Counterfactual: drop the `stripClearedFields` call at `book-list.service.ts` and
+// every case below goes red.
+describe('BookListService — user_cleared_fields is projected out (#2069 AC16)', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let service: BookListService;
+
+  const seededBook = createMockDbBook({ userClearedFields: '["genres"]' });
+
+  beforeEach(() => {
+    db = createMockDb();
+    service = new BookListService(inject<Db>(db));
+  });
+
+  function seedOneRow() {
+    db.select
+      .mockReturnValueOnce(mockDbChain([{ value: 1 }]))
+      .mockReturnValueOnce(mockDbChain([{ book: seededBook, importListName: null, primaryAuthorName: 'Brandon Sanderson' }]))
+      .mockReturnValueOnce(mockDbChain([{ bookId: 1, author: mockAuthor, position: 0 }]))
+      .mockReturnValueOnce(mockDbChain([]));
+  }
+
+  it('getAll rows carry no userClearedFields key', async () => {
+    seedOneRow();
+
+    const { data } = await service.getAll();
+
+    // Key PRESENCE, not value — an implementation that copies `undefined` through
+    // serializes nothing but must not pass by accident, and one that copies the raw
+    // string must fail.
+    expect('userClearedFields' in data[0]!).toBe(false);
+  });
+
+  it('the serialized list body contains neither the key nor the stored value', async () => {
+    seedOneRow();
+
+    const { data } = await service.getAll();
+
+    const body = JSON.stringify({ data, total: 1 });
+    expect(body).not.toContain('userClearedFields');
+    expect(body).not.toContain('["genres"]');
+  });
+
+  it('every other book column survives the strip', async () => {
+    seedOneRow();
+
+    const { data } = await service.getAll();
+
+    expect(data[0]!.title).toBe(seededBook.title);
+    expect(data[0]!.id).toBe(seededBook.id);
+    expect(data[0]!.authors[0]?.name).toBe('Brandon Sanderson');
+  });
+});

--- a/src/server/services/book-list.service.ts
+++ b/src/server/services/book-list.service.ts
@@ -7,6 +7,7 @@ import type { LibraryBookListItem } from '@shared/schemas/library-book.js';
 import { sortCollapsedRows, collapseRows, buildFallbackCompare } from './book-list-collapse.js';
 import type { BookWithAuthor } from './book.service.js';
 import type { BookRow } from './types.js';
+import { stripClearedFields } from './book-row-public.js';
 
 /** Server-side row shape for the library list — same fields as the wire
  *  LibraryBookListItem but with Drizzle Date timestamps (Fastify serializes
@@ -209,7 +210,10 @@ export class BookListService {
         .map((n) => n.narrator);
 
       return {
-        ...r.book,
+        // Drop the raw `user_cleared_fields` text (#2069 AC16): this list spreads
+        // whole `books` rows and its declared `BookWithAuthor` return type omits
+        // the column, but the `as` cast below cannot enforce that at runtime.
+        ...stripClearedFields(r.book as BookRow),
         importListName: r.importListName ?? null,
         authors: sortedAuthors,
         narrators: sortedNarrators,

--- a/src/server/services/book-rejection.service.test.ts
+++ b/src/server/services/book-rejection.service.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { createMockDb, createMockLogger, inject, mockDbChain } from '../__tests__/helpers.js';
 import { createMockDbBook } from '../__tests__/factories.js';
 import { BookRejectionService, BookRejectionError } from './book-rejection.service.js';
-import { BookService, type BookWithAuthor } from './book.service.js';
+import { BookService, type BookDetail } from './book.service.js';
 import type { DeleteManagedFilesResult } from '../utils/delete-managed-files.js';
 import { PathOutsideLibraryError } from '../utils/paths.js';
 import type { BlacklistService } from './blacklist.service.js';
@@ -253,7 +253,7 @@ describe('BookRejectionService', () => {
         // Real BookService: deleteBookFiles touches only the filesystem + logger (no DB), so the mock
         // DB is unused there; getById is spied to return the staged book.
         const realBookService = new BookService(inject<Db>(createMockDb()), inject<FastifyBaseLogger>(createMockLogger()));
-        vi.spyOn(realBookService, 'getById').mockResolvedValue({ ...importedBook, path: bookDir } as unknown as BookWithAuthor);
+        vi.spyOn(realBookService, 'getById').mockResolvedValue({ ...importedBook, path: bookDir, userClearedFields: [] } as unknown as BookDetail);
 
         const { service } = createService({
           bookService: realBookService,

--- a/src/server/services/book-rejection.service.ts
+++ b/src/server/services/book-rejection.service.ts
@@ -13,7 +13,7 @@ import { triggerCompanionReconcile, type CompanionBookReconcileTrigger } from '.
 import { preserveBookCover } from '../utils/cover-cache.js';
 import { config } from '../config.js';
 import { serializeError } from '../utils/serialize-error.js';
-import type { BookRow } from './types.js';
+import type { BookRowPublic } from './types.js';
 
 export class BookRejectionService {
   constructor(
@@ -113,7 +113,7 @@ export class BookRejectionService {
     this.log.info({ bookId, title: book.title }, 'Book rejected as wrong release');
   }
 
-  private recordWrongReleaseEvent(book: BookRow): void {
+  private recordWrongReleaseEvent(book: BookRowPublic): void {
     if (!this.eventHistory) return;
 
     this.eventHistory.create({

--- a/src/server/services/book-row-public.ts
+++ b/src/server/services/book-row-public.ts
@@ -1,0 +1,15 @@
+import type { BookRow, BookRowPublic } from './types.js';
+
+/**
+ * Drop the raw `user_cleared_fields` text from a whole-row `books` select (#2069 AC16).
+ *
+ * Call this at every seam where a book row becomes part of an HTTP response. The
+ * leak this prevents is a runtime object key, not a type error: the affected
+ * routes (`GET /api/activity`, `/activity/active`, `/activity/:id`, the retry
+ * `201`, `POST /api/search/grab`) declare no response schema, so nothing strips
+ * extra keys downstream — the projection has to happen in the service.
+ */
+export function stripClearedFields(row: BookRow): BookRowPublic {
+  const { userClearedFields: _userClearedFields, ...rest } = row;
+  return rest;
+}

--- a/src/server/services/book-series-link.ts
+++ b/src/server/services/book-series-link.ts
@@ -1,11 +1,12 @@
 import { and, eq, isNull, ne } from 'drizzle-orm';
 import type { FastifyBaseLogger } from 'fastify';
 import type { DbOrTx } from '@db/index.js';
-import { series, seriesMembers } from '@db/schema.js';
+import { books, series, seriesMembers } from '@db/schema.js';
 import { normalizeSeriesName } from '../utils/series-normalize.js';
 import { generatePublicId } from '../utils/public-id.js';
 import { normalizeMemberTitleForMatch } from './series-title-match.js';
 import { serializeError } from '../utils/serialize-error.js';
+import { parseClearedFields, serializeClearedFields } from '../utils/cleared-fields.js';
 
 /**
  * Slim payload for linking a freshly-created or rematched book to its series.
@@ -66,6 +67,37 @@ export async function replaceSeriesLink(
     position: args.position,
     source: 'local',
   });
+}
+
+/**
+ * Reconcile a book's `series_members` rows after the operator explicitly CLEARED
+ * its series through Edit Metadata (#2069 AC14). Runs on the caller's handle,
+ * inside the same transaction as the clear, so a failure here rolls the clear
+ * back rather than leaving exactly the stale residue this removes.
+ *
+ * The two sources are treated differently on purpose:
+ *
+ *   - `source: 'local'` rows are the book's own create-time cache seed. Nothing
+ *     else references them, so they are DELETED.
+ *   - `source: 'hardcover'` rows are canonical members of the series and still
+ *     belong on the SIBLING series card. Deleting one would drop a canonical
+ *     member until the weekly `series-refresh` cron rebuilds it, so the row keeps
+ *     its identity and only loses the book link (`book_id = NULL`). That is safe
+ *     for the cards: `buildCardFromCache` computes `inLibrary` by title-matching
+ *     against books selected on `books.series_name`, never off `series_members.book_id`.
+ *
+ * Deliberately NOT `replaceSeriesLink`, which deletes unconditionally by `bookId`
+ * — that behavior is correct for Fix Match and is left alone here.
+ */
+export async function detachBookFromSeriesMembers(tx: DbOrTx, bookId: number): Promise<void> {
+  await tx
+    .delete(seriesMembers)
+    .where(and(eq(seriesMembers.bookId, bookId), eq(seriesMembers.source, 'local')));
+  // Everything still linked to the book after that delete is provider-sourced.
+  await tx
+    .update(seriesMembers)
+    .set({ bookId: null, updatedAt: new Date() })
+    .where(eq(seriesMembers.bookId, bookId));
 }
 
 /**
@@ -179,4 +211,29 @@ export async function upsertSeriesLink(
   } catch (error: unknown) {
     log.warn({ error: serializeError(error), bookId, seriesName: args.name }, 'Series link upsert failed during book create');
   }
+}
+
+/**
+ * Read the book's tombstone set ON the supplied handle and return the canonical
+ * serialization with the `seriesName` entry removed (#2069 AC24) — the operator
+ * re-assertion a Hardcover series bind performs.
+ *
+ * Read → drop → validate → serialize, all inside the caller's transaction: the
+ * bind's `fetchById` is a network round-trip, so a `PUT` can add an unrelated
+ * tombstone while it is in flight and writing back a pre-fetch snapshot would
+ * silently erase that concurrent clear. Only `seriesName` is dropped — binding
+ * asserts nothing about the other clearable fields.
+ */
+export async function removeSeriesNameTombstone(
+  tx: DbOrTx,
+  log: FastifyBaseLogger,
+  bookId: number,
+): Promise<string | null> {
+  const rows = await tx
+    .select({ userClearedFields: books.userClearedFields })
+    .from(books)
+    .where(eq(books.id, bookId))
+    .limit(1);
+  const current = parseClearedFields(rows[0]?.userClearedFields ?? null, log, bookId);
+  return serializeClearedFields(current.filter((field) => field !== 'seriesName'));
 }

--- a/src/server/services/book.service.cleared-fields.test.ts
+++ b/src/server/services/book.service.cleared-fields.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createMockDb, createMockLogger, inject, mockDbChain } from '../__tests__/helpers.js';
+import { createMockDbBook, createMockDbAuthor } from '../__tests__/factories.js';
+import { BookService } from './book.service.js';
+import { CLEARABLE_BOOK_FIELDS } from '@shared/schemas/book.js';
+import { unmatchedGenres } from '@db/schema.js';
+import type { FastifyBaseLogger } from 'fastify';
+import type { Db, DbOrTx } from '@db/index.js';
+
+const mockAuthor = createMockDbAuthor();
+const mockBook = createMockDbBook();
+
+/** Queue the three getById selects onto whichever handle hydration runs on. */
+function queueGetById(handle: ReturnType<typeof createMockDb>) {
+  handle.select
+    .mockReturnValueOnce(mockDbChain([{ book: mockBook, importListName: null }]))
+    .mockReturnValueOnce(mockDbChain([{ author: mockAuthor, position: 0 }]))
+    .mockReturnValueOnce(mockDbChain([]));
+}
+
+describe('BookService — user-cleared fields (#2069)', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let log: ReturnType<typeof createMockLogger>;
+  let service: BookService;
+  let updateChain: ReturnType<typeof mockDbChain>;
+
+  beforeEach(() => {
+    db = createMockDb();
+    log = createMockLogger();
+    service = new BookService(inject<Db>(db), inject<FastifyBaseLogger>(log));
+    updateChain = mockDbChain([{ id: 1 }]);
+    db.update.mockReturnValue(updateChain);
+  });
+
+  /** The `.set(...)` payload the book UPDATE was actually issued with. */
+  function issuedSet(chain = updateChain): Record<string, unknown> {
+    return chain.set.mock.calls[0]![0] as Record<string, unknown>;
+  }
+
+  describe('AC2 — the write boundary rejects an unknown field name', () => {
+    it('throws BEFORE the transaction opens, issuing no write', async () => {
+      await expect(
+        service.update(1, { userClearedFields: '["genres","futureField"]' }),
+      ).rejects.toThrow();
+
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+      expect(updateChain.set).not.toHaveBeenCalled();
+    });
+
+    it('throws on an unparseable supplied column value, issuing no write', async () => {
+      await expect(service.update(1, { userClearedFields: '{oops' })).rejects.toThrow();
+
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(updateChain.set).not.toHaveBeenCalled();
+    });
+
+    it('accepts every canonical clearable name (guards against a typo’d enum)', async () => {
+      db.select.mockReturnValue(mockDbChain([{ userClearedFields: null }]));
+      queueGetById(db);
+
+      await service.update(1, { userClearedFields: JSON.stringify([...CLEARABLE_BOOK_FIELDS]) });
+
+      expect(issuedSet().userClearedFields).toBe(JSON.stringify([...CLEARABLE_BOOK_FIELDS].sort()));
+    });
+  });
+
+  describe('AC5 — only the userAsserted opt-in touches the column', () => {
+    it('an internal caller passing nulls writes no userClearedFields key at all', async () => {
+      queueGetById(db);
+
+      await service.update(1, { seriesName: null, seriesPosition: null, publisher: null });
+
+      expect(issuedSet()).not.toHaveProperty('userClearedFields');
+      // No precondition re-read either — the recompute never ran.
+      expect(db.select).toHaveBeenCalledTimes(3); // getById only
+    });
+
+    it('the userAsserted opt-in recomputes and writes the canonical set', async () => {
+      db.select.mockReturnValueOnce(mockDbChain([{ userClearedFields: null }]));
+      queueGetById(db);
+
+      await service.update(1, { seriesName: null, publisher: '  ' }, { userAsserted: true });
+
+      const set = issuedSet();
+      expect(set.userClearedFields).toBe('["publisher","seriesName"]');
+      // AC7: the stored values are normalized so they cannot contradict the tombstone.
+      expect(set.seriesName).toBeNull();
+      expect(set.publisher).toBeNull();
+    });
+  });
+
+  describe('AC8 / F24 — the set is re-read INSIDE the write transaction', () => {
+    it('merges a clear that commits between the caller entering update() and the transaction opening', async () => {
+      // The stored set is empty in the pre-transaction world; a concurrent operator
+      // edit commits `["subtitle"]` exactly as this transaction opens. An
+      // implementation that reads the set BEFORE `db.transaction` computes
+      // `["publisher"]` and silently erases that clear.
+      let stored: string | null = null;
+      let selectCall = 0;
+      db.select.mockImplementation(() => {
+        selectCall++;
+        if (selectCall === 1) return mockDbChain([{ userClearedFields: stored }]);
+        if (selectCall === 2) return mockDbChain([{ book: mockBook, importListName: null }]);
+        return mockDbChain([]);
+      });
+      db.transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => {
+        stored = '["subtitle"]';
+        return cb(db);
+      });
+
+      await service.update(1, { publisher: null }, { userAsserted: true });
+
+      expect(issuedSet().userClearedFields).toBe('["publisher","subtitle"]');
+    });
+
+    it('returns null without writing when the row disappeared before the transaction read it', async () => {
+      db.select.mockReturnValueOnce(mockDbChain([]));
+
+      const result = await service.update(999, { publisher: null }, { userAsserted: true });
+
+      expect(result).toBeNull();
+      expect(updateChain.set).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AC11 / F20 / F21 — the caller-owned transaction arm', () => {
+    it('runs every write on the caller handle, opens no transaction, and issues no off-handle query', async () => {
+      const tx = createMockDb();
+      const txUpdateChain = mockDbChain([{ id: 1 }]);
+      tx.update.mockReturnValue(txUpdateChain);
+      queueGetById(tx);
+
+      const result = await service.update(1, { genres: ['Fantasy'] }, { tx: inject<DbOrTx>(tx) });
+
+      expect(result).not.toBeNull();
+      expect(db.transaction).not.toHaveBeenCalled();
+      expect(tx.transaction).not.toHaveBeenCalled();
+      expect(tx.update).toHaveBeenCalledTimes(1);
+      // F20: the hydration read stays ON the handle, so it observes the write just
+      // made — a `this.db` read could not see the caller's uncommitted transaction.
+      expect(db.update).not.toHaveBeenCalled();
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it('runs no success log and no genre telemetry before the owner commits (F21)', async () => {
+      const tx = createMockDb();
+      tx.update.mockReturnValue(mockDbChain([{ id: 1 }]));
+      queueGetById(tx);
+
+      await service.update(1, { genres: ['Zzzz Unmatched Genre'] }, { tx: inject<DbOrTx>(tx) });
+      await Promise.resolve();
+
+      expect(log.info).not.toHaveBeenCalledWith(expect.anything(), 'Book updated');
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(tx.insert).not.toHaveBeenCalled();
+    });
+
+    it('the self-managed arm still logs and still tracks unmatched genres', async () => {
+      queueGetById(db);
+      db.insert.mockReturnValue(mockDbChain([]));
+
+      await service.update(1, { genres: ['Zzzz Unmatched Genre'] });
+      await Promise.resolve();
+
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+      expect(log.info).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }), 'Book updated');
+      expect(db.insert).toHaveBeenCalledWith(unmatchedGenres);
+    });
+
+    it('returns null on the tx arm when no row matched, without hydrating', async () => {
+      const tx = createMockDb();
+      tx.update.mockReturnValue(mockDbChain([]));
+
+      const result = await service.update(1, { title: 'Nope' }, { tx: inject<DbOrTx>(tx) });
+
+      expect(result).toBeNull();
+      expect(tx.select).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('AC13 — Fix Match resets the whole set', () => {
+    it('writes userClearedFields: null in the same transaction as the scalar replacement', async () => {
+      db.delete.mockReturnValue(mockDbChain([]));
+      db.insert.mockReturnValue(mockDbChain([{ id: 1 }]));
+      db.select.mockReturnValueOnce(mockDbChain([mockAuthor])); // syncAuthors → findOrCreateAuthor
+      queueGetById(db);
+
+      await service.fixMatch(1, { title: 'New Identity', authors: [{ name: 'Someone' }] });
+
+      const set = issuedSet();
+      expect(set.userClearedFields).toBeNull();
+      expect(set.enrichmentStatus).toBe('pending');
+      expect(db.transaction).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('AC16 — getById hydrates the parsed set', () => {
+    it('overrides the raw column with the parsed array', async () => {
+      db.select
+        .mockReturnValueOnce(mockDbChain([{ book: { ...mockBook, userClearedFields: '["genres","seriesName"]' }, importListName: null }]))
+        .mockReturnValueOnce(mockDbChain([{ author: mockAuthor, position: 0 }]))
+        .mockReturnValueOnce(mockDbChain([]));
+
+      const book = await service.getById(1);
+
+      expect(book!.userClearedFields).toEqual(['genres', 'seriesName']);
+    });
+
+    it('degrades a corrupt column to [] and warns once, without failing the request', async () => {
+      db.select
+        .mockReturnValueOnce(mockDbChain([{ book: { ...mockBook, userClearedFields: '{oops' }, importListName: null }]))
+        .mockReturnValueOnce(mockDbChain([]))
+        .mockReturnValueOnce(mockDbChain([]));
+
+      const book = await service.getById(7);
+
+      expect(book).not.toBeNull();
+      expect(book!.userClearedFields).toEqual([]);
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ bookId: 7 }),
+        expect.stringContaining('Unparseable userClearedFields'),
+      );
+    });
+  });
+});

--- a/src/server/services/book.service.test.ts
+++ b/src/server/services/book.service.test.ts
@@ -265,11 +265,16 @@ describe('BookService', () => {
         .mockReturnValueOnce(mockDbChain([{ author: mockAuthor, position: 0 }, { author: author2, position: 1 }]))
         .mockReturnValueOnce(mockDbChain([]));
 
+      // Real insert order: book row first (runResolvedInsert), then syncAuthors
+      // interleaves find-or-create with the junction row per author. The previous
+      // ordering made `findOrCreateAuthor` fall into its unique-violation retry and
+      // silently mis-align every later mock, which left `getById` reading the
+      // authors result as its book row.
       db.insert
-        .mockReturnValueOnce(mockDbChain([author2]))       // insert author[1]
         .mockReturnValueOnce(mockDbChain([{ id: 1 }]))     // insert book
-        .mockReturnValueOnce(mockDbChain([]))              // insert bookAuthors
-        .mockReturnValueOnce(mockDbChain([]));             // insert bookAuthors (2nd author)
+        .mockReturnValueOnce(mockDbChain([]))              // insert bookAuthors (author 0)
+        .mockReturnValueOnce(mockDbChain([author2]))       // insert author[1]
+        .mockReturnValueOnce(mockDbChain([]));             // insert bookAuthors (author 1)
 
       await service.create({
         title: 'The Way of Kings',
@@ -2079,7 +2084,7 @@ describe('BookService — transaction atomicity (#214)', () => {
       vi.mocked(unlink).mockReset();
       const preWriteBook = createMockDbBook({ id: 1, path: '/library/book', coverUrl: null });
       const getByIdSpy = vi.spyOn(service, 'getById')
-        .mockResolvedValueOnce(preWriteBook as Awaited<ReturnType<BookService['getById']>>) // initial existence/path check
+        .mockResolvedValueOnce(preWriteBook as unknown as Awaited<ReturnType<BookService['getById']>>) // initial existence/path check
         .mockRejectedValueOnce(new Error('libSQL read failed')); // post-write reload throws
       (writeFile as Mock).mockResolvedValue(undefined);
       (rename as Mock).mockResolvedValue(undefined);

--- a/src/server/services/book.service.ts
+++ b/src/server/services/book.service.ts
@@ -3,19 +3,26 @@ import { deleteManagedBookFiles, type DeleteManagedFilesResult } from '../utils/
 import { uploadBookCover, CoverUploadError } from './cover-upload.js';
 import type { CoverWriteOutcome } from './cover-write.js';
 import { SUPPORTED_COVER_MIMES } from '../utils/mime.js';
-import { eq, sql, inArray, and, isNotNull } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { Db, DbOrTx } from '@db/index.js';
 import type { FastifyBaseLogger } from 'fastify';
-import { books, authors, narrators, bookAuthors, bookNarrators, unmatchedGenres, importLists } from '@db/schema.js';
-import { slugify, findUnmatchedGenres, normalizeGenres } from '@core/index.js';
-import { replaceSeriesLink, upsertSeriesLink, type ReplaceSeriesLinkArgs } from './book-series-link.js';
+import { books, authors, narrators, bookAuthors, bookNarrators, importLists } from '@db/schema.js';
+import { slugify } from '@core/index.js';
+import { replaceSeriesLink, upsertSeriesLink, detachBookFromSeriesMembers, type ReplaceSeriesLinkArgs } from './book-series-link.js';
 import { findOrCreateAuthor, findOrCreateNarrator } from '../utils/find-or-create-person.js';
 import { type MetadataService } from './metadata.service.js';
 import { serializeError } from '../utils/serialize-error.js';
-import type { BookRow, CompanionEbookRow } from './types.js';
-import { productionTypeSchema, type BookStatus } from '@shared/schemas/book.js';
-import { findCompanionEbooksByBookIds } from './companion-ebook.repository.js';
-import { toCompanionEbookV1, type CompanionEbookV1 } from '@shared/schemas/v1/companion-ebook.js';
+import type { BookRow, BookRowPublic } from './types.js';
+import { productionTypeSchema, type BookStatus, type ClearableBookField } from '@shared/schemas/book.js';
+import {
+  parseClearedFields,
+  serializeClearedFields,
+  normalizeClearedFieldsColumn,
+  recomputeClearedFields,
+} from '../utils/cleared-fields.js';
+import type { CompanionEbookV1 } from '@shared/schemas/v1/companion-ebook.js';
+import { findLibraryStatusByAsins } from './book-library-status.js';
+import { trackUnmatchedGenres } from './unmatched-genres.js';
 import { buildNewBookValues, type CreateBookInput, type ResolvedBookCreateInput } from './book-create.js';
 import { canonicalizeAsin } from '@shared/asin.js';
 import { isUniqueViolation } from '@shared/error-message.js';
@@ -82,6 +89,10 @@ function buildFixMatchScalarUpdates(r: FixMatchReplacement): Partial<typeof book
     duration: r.duration ?? null,
     publishedDate: r.publishedDate ?? null,
     genres: r.genres ?? null,
+    // Re-identifying a book is a NEW operator assertion (#2069 AC13): the prior
+    // clears described the old record, so the whole tombstone set is reset rather
+    // than honored. Written in the same transaction as the scalar replacement.
+    userClearedFields: null,
     enrichmentStatus: 'pending',
     enrichmentAttempts: 0,
     updatedAt: new Date(),
@@ -98,10 +109,58 @@ function buildReplaceSeriesLinkArgs(r: FixMatchReplacement): ReplaceSeriesLinkAr
   };
 }
 
-export interface BookWithAuthor extends BookRow {
+/**
+ * A hydrated book row for LIST responses. Extends `BookRowPublic`, not `BookRow`,
+ * so the raw `user_cleared_fields` text cannot ride along into `GET /api/books`
+ * (#2069 AC16) — the list has no consumer for tombstones.
+ */
+export interface BookWithAuthor extends BookRowPublic {
   authors: AuthorRow[];
   narrators: NarratorRow[];
   importListName?: string | null;
+}
+
+/**
+ * The hydrated DETAIL shape (#2069 AC16) — what `getById`, `update`, `fixMatch`,
+ * and the create paths return, and therefore what `GET /api/books/:id` serializes.
+ *
+ * `userClearedFields` is the PARSED set (`parseClearedFields` output), never the
+ * raw column string: a corrupt row degrades to `[]` instead of failing the request.
+ * No consumer may assume the field is parsed unless it came from here.
+ */
+export interface BookDetail extends BookWithAuthor {
+  userClearedFields: ClearableBookField[];
+}
+
+/**
+ * Options for {@link BookService.update} (#2069).
+ *
+ * Both flags are explicit OPT-INS — `update()` never infers operator intent from
+ * the values it is handed. The internal callers (`refresh-scan`, `rename`,
+ * scheduled enrichment, `enrichment-utils`, post-import enrichment) all pass
+ * `null`s of their own and must neither create nor remove a tombstone.
+ */
+export interface BookUpdateOptions {
+  /**
+   * The write is an operator assertion (`PUT /api/books/:id`): recompute the
+   * tombstone set from the body and normalize blank clearable values to NULL
+   * (AC5/AC6/AC7). Also reconciles `series_members` when `seriesName` is blanked
+   * (AC14), in the same transaction.
+   */
+  userAsserted?: boolean;
+  /**
+   * Caller-owned transaction handle (AC11). Every write runs on it and NO
+   * transaction is opened — `db.transaction` is serialized per connection and
+   * nesting throws `NestedTransactionError`.
+   *
+   * **Pre-commit return contract.** On this arm the returned `BookDetail` is read
+   * on the caller's handle and therefore describes the state INSIDE their still-open
+   * transaction; if the owner rolls back, that state never existed. The arm is also
+   * deliberately side-effect-free — no success log, no unmatched-genre telemetry —
+   * so a rollback cannot strand bookkeeping for data that never committed (the same
+   * split `create`/`createResolved` already makes).
+   */
+  tx?: DbOrTx;
 }
 
 /** One entry of `findLibraryStatusByAsins`'s map — the v1 metadata-search
@@ -119,8 +178,18 @@ export class BookService {
     private metadataService?: MetadataService,
   ) {}
 
-  async getById(id: number): Promise<BookWithAuthor | null> {
-    const bookResults = await this.db
+  /**
+   * Hydrate one book into the DETAIL shape.
+   *
+   * `executor` defaults to `this.db`; a caller that owns a transaction passes its
+   * handle so the read stays ON that handle and observes its own uncommitted
+   * writes (#2069 AC11) — a `this.db` read cannot see them.
+   *
+   * The spread's raw `userClearedFields` string is OVERRIDDEN with the parsed set
+   * (AC16), so the raw column never leaves this service.
+   */
+  async getById(id: number, executor: DbOrTx = this.db): Promise<BookDetail | null> {
+    const bookResults = await executor
       .select({ book: books, importListName: importLists.name })
       .from(books)
       .leftJoin(importLists, eq(books.importListId, importLists.id))
@@ -129,14 +198,14 @@ export class BookService {
 
     if (bookResults.length === 0) return null;
 
-    const authorResults = await this.db
+    const authorResults = await executor
       .select({ author: authors, position: bookAuthors.position })
       .from(bookAuthors)
       .innerJoin(authors, eq(bookAuthors.authorId, authors.id))
       .where(eq(bookAuthors.bookId, id))
       .orderBy(bookAuthors.position);
 
-    const narratorResults = await this.db
+    const narratorResults = await executor
       .select({ narrator: narrators, position: bookNarrators.position })
       .from(bookNarrators)
       .innerJoin(narrators, eq(bookNarrators.narratorId, narrators.id))
@@ -145,6 +214,7 @@ export class BookService {
 
     return {
       ...bookResults[0]!.book,
+      userClearedFields: parseClearedFields(bookResults[0]!.book.userClearedFields, this.log, id),
       importListName: bookResults[0]!.importListName ?? null,
       authors: authorResults.sort((a, b) => a.position - b.position).map((r) => r.author),
       narrators: narratorResults.sort((a, b) => a.position - b.position).map((r) => r.narrator),
@@ -170,92 +240,14 @@ export class BookService {
 
   /**
    * Batch ASIN → library-status lookup for the v1 metadata-search cross-reference
-   * (#1537). Given the result ASINs of a metadata search, returns a Map keyed by
-   * the UPPERCASED ASIN with `{ bookId: <bk_ publicId>, status, companionEbook }`
-   * for each owned book — so the caller does a plain
-   * `.get(result.asin?.toUpperCase())`.
-   *
-   * Case-insensitive by design: ASINs are NOT globally normalized in narratorr
-   * (the parser uppercases, but API validators only `.trim()` and add-by-ASIN
-   * stores as-is), so an exact `IN` would silently miss a case-drifted stored
-   * ASIN and wrongly show every such book as "not owned". We match on
-   * `upper(asin)` — matching `idx_books_asin_unique`, which is
-   * `upper("asin") WHERE asin IS NOT NULL`, and matching what `:367` and `:484`
-   * already do. (An earlier revision used `lower(asin)` and cited a
-   * `book-list.service` precedent; that was the wrong precedent, and it made this
-   * query unable to use the index at all.)
-   *
-   * **`asin IS NOT NULL` in the predicate is NOT redundant.** SQLite will only use a
-   * PARTIAL index when the query restates its condition, even where the condition is
-   * logically implied. Measured with EXPLAIN QUERY PLAN against the real schema:
-   * `lower(asin) IN (…)` → `SCAN books`; `upper(asin) IN (…)` → **still** `SCAN books`;
-   * `upper(asin) IN (…) AND asin IS NOT NULL` → `SEARCH books USING INDEX
-   * idx_books_asin_unique`. Dropping either half silently returns this to a full scan
-   * of `books` on every metadata search.
-   *
-   * The query is bounded by the small search result set (currently ≤10), so no
-   * chunking is needed — but guard the empty list so we never emit `IN ()`.
-   *
-   * Null-ASIN owned books cannot match (the index is partial); that limitation is
-   * accepted and documented in #1537, so the added predicate encodes an existing
-   * invariant rather than changing behaviour.
-   *
-   * **Companion ebooks (#1961).** `companionEnabled` is supplied BY THE CALLER —
-   * this service takes no `SettingsService`, matching the convention
-   * `isCompanionEbookEligible` already sets. When it is false, or when no row
-   * matched, NO companion query is issued and every value carries
-   * `companionEbook: null`. Otherwise observations are batch-loaded by numeric
-   * `books.id` through `findCompanionEbooksByBookIds` (already chunked at 480),
-   * so the whole annotation costs one books select plus
-   * `ceil(matched / 480)` companion selects — never one per result.
-   *
-   * The select therefore also projects the numeric `books.id` (the companion FK).
-   * It does NOT project `books.path`: the exposure predicate takes exactly
-   * `{ enabled, bookStatus, observationStatus }` and must never grow a live/path
-   * term (see `src/shared/companion-ebook-exposure.ts`). The projection is built
-   * inside this method body, never as a module-level constant
-   * (`drizzle-schema-toplevel-deref-breaks-partial-mocks`).
+   * (#1537). Delegates to the free function in `book-library-status.ts` (keeps this
+   * file under the line cap); see there for the index-usage and companion notes.
    */
   async findLibraryStatusByAsins(
     asins: string[],
     options: { companionEnabled: boolean },
   ): Promise<Map<string, LibraryStatusByAsin>> {
-    const map = new Map<string, LibraryStatusByAsin>();
-    if (asins.length === 0) return map;
-
-    const uppered = asins.map((a) => a.toUpperCase());
-    const rows = await this.db
-      .select({ id: books.id, bookId: books.publicId, status: books.status, asin: books.asin })
-      .from(books)
-      // `upper()`, and the redundant-looking `asin IS NOT NULL`, are BOTH required to hit
-      // `idx_books_asin_unique` — see the note above the method. Measured with
-      // EXPLAIN QUERY PLAN: `lower(asin) IN (…)` and `upper(asin) IN (…)` both SCAN;
-      // only `upper(asin) IN (…) AND asin IS NOT NULL` produces
-      // `SEARCH books USING INDEX idx_books_asin_unique`.
-      .where(and(inArray(sql`upper(${books.asin})`, uppered), isNotNull(books.asin)));
-
-    const matchedIds = rows.filter((r) => r.asin != null).map((r) => r.id);
-    const companionByBookId: Map<number, CompanionEbookRow> =
-      options.companionEnabled && matchedIds.length > 0
-        ? await findCompanionEbooksByBookIds(this.db, matchedIds)
-        : new Map();
-
-    for (const row of rows) {
-      if (row.asin == null) continue;
-      const status = row.status as BookStatus;
-      map.set(row.asin.toUpperCase(), {
-        bookId: row.bookId,
-        status,
-        // The exposure→DTO decision lives in exactly one place (#1961 AC 10a) —
-        // no term, no size guard, and no `'epub'` literal is re-spelled here.
-        companionEbook: toCompanionEbookV1({
-          enabled: options.companionEnabled,
-          bookStatus: status,
-          observation: companionByBookId.get(row.id),
-        }),
-      });
-    }
-    return map;
+    return findLibraryStatusByAsins(this.db, asins, options);
   }
 
   /**
@@ -319,7 +311,7 @@ export class BookService {
    * hydrates to a `BookWithAuthor`. The post-commit side effects live here (not
    * in the primitive) so a future caller-owned-tx rollback can never strand them.
    */
-  async create(data: CreateBookInput): Promise<BookWithAuthor> {
+  async create(data: CreateBookInput): Promise<BookDetail> {
     const resolved = await this.resolveCreateInput(data);
     const bookId = await this.createResolved(resolved);
 
@@ -330,7 +322,7 @@ export class BookService {
     // explicit `null` rather than a leftover input string.
     this.log.info({ title: data.title, authors: data.authors?.map(a => a.name), asin: canonicalizeAsin(resolved.asin) }, 'Book added to library');
     this.trackUnmatchedGenres(data.genres).catch((error) => this.log.debug({ error: serializeError(error) }, 'Failed to track unmatched genres'));
-    return this.getById(bookId) as Promise<BookWithAuthor>;
+    return this.getById(bookId) as Promise<BookDetail>;
   }
 
   /**
@@ -437,7 +429,11 @@ export class BookService {
     return id;
   }
 
-  async update(id: number, data: { [K in keyof NewBook]?: NewBook[K] | undefined } & { narrators?: string[] | undefined; authors?: { name: string; asin?: string | undefined }[] | undefined }): Promise<BookWithAuthor | null> {
+  async update(
+    id: number,
+    data: { [K in keyof NewBook]?: NewBook[K] | undefined } & { narrators?: string[] | undefined; authors?: { name: string; asin?: string | undefined }[] | undefined },
+    options?: BookUpdateOptions,
+  ): Promise<BookDetail | null> {
     const { narrators: narratorNames, authors: authorList, ...bookData } = data;
 
     // Canonicalize the ASIN at this service-internal write boundary (#1733). The
@@ -458,25 +454,26 @@ export class BookService {
       bookData.productionType = productionTypeSchema.parse(bookData.productionType);
     }
 
-    const updated = await this.db.transaction(async (tx) => {
-      const result = await tx
-        .update(books)
-        .set({ ...bookData, updatedAt: new Date() })
-        .where(eq(books.id, id))
-        .returning();
+    // Same write-boundary rule for the tombstone column (#2069 AC2) — SQLite text
+    // columns emit no DB CHECK either. A supplied raw value carrying an unknown
+    // field name throws HERE, before any transaction opens, so no `.set(...)` is
+    // ever issued for it.
+    if ('userClearedFields' in bookData) {
+      bookData.userClearedFields = normalizeClearedFieldsColumn(bookData.userClearedFields as string | null | undefined);
+    }
 
-      if (result.length === 0) return false;
+    // Caller owns the transaction: run every write on their handle, open none,
+    // and skip the post-commit side effects entirely (they'd be stranded by a
+    // rollback the owner may still perform). The hydration reads their handle so
+    // it observes the writes just made — see `BookUpdateOptions.tx`.
+    if (options?.tx) {
+      const applied = await this.runUpdate(options.tx, id, bookData, narratorNames, authorList, options);
+      return applied ? this.getById(id, options.tx) : null;
+    }
 
-      if (narratorNames !== undefined) {
-        await this.syncNarrators(tx, id, narratorNames);
-      }
-
-      if (authorList !== undefined) {
-        await this.syncAuthors(tx, id, authorList);
-      }
-
-      return true;
-    });
+    const updated = await this.db.transaction((tx) =>
+      this.runUpdate(tx, id, bookData, narratorNames, authorList, options),
+    );
 
     if (!updated) return null;
 
@@ -490,6 +487,68 @@ export class BookService {
     }
 
     return this.getById(id);
+  }
+
+  /**
+   * The in-transaction write sequence shared by both `update()` arms. Returns
+   * whether a row matched.
+   *
+   * On the `userAsserted` path the tombstone read-modify-write happens HERE, on
+   * the same handle as the scalar UPDATE (#2069 AC8): re-reading the stored set
+   * inside the transaction is what keeps two concurrent edits from interleaving
+   * into a stale set — an implementation that reads it before the transaction
+   * opens can silently drop the other edit's tombstone.
+   */
+  private async runUpdate(
+    tx: DbOrTx,
+    id: number,
+    bookData: Record<string, unknown>,
+    narratorNames: string[] | undefined,
+    authorList: { name: string; asin?: string | undefined }[] | undefined,
+    options: BookUpdateOptions | undefined,
+  ): Promise<boolean> {
+    const setValues: Record<string, unknown> = { ...bookData };
+    let blankedSeriesName = false;
+
+    if (options?.userAsserted) {
+      const existing = await tx
+        .select({ userClearedFields: books.userClearedFields })
+        .from(books)
+        .where(eq(books.id, id))
+        .limit(1);
+      if (existing.length === 0) return false;
+
+      const current = parseClearedFields(existing[0]!.userClearedFields, this.log, id);
+      const { cleared, normalized, blanked } = recomputeClearedFields(current, bookData);
+      Object.assign(setValues, normalized);
+      setValues.userClearedFields = serializeClearedFields(cleared);
+      blankedSeriesName = blanked.includes('seriesName');
+    }
+
+    const result = await tx
+      .update(books)
+      .set({ ...setValues, updatedAt: new Date() })
+      .where(eq(books.id, id))
+      .returning();
+
+    if (result.length === 0) return false;
+
+    if (narratorNames !== undefined) {
+      await this.syncNarrators(tx, id, narratorNames);
+    }
+
+    if (authorList !== undefined) {
+      await this.syncAuthors(tx, id, authorList);
+    }
+
+    // Series membership residue (#2069 AC14). Same transaction as the scalar
+    // write, so a reconcile failure rolls the clear back too rather than leaving
+    // exactly the stale residue this exists to remove.
+    if (blankedSeriesName) {
+      await detachBookFromSeriesMembers(tx, id);
+    }
+
+    return true;
   }
 
   /**
@@ -527,7 +586,7 @@ export class BookService {
    * `findAsinCollision`. Any non-collision DB failure bubbles up and rolls
    * back the entire transaction.
    */
-  async fixMatch(id: number, replacement: FixMatchReplacement): Promise<BookWithAuthor | null> {
+  async fixMatch(id: number, replacement: FixMatchReplacement): Promise<BookDetail | null> {
     const scalarUpdates = buildFixMatchScalarUpdates(replacement);
     const seriesArgs = buildReplaceSeriesLinkArgs(replacement);
 
@@ -551,7 +610,7 @@ export class BookService {
     return this.getById(id);
   }
 
-  async updateStatus(id: number, status: BookRow['status']): Promise<BookWithAuthor | null> {
+  async updateStatus(id: number, status: BookRow['status']): Promise<BookDetail | null> {
     this.log.info({ id, status }, 'Book status changed');
     return this.update(id, { status });
   }
@@ -602,7 +661,7 @@ export class BookService {
     bookId: number,
     buffer: Buffer,
     mimeType: string,
-  ): Promise<{ book: BookWithAuthor; coverOutcome: CoverWriteOutcome }> {
+  ): Promise<{ book: BookDetail; coverOutcome: CoverWriteOutcome }> {
     if (!SUPPORTED_COVER_MIMES.has(mimeType)) {
       throw new CoverUploadError('Only JPG, PNG, and WebP images are supported', 'INVALID_MIME');
     }
@@ -620,27 +679,12 @@ export class BookService {
     // usable state and still fires its `'metadata'` refresh. `finalizeCoverWrite` deliberately keeps
     // `coverOutcome === 'written'` on a post-rename DB failure *so the refresh fires* — re-throwing
     // here on a reload miss would re-introduce the very failure point it avoids.
-    const reloaded = await this.getById(bookId).catch(() => book) as BookWithAuthor;
+    const reloaded = await this.getById(bookId).catch(() => book) as BookDetail;
     return { book: reloaded, coverOutcome };
   }
 
   /** Fire-and-forget: track genres not in the synonym/known lists for future analysis */
   async trackUnmatchedGenres(genres: string[] | undefined): Promise<void> {
-    const unmatched = findUnmatchedGenres(normalizeGenres(genres));
-    if (unmatched.length === 0) return;
-
-    for (const genre of unmatched) {
-      await this.db
-        .insert(unmatchedGenres)
-        .values({ genre, count: 1 })
-        .onConflictDoUpdate({
-          target: unmatchedGenres.genre,
-          set: {
-            count: sql`${unmatchedGenres.count} + 1`,
-            lastSeen: sql`(unixepoch())`,
-          },
-        });
-    }
-    this.log.debug({ genres: unmatched }, 'Tracked unmatched genres');
+    return trackUnmatchedGenres(this.db, this.log, genres);
   }
 }

--- a/src/server/services/companion-ebook-file-preservation.test.ts
+++ b/src/server/services/companion-ebook-file-preservation.test.ts
@@ -7,7 +7,7 @@ import type { FastifyBaseLogger } from 'fastify';
 import type { Db } from '@db/index.js';
 import { createMockDb, createMockLogger, inject, mockDbChain, createMockSettingsService } from '../__tests__/helpers.js';
 import { createMockDbBook } from '../__tests__/factories.js';
-import { BookService, type BookWithAuthor } from './book.service.js';
+import { BookService, type BookDetail } from './book.service.js';
 import { BookRejectionService } from './book-rejection.service.js';
 import { RenameService } from './rename.service.js';
 import type { BlacklistService } from './blacklist.service.js';
@@ -84,7 +84,7 @@ describe('companion .epub survives every file-cleanup path (#1960 AC32/AC33)', (
       lastGrabGuid: 'guid-abc',
       lastGrabInfoHash: 'hash-123',
     };
-    vi.spyOn(bookService, 'getById').mockResolvedValue(book as unknown as BookWithAuthor);
+    vi.spyOn(bookService, 'getById').mockResolvedValue({ ...book, userClearedFields: [] } as unknown as BookDetail);
     const db = createMockDb();
     db.update.mockReturnValue(mockDbChain());
     const service = new BookRejectionService(

--- a/src/server/services/download.service.test.ts
+++ b/src/server/services/download.service.test.ts
@@ -2414,3 +2414,77 @@ describe('DownloadService', () => {
     });
   });
 });
+
+// ─── #2069 AC16: the raw tombstone column must not reach a serialized response ───
+//
+// `DownloadWithBook.book` is a `BookRowPublic`, and each builder copies the joined
+// row wholesale into five responses that declare NO response schema — nothing
+// downstream strips extra keys, so the projection has to happen in the service.
+// Typecheck alone cannot catch a regression here: the leak is a runtime object key
+// and the old code reached the response through a `BookRow`-typed field that
+// compiles fine. These assert on key PRESENCE, not value — an implementation that
+// copies `undefined` through serializes nothing but should not pass by accident,
+// and one that copies the raw string must fail.
+//
+// Counterfactual: revert `DownloadWithBook.book` to `BookRow` (drop the
+// `stripClearedFields` calls) and every case below goes red.
+describe('DownloadService — user_cleared_fields is projected out (#2069 AC16)', () => {
+  let db: ReturnType<typeof createMockDb>;
+  let service: DownloadService;
+
+  const seededBook = createMockDbBook({ userClearedFields: '["genres"]' });
+
+  beforeEach(() => {
+    db = createMockDb();
+    service = new DownloadService(
+      inject<Db>(db),
+      createMockDownloadClientService(),
+      inject<FastifyBaseLogger>(createMockLogger()),
+    );
+  });
+
+  it('getAll: the joined book carries no userClearedFields key', async () => {
+    db.select
+      .mockReturnValueOnce(mockDbChain([{ value: 1 }]))
+      .mockReturnValueOnce(mockDbChain([{ download: mockDownload, book: seededBook }]));
+
+    const { data } = await service.getAll();
+
+    expect(data[0]!.book).toBeDefined();
+    expect('userClearedFields' in data[0]!.book!).toBe(false);
+    expect(JSON.stringify(data[0])).not.toContain('userClearedFields');
+  });
+
+  it('getById: the joined book carries no userClearedFields key', async () => {
+    db.select.mockReturnValueOnce(mockDbChain([{ download: mockDownload, book: seededBook }]));
+
+    const row = await service.getById(1);
+
+    expect('userClearedFields' in row!.book!).toBe(false);
+  });
+
+  it('getActive: the joined book carries no userClearedFields key', async () => {
+    db.select.mockReturnValueOnce(mockDbChain([{ download: mockDownload, book: seededBook }]));
+
+    const rows = await service.getActive();
+
+    expect('userClearedFields' in rows[0]!.book!).toBe(false);
+  });
+
+  it('getActiveByBookId: the joined book carries no userClearedFields key', async () => {
+    db.select.mockReturnValueOnce(mockDbChain([{ download: mockDownload, book: seededBook }]));
+
+    const rows = await service.getActiveByBookId(1);
+
+    expect('userClearedFields' in rows[0]!.book!).toBe(false);
+  });
+
+  it('preserves every other book column while stripping only that one', async () => {
+    db.select.mockReturnValueOnce(mockDbChain([{ download: mockDownload, book: seededBook }]));
+
+    const row = await service.getById(1);
+
+    expect(row!.book!.title).toBe(seededBook.title);
+    expect(row!.book!.id).toBe(seededBook.id);
+  });
+});

--- a/src/server/services/download.service.ts
+++ b/src/server/services/download.service.ts
@@ -23,7 +23,8 @@ import { resolveAdapterDownloadUrl } from './download-resolve-adapter-url.js';
 import { resolveArtifact, insertDownloadRecordOrCompensate } from './download-record.js';
 import { gatherBookBlockers, classifyBlockers } from './download-blockers.js';
 
-import type { BookRow, DownloadRow } from './types.js';
+import type { BookRowPublic, DownloadRow } from './types.js';
+import { stripClearedFields } from './book-row-public.js';
 import type { BookStatus } from '@shared/schemas/book.js';
 import { serializeError } from '../utils/serialize-error.js';
 import { DownloadError, DuplicateDownloadError } from './download-errors.js';
@@ -31,7 +32,16 @@ import { DownloadError, DuplicateDownloadError } from './download-errors.js';
 export interface DownloadWithBook extends DownloadRow {
   /** Derived legacy display status — the REST/SSE/client compatibility seam (#1445). */
   status: DownloadStatus;
-  book?: BookRow;
+  /**
+   * `BookRowPublic`, not `BookRow` (#2069 AC16). Every builder below copies the
+   * joined row wholesale into a response that has NO response schema to strip
+   * extra keys — `GET /api/activity`, `/activity/active`, `/activity/:id`, the
+   * `retried` arm of `POST /api/activity/:id/retry`, and `POST /api/search/grab`
+   * (which serializes `grabInternal`'s `DownloadWithBook` directly). Stripping the
+   * raw `user_cleared_fields` text once in the shared row mapping is what keeps it
+   * out of all five.
+   */
+  book?: BookRowPublic;
   indexerName: string | null;
 }
 
@@ -113,7 +123,7 @@ export class DownloadService {
     const data = results.map((r) => ({
       ...r.download,
       status: deriveDisplayStatus(r.download.clientStatus, r.download.pipelineStage),
-      ...(r.book && { book: r.book }),
+      ...(r.book && { book: stripClearedFields(r.book) }),
       indexerName: r.indexer?.name ?? null,
     }));
 
@@ -138,7 +148,7 @@ export class DownloadService {
     return {
       ...results[0]!.download,
       status: deriveDisplayStatus(results[0]!.download.clientStatus, results[0]!.download.pipelineStage),
-      ...(results[0]!.book && { book: results[0]!.book }),
+      ...(results[0]!.book && { book: stripClearedFields(results[0]!.book) }),
       indexerName: results[0]!.indexer?.name ?? null,
     };
   }
@@ -159,7 +169,7 @@ export class DownloadService {
     return results.map((r) => ({
       ...r.download,
       status: deriveDisplayStatus(r.download.clientStatus, r.download.pipelineStage),
-      ...(r.book && { book: r.book }),
+      ...(r.book && { book: stripClearedFields(r.book) }),
       indexerName: r.indexer?.name ?? null,
     }));
   }
@@ -206,7 +216,7 @@ export class DownloadService {
     return results.map((r) => ({
       ...r.download,
       status: deriveDisplayStatus(r.download.clientStatus, r.download.pipelineStage),
-      ...(r.book && { book: r.book }),
+      ...(r.book && { book: stripClearedFields(r.book) }),
       indexerName: r.indexer?.name ?? null,
     }));
   }

--- a/src/server/services/enrichment-orchestration.helpers.test.ts
+++ b/src/server/services/enrichment-orchestration.helpers.test.ts
@@ -23,11 +23,25 @@ import { orchestrateBookEnrichment, applyAudnexusEnrichment } from './enrichment
 import { mockDbChain } from '../__tests__/helpers.js';
 import { RateLimitError, TransientError } from '@core/index.js';
 
-/** A db whose `update().set().where()` chain resolves; returns the captured chain for assertions. */
-function dbWithUpdateChain() {
+/**
+ * A db whose `update().set().where()` chain resolves; returns the captured chain
+ * for assertions.
+ *
+ * Also carries the two seams #2069 AC11 added to this path: a `select` (the
+ * pre-fetch ASIN capture AND the in-transaction re-read of
+ * `{ asin, user_cleared_fields }`) and a `transaction` that runs its callback on
+ * the same handle. Both reads hit the same stub, so the identity guard holds by
+ * construction unless a test deliberately varies the row between them.
+ */
+function dbWithUpdateChain(row?: { asin?: string | null; userClearedFields?: string | null }) {
   const updateChain = mockDbChain();
-  const db = { update: vi.fn().mockReturnValue(updateChain) } as unknown as Db;
-  return { db, updateChain };
+  const selectRow = { asin: row?.asin ?? null, userClearedFields: row?.userClearedFields ?? null };
+  const db = {
+    update: vi.fn().mockReturnValue(updateChain),
+    select: vi.fn().mockReturnValue(mockDbChain([selectRow])),
+  } as unknown as Db & { transaction: unknown };
+  db.transaction = vi.fn().mockImplementation((cb: (tx: Db) => Promise<unknown>) => cb(db));
+  return { db: db as Db, updateChain };
 }
 
 const mockEnrichBookFromAudio = vi.mocked(enrichBookFromAudio);
@@ -35,10 +49,10 @@ const mockResolveFfprobePath = vi.mocked(resolveFfprobePathFromSettings);
 
 function createMockDeps() {
   return {
-    db: {} as Db,
+    db: dbWithUpdateChain().db,
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() } as unknown as FastifyBaseLogger,
     settingsService: { get: vi.fn().mockResolvedValue({ }) } as unknown as SettingsService,
-    bookService: { update: vi.fn(), findAsinCollision: vi.fn().mockResolvedValue(null) } as unknown as BookService,
+    bookService: { update: vi.fn(), findAsinCollision: vi.fn().mockResolvedValue(null), trackUnmatchedGenres: vi.fn().mockResolvedValue(undefined) } as unknown as BookService,
     metadataService: { enrichBook: vi.fn(), resolveBook: vi.fn() } as unknown as MetadataService,
   };
 }
@@ -193,8 +207,7 @@ describe('applyAudnexusEnrichment', () => {
   });
 
   it('fills blank subtitle/publisher from the enrichment data (#1614)', async () => {
-    const updateChain = mockDbChain();
-    const db = { update: vi.fn().mockReturnValue(updateChain) } as unknown as Db;
+    const { db, updateChain } = dbWithUpdateChain();
     (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ subtitle: 'Filled Subtitle', publisher: 'Filled Publisher' });
 
     await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingSubtitle: null, existingPublisher: null }, { ...deps, db });
@@ -205,8 +218,7 @@ describe('applyAudnexusEnrichment', () => {
   });
 
   it('does NOT overwrite an existing subtitle/publisher (#1614)', async () => {
-    const updateChain = mockDbChain();
-    const db = { update: vi.fn().mockReturnValue(updateChain) } as unknown as Db;
+    const { db, updateChain } = dbWithUpdateChain();
     (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ subtitle: 'Provider Subtitle', publisher: 'Provider Publisher' });
 
     await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingSubtitle: 'Kept Subtitle', existingPublisher: 'Kept Publisher' }, { ...deps, db });
@@ -694,5 +706,191 @@ describe('buildBookCreatePayload (#1028)', () => {
     const { buildBookCreatePayload } = await import('./enrichment-orchestration.helpers.js');
     const payload = buildBookCreatePayload({ path: '/x', title: 'T' }, null, 'importing');
     expect(payload.productionType).toBe('unknown');
+  });
+});
+
+// ─── #2069 AC10/AC11: the post-import fill surface honors tombstones ───
+//
+// This is the SECOND fill-empty writer. It writes no series field, so only
+// `subtitle`, `publisher` and `genres` are guardable here — that asymmetry with the
+// scheduled job (AC9) is deliberate. Its scalar write and its array writes now also
+// share ONE transaction, and re-read the row identity inside it.
+describe('applyAudnexusEnrichment — user-cleared fields (#2069)', () => {
+  let deps: ReturnType<typeof createMockDeps>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    deps = createMockDeps();
+  });
+
+  const providerData = { subtitle: 'Provider Subtitle', publisher: 'Provider Publisher', genres: ['Fantasy'], narrators: ['Michael Kramer'] };
+
+  it('mixed state: a subtitle tombstone is omitted from the scalar set while publisher still fills', async () => {
+    const { db, updateChain } = dbWithUpdateChain({ userClearedFields: '["subtitle"]' });
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingSubtitle: null, existingPublisher: null }, { ...deps, db });
+
+    const setArg = updateChain.set.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg).not.toHaveProperty('subtitle');
+    expect(setArg.publisher).toBe('Provider Publisher');
+    expect(setArg.enrichmentStatus).toBe('enriched');
+  });
+
+  it('a publisher tombstone is omitted while subtitle still fills', async () => {
+    const { db, updateChain } = dbWithUpdateChain({ userClearedFields: '["publisher"]' });
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingSubtitle: null, existingPublisher: null }, { ...deps, db });
+
+    const setArg = updateChain.set.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg).not.toHaveProperty('publisher');
+    expect(setArg.subtitle).toBe('Provider Subtitle');
+  });
+
+  it('a genres tombstone skips the genres fill while the narrator fill in the same helper still runs', async () => {
+    const { db } = dbWithUpdateChain({ userClearedFields: '["genres"]' });
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+    const calls = (deps.bookService.update as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.map((c) => Object.keys(c[1] as object)[0])).toEqual(['narrators']);
+  });
+
+  it('AC10 scope: a seriesName-only tombstone leaves this path byte-identical to today', async () => {
+    const { db, updateChain } = dbWithUpdateChain({ userClearedFields: '["seriesName"]' });
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingSubtitle: null, existingPublisher: null, existingGenres: null, existingNarrator: null }, { ...deps, db });
+
+    const setArg = updateChain.set.mock.calls[0]![0] as Record<string, unknown>;
+    expect(setArg.subtitle).toBe('Provider Subtitle');
+    expect(setArg.publisher).toBe('Provider Publisher');
+    expect(setArg).not.toHaveProperty('seriesName');
+    const calls = (deps.bookService.update as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.map((c) => Object.keys(c[1] as object)[0])).toEqual(['narrators', 'genres']);
+  });
+
+  it('both writes share one transaction, and the array writes run on its handle', async () => {
+    const { db } = dbWithUpdateChain();
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+    expect((db as unknown as { transaction: ReturnType<typeof vi.fn> }).transaction).toHaveBeenCalledTimes(1);
+    for (const call of (deps.bookService.update as ReturnType<typeof vi.fn>).mock.calls) {
+      expect(call[2]).toEqual({ tx: expect.anything() });
+    }
+  });
+
+  // The F14 rollback proof deliberately does NOT live here. This suite's `db` and
+  // its transaction handle are the SAME object, so a regression that moved the
+  // scalar write before `db.transaction` would produce identical observations
+  // (same update chain, one transaction call, same rejected promise) — the test
+  // could not tell in-transaction from pre-transaction. It lives against a real
+  // migrated DB instead, with the split-transaction counterfactual executed
+  // alongside it: see `src/db/user-cleared-fields-schema.integration.test.ts`,
+  // 'AC11 / F14 — post-import atomicity, against a real DB'.
+
+  describe('F21 / F5 — the genre telemetry is a DEFERRED post-commit effect', () => {
+    it('runs the telemetry with the written payload, AFTER the write transaction resolves', async () => {
+      const order: string[] = [];
+      const { db } = dbWithUpdateChain();
+      const txMock = (db as unknown as { transaction: ReturnType<typeof vi.fn> }).transaction;
+      txMock.mockImplementation(async (cb: (tx: Db) => Promise<unknown>) => {
+        const result = await cb(db);
+        order.push('tx-committed');
+        return result;
+      });
+      (deps.bookService.trackUnmatchedGenres as ReturnType<typeof vi.fn>)
+        .mockImplementation(async () => { order.push('telemetry'); });
+      (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+      await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+      expect(deps.bookService.trackUnmatchedGenres).toHaveBeenCalledWith(['Fantasy']);
+      // Running this before the commit would strand it on a rollback — the tx arm of
+      // `update` emits no post-commit effects precisely so the owner can sequence it.
+      expect(order).toEqual(['tx-committed', 'telemetry']);
+    });
+
+    it('records nothing when the genre fill was suppressed by a tombstone', async () => {
+      const { db } = dbWithUpdateChain({ userClearedFields: '["genres"]' });
+      (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+      await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+      expect(deps.bookService.trackUnmatchedGenres).not.toHaveBeenCalled();
+    });
+
+    it('records nothing when the write is stale-dropped on the identity re-read', async () => {
+      const updateChain = mockDbChain();
+      const db = {
+        update: vi.fn().mockReturnValue(updateChain),
+        select: vi.fn()
+          .mockReturnValueOnce(mockDbChain([{ asin: 'B001' }]))
+          .mockReturnValue(mockDbChain([{ asin: 'B999_REIDENTIFIED', userClearedFields: null }])),
+      } as unknown as Db & { transaction: unknown };
+      db.transaction = vi.fn().mockImplementation((cb: (tx: Db) => Promise<unknown>) => cb(db as Db));
+      (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+      await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db: db as Db });
+
+      expect(deps.bookService.trackUnmatchedGenres).not.toHaveBeenCalled();
+    });
+
+    it('does NOT record for a narrators-only write (narrators carry no telemetry)', async () => {
+      const { db } = dbWithUpdateChain();
+      (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({ narrators: ['Michael Kramer'] });
+
+      await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+      expect(deps.bookService.update).toHaveBeenCalledWith(42, { narrators: ['Michael Kramer'] }, { tx: expect.anything() });
+      expect(deps.bookService.trackUnmatchedGenres).not.toHaveBeenCalled();
+    });
+
+    it('a telemetry failure is non-fatal — the success log still fires', async () => {
+      const { db } = dbWithUpdateChain();
+      (deps.bookService.trackUnmatchedGenres as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('telemetry boom'));
+      (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+      await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+      expect(deps.log.info).toHaveBeenCalledWith(expect.anything(), 'Audnexus enrichment applied');
+    });
+  });
+
+  it('F15: a Fix Match committed during the provider fetch aborts the write, tombstones held constant', async () => {
+    // The pre-fetch capture reads 'B001'; the in-transaction re-read sees the
+    // re-identified row. The tombstone column is NULL on both sides, so a
+    // tombstone-only guard could not catch this.
+    const updateChain = mockDbChain();
+    const db = {
+      update: vi.fn().mockReturnValue(updateChain),
+      select: vi.fn()
+        .mockReturnValueOnce(mockDbChain([{ asin: 'B001' }]))                                  // pre-fetch capture
+        .mockReturnValue(mockDbChain([{ asin: 'B999_REIDENTIFIED', userClearedFields: null }])), // in-tx re-read
+    } as unknown as Db & { transaction: unknown };
+    db.transaction = vi.fn().mockImplementation((cb: (tx: Db) => Promise<unknown>) => cb(db as Db));
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db: db as Db });
+
+    expect(updateChain.set).not.toHaveBeenCalled();
+    expect(deps.bookService.update).not.toHaveBeenCalled();
+    expect(deps.log.info).not.toHaveBeenCalledWith(expect.anything(), 'Audnexus enrichment applied');
+  });
+
+  it('negative control: with the identity unchanged the write lands and logs success', async () => {
+    const { db, updateChain } = dbWithUpdateChain({ asin: 'B001' });
+    (deps.metadataService.enrichBook as ReturnType<typeof vi.fn>).mockResolvedValueOnce(providerData);
+
+    await applyAudnexusEnrichment(42, { primaryAsin: 'B001', existingNarrator: null, existingGenres: null }, { ...deps, db });
+
+    expect(updateChain.set).toHaveBeenCalled();
+    expect(deps.log.info).toHaveBeenCalledWith(expect.anything(), 'Audnexus enrichment applied');
   });
 });

--- a/src/server/services/enrichment-orchestration.helpers.ts
+++ b/src/server/services/enrichment-orchestration.helpers.ts
@@ -1,6 +1,6 @@
 import type { FastifyBaseLogger } from 'fastify';
 import { eq } from 'drizzle-orm';
-import type { Db } from '@db/index.js';
+import type { Db, DbOrTx } from '@db/index.js';
 import { books } from '@db/schema.js';
 import type { BookService } from './book.service.js';
 import type { MetadataService } from './metadata.service.js';
@@ -16,6 +16,8 @@ import { canonicalizeAsin } from '@shared/asin.js';
 import { pickPrimarySeries } from '@shared/pick-primary-series.js';
 import { resolveImportSeries } from './resolve-import-series.js';
 import { serializeError } from '../utils/serialize-error.js';
+import { parseClearedFields } from '../utils/cleared-fields.js';
+import type { ClearableBookField } from '@shared/schemas/book.js';
 
 
 // ─── Shared types ───────────────────────────────────────────────────────
@@ -93,12 +95,19 @@ export async function applyAudnexusEnrichment(
   // Nothing to resolve from: no ASIN to look up AND no title to search.
   if (asinsToTry.length === 0 && !title) return;
 
+  // The row's ASIN as of BEFORE the provider fetch (#2069 AC11). `resolveAsinWriteback`
+  // is not an identity guard: it canonicalizes the FETCHED asin, compares it to the
+  // caller-supplied `primaryAsin`, and checks cross-row collision — it never reads the
+  // row's current ASIN, so a Fix Match committed during the fetch is invisible to it.
+  // The write transaction re-reads and compares against this captured value instead.
+  const capturedAsin = await readBookAsin(deps.db, bookId);
+
   // ASIN recovery loop — precise identity fast path; first hit wins.
   for (const asin of asinsToTry) {
     try {
       const data = await deps.metadataService.enrichBook(asin);
       if (data) {
-        await applyEnrichmentData(bookId, asin, data, opts, deps);
+        await applyEnrichmentData(bookId, asin, data, opts, deps, capturedAsin);
         return;
       }
     } catch (error: unknown) {
@@ -127,8 +136,14 @@ export async function applyAudnexusEnrichment(
     return;
   }
   if (resolved) {
-    await applyEnrichmentData(bookId, resolved.asin, resolved, opts, deps);
+    await applyEnrichmentData(bookId, resolved.asin, resolved, opts, deps, capturedAsin);
   }
+}
+
+/** The row's current ASIN, canonicalized — the identity value AC11's write transaction re-checks. */
+async function readBookAsin(db: Db, bookId: number): Promise<string | null> {
+  const rows = await db.select({ asin: books.asin }).from(books).where(eq(books.id, bookId)).limit(1);
+  return canonicalizeAsin(rows[0]?.asin);
 }
 
 /**
@@ -161,49 +176,122 @@ async function resolveAsinWriteback(
   return canonical;
 }
 
+/**
+ * Persist one Audnexus result. This is the SECOND fill-empty writer, so it honors
+ * the same tombstones as the scheduled job, independently per field (#2069 AC10):
+ * `subtitle` and `publisher` are dropped from the scalar payload when tombstoned,
+ * and the genres fill is skipped when `genres` is. It writes NO series field, so
+ * `seriesName`/`publishedDate` need no guard here — that asymmetry with AC9 is
+ * deliberate, not an omission.
+ *
+ * Both writes now live in ONE transaction (AC11). They used to commit separately,
+ * so `enrichmentStatus: 'enriched'` could land while a later write did not — and
+ * the row is then permanently outside the scheduled candidate selector, which only
+ * picks `pending`/`skipped`/retryable `failed`. Completion status and the field
+ * writes now commit or roll back together.
+ *
+ * The tombstone set that drives the three suppressions is read INSIDE that
+ * transaction, not from the caller's pre-fetch `db.select({ genres, subtitle,
+ * publisher })`: that earlier read still supplies the `existing*` fill-empty
+ * inputs, but it happens before a provider fetch a clear can commit during.
+ *
+ * `resolveAsinWriteback` stays OUTSIDE the transaction — it issues a collision
+ * query on `this.db`, which must not run on (or alongside) the open handle.
+ */
 async function applyEnrichmentData(
   bookId: number,
   resolvedAsin: string | null | undefined,
   data: { duration?: number | undefined; narrators?: string[] | undefined; genres?: string[] | undefined; subtitle?: string | undefined; publisher?: string | undefined },
   opts: { primaryAsin?: string | null | undefined; existingNarrator?: string | null | undefined; existingDuration?: number | null | undefined; existingGenres?: string[] | null | undefined; existingSubtitle?: string | null | undefined; existingPublisher?: string | null | undefined },
   deps: Pick<EnrichmentDeps, 'db' | 'log' | 'bookService'>,
+  capturedAsin: string | null,
 ): Promise<void> {
-  const updates: Partial<{ enrichmentStatus: EnrichmentStatus; asin: string; duration: number; subtitle: string; publisher: string; updatedAt: Date }> = {
-    enrichmentStatus: 'enriched',
-    updatedAt: new Date(),
-  };
   const asinToWrite = await resolveAsinWriteback(bookId, resolvedAsin, opts.primaryAsin, deps);
-  if (asinToWrite) updates.asin = asinToWrite;
-  if (!opts.existingDuration && data.duration) {
-    updates.duration = data.duration;
+
+  const committed = await deps.db.transaction(async (tx) => {
+    const rows = await tx
+      .select({ asin: books.asin, userClearedFields: books.userClearedFields })
+      .from(books)
+      .where(eq(books.id, bookId))
+      .limit(1);
+    const row = rows[0];
+    // Identity guard: a Fix Match committed during the provider fetch re-pointed
+    // this row, so the payload no longer describes it. A missing row is the same
+    // outcome — there is nothing to enrich.
+    if (!row || canonicalizeAsin(row.asin) !== capturedAsin) return { applied: false, genresWritten: null };
+
+    const cleared = new Set(parseClearedFields(row.userClearedFields, deps.log, bookId));
+
+    const updates: Partial<{ enrichmentStatus: EnrichmentStatus; asin: string; duration: number; subtitle: string; publisher: string; updatedAt: Date }> = {
+      enrichmentStatus: 'enriched',
+      updatedAt: new Date(),
+    };
+    if (asinToWrite) updates.asin = asinToWrite;
+    if (!opts.existingDuration && data.duration) {
+      updates.duration = data.duration;
+    }
+    if (!opts.existingSubtitle && data.subtitle && !cleared.has('subtitle')) {
+      updates.subtitle = data.subtitle;
+    }
+    if (!opts.existingPublisher && data.publisher && !cleared.has('publisher')) {
+      updates.publisher = data.publisher;
+    }
+    await tx.update(books).set(updates).where(eq(books.id, bookId));
+    const genresWritten = await applyEnrichmentArrayFields(bookId, data, opts, deps, cleared, tx);
+    return { applied: true, genresWritten };
+  });
+
+  // A stale drop is not a success — do not log one.
+  if (!committed.applied) {
+    deps.log.debug({ bookId, asin: capturedAsin }, 'stale post-import enrichment dropped (identity re-read)');
+    return;
   }
-  if (!opts.existingSubtitle && data.subtitle) {
-    updates.subtitle = data.subtitle;
+
+  // Deferred effect, run only now that the write transaction has COMMITTED (#2069
+  // F21/F5). `bookService.update`'s caller-owned-tx arm deliberately emits no
+  // post-commit side effects — a rollback the owner may still perform would strand
+  // them — so this owner runs the telemetry itself, after its own commit. Awaited
+  // rather than fire-and-forget so the import cannot outlive its own telemetry;
+  // still non-fatal, matching the `update()` wrapper.
+  if (committed.genresWritten) {
+    await deps.bookService.trackUnmatchedGenres(committed.genresWritten).catch((error: unknown) => {
+      deps.log.debug({ error: serializeError(error) }, 'Failed to track unmatched genres');
+    });
   }
-  if (!opts.existingPublisher && data.publisher) {
-    updates.publisher = data.publisher;
-  }
-  await deps.db.update(books).set(updates).where(eq(books.id, bookId));
-  await applyEnrichmentArrayFields(bookId, data, opts, deps);
+
   deps.log.info(
     { bookId, asin: resolvedAsin ?? null, wasAlternate: !!resolvedAsin && resolvedAsin !== opts.primaryAsin },
     'Audnexus enrichment applied',
   );
 }
 
-/** Fill-guarded narrator/genre writes (separate rows, so they bypass the scalar `updates` set). */
+/**
+ * Fill-guarded narrator/genre writes (separate rows, so they bypass the scalar
+ * `updates` set). Runs on the caller's transaction handle — `bookService.update`
+ * must not open a second one, since nesting `db.transaction` throws
+ * `NestedTransactionError`. `narrators` is not clearable, so only the genres fill
+ * consults the tombstone set.
+ *
+ * Returns the genre payload that actually landed, or `null` — the caller runs the
+ * unmatched-genre telemetry for it AFTER the owning transaction commits (#2069
+ * F21/F5). Narrators carry no telemetry, so only the genre arm reports back.
+ */
 async function applyEnrichmentArrayFields(
   bookId: number,
   data: { narrators?: string[] | undefined; genres?: string[] | undefined },
   opts: { existingNarrator?: string | null | undefined; existingGenres?: string[] | null | undefined },
   deps: Pick<EnrichmentDeps, 'bookService'>,
-): Promise<void> {
+  cleared: ReadonlySet<ClearableBookField>,
+  tx: DbOrTx,
+): Promise<string[] | null> {
   if (!opts.existingNarrator && data.narrators?.length) {
-    await deps.bookService.update(bookId, { narrators: data.narrators });
+    await deps.bookService.update(bookId, { narrators: data.narrators }, { tx });
   }
-  if (data.genres?.length && !opts.existingGenres?.length) {
-    await deps.bookService.update(bookId, { genres: data.genres });
+  if (data.genres?.length && !opts.existingGenres?.length && !cleared.has('genres')) {
+    await deps.bookService.update(bookId, { genres: data.genres }, { tx });
+    return data.genres;
   }
+  return null;
 }
 
 // ─── Book creation payload ──────────────────────────────────────────────

--- a/src/server/services/hardcover-series-upsert.ts
+++ b/src/server/services/hardcover-series-upsert.ts
@@ -1,0 +1,72 @@
+import { eq } from 'drizzle-orm';
+import type { DbOrTx } from '@db/index.js';
+import { series } from '@db/schema.js';
+import type { SeriesRow } from './types.js';
+import type { HardcoverSeriesData } from '@core/metadata/hardcover.js';
+import { generatePublicId } from '../utils/public-id.js';
+
+/**
+ * Id-first upsert of the canonical `series` row for a resolved Hardcover series.
+ * Extracted from `series-card.service.ts` (which is at its `max-lines` cap); the
+ * body is unchanged. Matches on `hardcover_series_id` first so a renamed series
+ * cannot collide on the normalized-name unique index, then falls back to the
+ * normalized name, then inserts.
+ */
+export async function upsertHardcoverSeries(
+  tx: DbOrTx,
+  resolved: HardcoverSeriesData,
+  normalized: string,
+): Promise<SeriesRow> {
+  const byHardcoverId = await tx
+    .select()
+    .from(series)
+    .where(eq(series.hardcoverSeriesId, resolved.id))
+    .limit(1);
+  if (byHardcoverId.length > 0) {
+    const existing = byHardcoverId[0]!;
+    const updated = await tx
+      .update(series)
+      .set({
+        name: resolved.name,
+        normalizedName: normalized,
+        authorName: resolved.authorName,
+        lastFetchedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(series.id, existing.id))
+      .returning();
+    return updated[0]!;
+  }
+  const byName = await tx
+    .select()
+    .from(series)
+    .where(eq(series.normalizedName, normalized))
+    .limit(1);
+  if (byName.length > 0) {
+    const existing = byName[0]!;
+    const updated = await tx
+      .update(series)
+      .set({
+        hardcoverSeriesId: resolved.id,
+        name: resolved.name,
+        authorName: resolved.authorName,
+        lastFetchedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(series.id, existing.id))
+      .returning();
+    return updated[0]!;
+  }
+  const inserted = await tx
+    .insert(series)
+    .values({
+      publicId: generatePublicId('sr'),
+      hardcoverSeriesId: resolved.id,
+      name: resolved.name,
+      normalizedName: normalized,
+      authorName: resolved.authorName,
+      lastFetchedAt: new Date(),
+    })
+    .returning();
+  return inserted[0]!;
+}

--- a/src/server/services/import-queue-worker.test.ts
+++ b/src/server/services/import-queue-worker.test.ts
@@ -1092,9 +1092,11 @@ describe('ImportQueueWorker', () => {
       await new Promise(r => setTimeout(r, 100));
       await workerWithBroadcaster.stop();
 
-      // Warn was emitted by parsePhaseHistory for the malformed JSON.
+      // Warn was emitted by parsePhaseHistory for the malformed JSON. The payload is
+      // `{ jobId }` ONLY — the parse error used to ride along, and V8 quotes a window
+      // of the offending source into its message (#2069 F2 sibling).
       expect(log.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ jobId: 42, error: expect.any(Object) }),
+        { jobId: 42 },
         expect.stringContaining('Unparseable phaseHistory'),
       );
 
@@ -1144,8 +1146,10 @@ describe('ImportQueueWorker', () => {
       await new Promise(r => setTimeout(r, 100));
       await workerWithBroadcaster.stop();
 
+      // Issue PATHS, not the ZodError — its message renders the `received` values,
+      // which for this column is persisted content (#2069 F2 sibling, #1404 rule).
       expect(log.warn).toHaveBeenCalledWith(
-        expect.objectContaining({ jobId: 43, error: expect.any(Object) }),
+        expect.objectContaining({ jobId: 43, issuePaths: expect.any(Array) }),
         expect.stringContaining('Malformed phaseHistory'),
       );
 

--- a/src/server/services/merge-post-tag.ts
+++ b/src/server/services/merge-post-tag.ts
@@ -1,0 +1,81 @@
+import { stat } from 'node:fs/promises';
+import { eq } from 'drizzle-orm';
+import type { FastifyBaseLogger } from 'fastify';
+import type { Db } from '@db/index.js';
+import { books } from '@db/schema.js';
+import type { SettingsService } from './settings.service.js';
+import type { ConnectorService } from './connector.service.js';
+import type { TaggingService } from './tagging.service.js';
+import { enqueueRetagRefresh } from '../utils/enqueue-book-refresh.js';
+import { serializeError } from '../utils/serialize-error.js';
+
+/**
+ * Collaborators the post-merge tag step needs. Split out of `MergeService` to keep that file
+ * under the max-lines cap, mirroring the `ffmpeg-resolver.ts` extraction in `audio-processor.ts`.
+ */
+export interface MergePostTagDeps {
+  db: Db;
+  settingsService: SettingsService;
+  log: FastifyBaseLogger;
+  taggingService?: TaggingService | undefined;
+  connectorService?: ConnectorService | undefined;
+}
+
+/**
+ * Layer 2 of #2078: re-tag a committed merge output when Tag Embedding is enabled, and return
+ * the tag-step warnings for the operator-visible completion message.
+ *
+ * Must run AFTER the merge commit — `retagBook` resolves the directory from `book.path` itself,
+ * which holds the un-merged source parts until the commit lands (and the staging dir never
+ * receives `cover.jpg`, so it is not a candidate at all).
+ *
+ * Wholly NONFATAL: the merge already succeeded on disk, so nothing here may turn it into a
+ * failure. EVERY await lives under the try — the tagging-settings read included — because a
+ * throw escaping this helper reaches `executeMerge`'s outer catch, which emits `merge_failed`
+ * for a merge whose originals are already deleted. A rejection (including `RetagError`), a
+ * rejecting settings read, a returned `failed > 0`, and an unwired `taggingService` all log a
+ * warning and return.
+ *
+ * `retagBook(bookId)` is called with NO overrides on purpose. It re-resolves the tagging
+ * settings, the ffmpeg path, and the canonical hydrated-book → tag projection itself — the same
+ * call the bulk re-tag job and the fix-match route make — which is what keeps merge-time tagging
+ * from introducing a third author/narrator serialization policy.
+ */
+export async function retagMergedOutput(
+  deps: MergePostTagDeps,
+  bookId: number,
+  outputPath: string,
+): Promise<string[]> {
+  try {
+    // The settings read lives INSIDE the nonfatal boundary. It runs after `commitMerge`, so a
+    // transient rejection here would otherwise reach `executeMerge`'s outer catch and report an
+    // already-committed merge — originals deleted, output in place — as `merge_failed`.
+    const taggingSettings = await deps.settingsService.get('tagging');
+    // `retagBook` is the manual-action entry point and has no `enabled` gate of its own, so the
+    // Tag Embedding gate lives here.
+    if (!taggingSettings?.enabled) return [];
+    if (!deps.taggingService) {
+      deps.log.warn({ bookId }, 'Tag embedding is enabled but no tagging service is wired — merged output keeps only its preserved source tags');
+      return [];
+    }
+
+    const result = await deps.taggingService.retagBook(bookId);
+    if (result.failed > 0) {
+      deps.log.warn({ bookId, failed: result.failed }, 'Post-merge tag write reported failures — merge still succeeded');
+    }
+    // The same `tagged > 0` gate the standalone and bulk re-tag callers use.
+    enqueueRetagRefresh(deps.connectorService, deps.log, result);
+    if (result.tagged > 0) {
+      // `tagFile` rewrites the file through a temp + atomic rename, which invalidates the stat
+      // `commitMerge` took. Nothing else repairs it — `enrichBookFromAudio` writes
+      // `audioTotalSize`, not `size`. Skipped when nothing was rewritten: the file is then
+      // byte-identical to the one `commitMerge` already measured.
+      const fileStats = await stat(outputPath);
+      await deps.db.update(books).set({ size: fileStats.size, updatedAt: new Date() }).where(eq(books.id, bookId));
+    }
+    return result.warnings;
+  } catch (error: unknown) {
+    deps.log.warn({ bookId, error: serializeError(error) }, 'Post-merge tag step failed — merge succeeded on disk, but the output carries only its preserved source tags');
+    return [];
+  }
+}

--- a/src/server/services/merge.service.test.ts
+++ b/src/server/services/merge.service.test.ts
@@ -419,6 +419,17 @@ describe('MergeService', () => {
       );
     });
 
+    it('omits bitrate entirely when keepOriginalBitrate is set (128 must not leak)', async () => {
+      const { service } = createService({ processing: { keepOriginalBitrate: true, bitrate: 128 } });
+      setupHappyPath();
+
+      await service.enqueueMerge(42);
+      await settle();
+
+      const config = vi.mocked(processAudioFiles).mock.calls[0]![1];
+      expect(config).not.toHaveProperty('bitrate');
+    });
+
     it('omits sourceBitrateKbps when book.audioBitrate is null', async () => {
       // mockBook has audioBitrate: null by default
       const { service } = createService();
@@ -433,25 +444,6 @@ describe('MergeService', () => {
       expect(processAudioFiles).toHaveBeenCalled();
       const config = vi.mocked(processAudioFiles).mock.calls[0]![1];
       expect(config).not.toHaveProperty('sourceBitrateKbps');
-    });
-
-    it('emits debug log when source bitrate is lower than target', async () => {
-      const bookWithBitrate = {
-        ...createMockDbBook({ id: 42, title: 'The Way of Kings', path: BOOK_PATH, status: 'imported', audioBitrate: 64000 }),
-        authors: [mockAuthor],
-        narrators: [],
-      };
-      const { service, bookService, log } = createService();
-      bookService.getById.mockResolvedValue(bookWithBitrate);
-      setupHappyPath();
-
-      await service.enqueueMerge(42);
-      await settle();
-
-      expect(log.debug).toHaveBeenCalledWith(
-        expect.objectContaining({ sourceBitrateKbps: 64, targetBitrateKbps: 128, effectiveBitrateKbps: 64 }),
-        expect.stringContaining('Capping target bitrate'),
-      );
     });
 
     it('does not delete the output file when an original shares the same basename as the staged M4B', async () => {
@@ -702,6 +694,62 @@ describe('MergeService', () => {
         book_title: 'The Way of Kings',
         success: true,
         message: 'Merged 2 files into The Way of Kings.m4b',
+      });
+    });
+
+    describe('#2068 processing notices reach the operator (AC14)', () => {
+      /**
+       * Observation point matters: the stderr deduplicator logs at debug, which the shipped
+       * default log level hides, so asserting there would pass while the operator sees
+       * nothing. These assert the structured `warnings` channel — log.warn and the
+       * merge-complete message.
+       */
+      function withWarnings(warnings: string[]): void {
+        setupHappyPath();
+        (processAudioFiles as Mock).mockResolvedValue({
+          success: true, outputFiles: [STAGING_DIR + '/The Way of Kings.m4b'], warnings,
+        });
+      }
+
+      it.each([
+        ['no-usable-evidence', 'No usable source bitrate evidence — requesting the 192 kbps default.', '192'],
+        ['an explicit target changed', 'Requested bitrate rounded down from 200 kbps to 192 kbps.', '200'],
+        ['hint-overrode-probes', 'Stored source bitrate 251 kbps exceeds every probed part (highest 64 kbps).', '251'],
+        ['unusable-target', 'Configured target bitrate "NaN" is not a usable kbps value.', 'NaN'],
+        ['a cover-art degradation', 'Cover art could not be reattached — continuing without it.', 'Cover art'],
+      ])('logs a %s notice at warn and appends it to the merge-complete message', async (_kind, warning, needle) => {
+        withWarnings([warning]);
+        const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+        const { service, log } = createService({ eventBroadcaster });
+
+        await service.enqueueMerge(42);
+        await settle();
+
+        expect(log.warn).toHaveBeenCalledWith(expect.objectContaining({ bookId: 42 }), warning);
+        const emitCalls = (eventBroadcaster.emit as Mock).mock.calls;
+        const complete = emitCalls.find((c: unknown[]) => c[0] === 'merge_complete');
+        expect((complete![1] as { message: string }).message).toContain(needle);
+      });
+
+      it('still logs the notices when the encode itself failed', async () => {
+        (readdir as Mock).mockResolvedValue(['01.mp3', '02.mp3']);
+        (mkdir as Mock).mockResolvedValue(undefined);
+        (cp as Mock).mockResolvedValue(undefined);
+        (rm as Mock).mockResolvedValue(undefined);
+        (processAudioFiles as Mock).mockResolvedValue({
+          success: false,
+          error: 'ffmpeg exited with code 1',
+          warnings: ['Requested bitrate rounded down from 200 kbps to 192 kbps.'],
+        });
+
+        const { service, log } = createService();
+        await service.enqueueMerge(42);
+        await settle();
+
+        expect(log.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ bookId: 42 }),
+          'Requested bitrate rounded down from 200 kbps to 192 kbps.',
+        );
       });
     });
 

--- a/src/server/services/merge.service.test.ts
+++ b/src/server/services/merge.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
-import { createMockLogger, createMockDb, inject, createMockSettingsService } from '../__tests__/helpers.js';
+import { createMockLogger, createMockDb, mockDbChain, inject, createMockSettingsService } from '../__tests__/helpers.js';
 import { createMockDbBook, createMockDbAuthor } from '../__tests__/factories.js';
 import { MergeService, clampConcurrency } from './merge.service.js';
 import { processAudioFiles } from '@core/utils/audio-processor.js';
@@ -10,10 +10,13 @@ import type { SettingsService } from './settings.service.js';
 import type { EventHistoryService } from './event-history.service.js';
 import type { EventBroadcasterService } from './event-broadcaster.service.js';
 import type { ConnectorService } from './connector.service.js';
+import { RetagError, type TaggingService, type RetagResult } from './tagging.service.js';
 import type { Db } from '@db/index.js';
 import type { FastifyBaseLogger } from 'fastify';
 import { readdir, mkdir, cp, unlink, stat, rm, rename } from 'node:fs/promises';
 import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { books } from '@db/schema.js';
 import { dotPrefixBasename } from '@core/utils/hidden-staging.js';
 import { recoverInterruptedCommit } from '../utils/recover-interrupted-commit.js';
 
@@ -97,7 +100,15 @@ const SCAN_RESULT = {
   hasCoverArt: false,
 };
 
-function createService(opts?: { eventHistory?: EventHistoryService; eventBroadcaster?: EventBroadcasterService; connector?: { notifyRefresh: ReturnType<typeof vi.fn> }; processing?: Partial<{ outputFormat: 'm4b' | 'mp3'; bitrate: number; keepOriginalBitrate: boolean; maxConcurrentProcessing: number }> }) {
+function createService(opts?: {
+  eventHistory?: EventHistoryService;
+  eventBroadcaster?: EventBroadcasterService;
+  connector?: { notifyRefresh: ReturnType<typeof vi.fn> };
+  processing?: Partial<{ outputFormat: 'm4b' | 'mp3'; bitrate: number; keepOriginalBitrate: boolean; maxConcurrentProcessing: number }>;
+  tagging?: Partial<{ enabled: boolean; mode: 'populate_missing' | 'overwrite'; embedCover: boolean }>;
+  /** Pass `null` to exercise "tag embedding enabled but no tagger wired" (AC10's absent arm). */
+  taggingService?: { retagBook: ReturnType<typeof vi.fn> } | null;
+}) {
   const db = createMockDb();
   const bookService = {
     getById: vi.fn().mockResolvedValue(mockBook),
@@ -105,6 +116,7 @@ function createService(opts?: { eventHistory?: EventHistoryService; eventBroadca
   };
   const settingsService = createMockSettingsService({
     processing: { ...processingOverrides.processing, ...opts?.processing },
+    ...(opts?.tagging && { tagging: opts.tagging }),
   });
   const log = createMockLogger();
 
@@ -116,9 +128,10 @@ function createService(opts?: { eventHistory?: EventHistoryService; eventBroadca
     opts?.eventHistory,
     opts?.eventBroadcaster,
     opts?.connector ? inject<ConnectorService>(opts.connector) : undefined,
+    opts?.taggingService ? inject<TaggingService>(opts.taggingService) : undefined,
   );
 
-  return { service, db, bookService, log, connector: opts?.connector };
+  return { service, db, bookService, log, settingsService, connector: opts?.connector, taggingService: opts?.taggingService };
 }
 
 const settle = () => new Promise((r) => setTimeout(r, 50));
@@ -679,6 +692,10 @@ describe('MergeService', () => {
         size: 123_456_789,
         updatedAt: expect.any(Date),
       }));
+      // Sibling of the post-tag write's F12 fix: the DB mutation contract is payload AND
+      // filter, so this pre-existing commit-time write gets its row predicate pinned too.
+      const whereMock = setMock.mock.results[0]?.value?.where as Mock;
+      expect(whereMock).toHaveBeenCalledWith(eq(books.id, 42));
     });
 
     it('emits merge_complete SSE event with message field on success', async () => {
@@ -2624,5 +2641,371 @@ describe('#1838 merge origin — event provenance', () => {
 
     // Two sequential merges of the same bookId record their OWN origin, in order.
     expect(historyFor(create, 42, 'merged').map((e) => e.source)).toEqual(['auto', 'manual']);
+  });
+});
+
+// ============================================================================
+// #2078 Layer 2 — post-merge re-tag (AC9–AC15)
+//
+// Layer 1 (in `src/core/utils/audio-processor.ts`) only carries the SOURCE parts' tags
+// forward. When Tag Embedding is on, the merged output must additionally be re-tagged from
+// canonical DB state — through the existing `retagBook`, so no second hydrated-book → tag
+// projection is introduced.
+// ============================================================================
+
+const MERGED_OUTPUT = join(BOOK_PATH, 'The Way of Kings.m4b');
+
+function retagResult(over: Partial<RetagResult> = {}): RetagResult {
+  return {
+    bookId: 42,
+    tagged: 1,
+    skipped: 0,
+    failed: 0,
+    warnings: [],
+    refreshItem: { bookId: 42, title: 'The Way of Kings', authorName: 'Author', libraryPath: BOOK_PATH },
+    ...over,
+  };
+}
+
+/** A tagger whose `retagBook` resolves to `result`. */
+function tagger(result: RetagResult = retagResult()) {
+  return { retagBook: vi.fn().mockResolvedValue(result) };
+}
+
+const TAGGING_ON = { enabled: true, mode: 'overwrite' as const, embedCover: true };
+
+describe('#2078 post-merge re-tag', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('calls retagBook(bookId) exactly once, with no overrides, when tag embedding is on (AC10)', async () => {
+    setupHappyPath();
+    const tagging = tagger();
+    const { service } = createService({ tagging: TAGGING_ON, taggingService: tagging });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    // The ABSENCE of a second argument is the point: passing a locally-built metadata object
+    // (or mode/embedCover overrides) would fork the canonical projection and let merge-time
+    // tagging drift from the manual Re-tag button.
+    expect(tagging.retagBook).toHaveBeenCalledTimes(1);
+    expect(tagging.retagBook).toHaveBeenCalledWith(42);
+    expect(tagging.retagBook.mock.calls[0]).toHaveLength(1);
+  });
+
+  it('does not start the tag write until the merge commit has landed the output (AC10)', async () => {
+    setupHappyPath();
+    // Hold the commit's staging→bookPath rename open. That rename IS the moment the merged file
+    // appears at `book.path`, and `retagBook` resolves its working directory from `book.path`
+    // itself — started any earlier it would tag the soon-to-be-deleted source parts and could
+    // not see the merged output or the folder cover.
+    let releaseCommit!: () => void;
+    const committed = new Promise<void>((res) => { releaseCommit = res; });
+    (rename as Mock).mockImplementation(() => committed);
+
+    const tagging = tagger();
+    const { service } = createService({ tagging: TAGGING_ON, taggingService: tagging });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(rename).toHaveBeenCalledWith(join(STAGING_DIR, 'The Way of Kings.m4b'), MERGED_OUTPUT);
+    // Moving retagMergedOutput above commitMerge makes this the failing line.
+    expect(tagging.retagBook).not.toHaveBeenCalled();
+
+    releaseCommit();
+    await settle();
+
+    expect(tagging.retagBook).toHaveBeenCalledWith(42);
+  });
+
+  it('survives a rejecting tagging-settings read — the merge is already committed (AC10)', async () => {
+    setupHappyPath();
+    const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+    const tagging = tagger();
+    const { service, settingsService, log } = createService({
+      tagging: TAGGING_ON, taggingService: tagging, eventBroadcaster,
+    });
+    // Only the tagging read rejects; every other category still resolves, so this isolates the
+    // post-commit lookup rather than failing the merge somewhere upstream.
+    const realGet = (settingsService.get as Mock).getMockImplementation()!;
+    (settingsService.get as Mock).mockImplementation((category: string) =>
+      category === 'tagging'
+        ? Promise.reject(new Error('settings store unavailable'))
+        : realGet(category));
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    // By this point commitMerge has deleted the originals — reporting merge_failed here would
+    // tell the operator a completed, irreversible merge did not happen.
+    expect(log.warn).toHaveBeenCalled();
+    expect(vi.mocked(eventBroadcaster.emit)).toHaveBeenCalledWith(
+      'merge_complete', expect.objectContaining({ success: true }),
+    );
+    expect(vi.mocked(eventBroadcaster.emit).mock.calls.some((c) => c[0] === 'merge_failed')).toBe(false);
+    expect(tagging.retagBook).not.toHaveBeenCalled();
+    expect(enrichBookFromAudio).toHaveBeenCalled();
+  });
+
+  it('never calls retagBook when tag embedding is off — Layer 1 alone governs (AC14)', async () => {
+    setupHappyPath();
+    const tagging = tagger();
+    const { service } = createService({
+      tagging: { enabled: false, mode: 'overwrite', embedCover: true },
+      taggingService: tagging,
+    });
+
+    const ack = await service.enqueueMerge(42);
+    await settle();
+
+    // retagBook has no `enabled` gate of its own (it is the manual-action entry point), so a
+    // missing gate here would silently re-tag on every merge with the setting off.
+    expect(tagging.retagBook).not.toHaveBeenCalled();
+    expect(ack).toEqual({ status: 'started', bookId: 42 });
+    expect(enrichBookFromAudio).toHaveBeenCalled();
+  });
+
+  it.each([
+    ['a plain Error', new Error('ffmpeg blew up')],
+    ['a RetagError', new RetagError('PATH_MISSING', 'Book path does not exist on disk')],
+  ])('survives a rejected retagBook (%s) — merge still reports success (AC10)', async (_label, error) => {
+    setupHappyPath();
+    const tagging = { retagBook: vi.fn().mockRejectedValue(error) };
+    const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+    const { service, log } = createService({ tagging: TAGGING_ON, taggingService: tagging, eventBroadcaster });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(log.warn).toHaveBeenCalled();
+    expect(vi.mocked(eventBroadcaster.emit)).toHaveBeenCalledWith(
+      'merge_complete', expect.objectContaining({ success: true }),
+    );
+    // The on-disk merge succeeded; a tagging failure must not convert it into a merge failure.
+    expect(log.error).not.toHaveBeenCalled();
+    expect(enrichBookFromAudio).toHaveBeenCalled();
+  });
+
+  it('survives a returned failed > 0 and surfaces its warnings to the operator (AC10, AC13)', async () => {
+    setupHappyPath();
+    const tagging = tagger(retagResult({
+      tagged: 0, failed: 1, warnings: ['01.m4b: Output file suspiciously small — possible corruption'],
+    }));
+    const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+    const { service, log } = createService({ tagging: TAGGING_ON, taggingService: tagging, eventBroadcaster });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(log.warn).toHaveBeenCalled();
+    expect(vi.mocked(eventBroadcaster.emit)).toHaveBeenCalledWith('merge_complete', expect.objectContaining({
+      success: true,
+      message: expect.stringContaining('Output file suspiciously small'),
+    }));
+    expect(enrichBookFromAudio).toHaveBeenCalled();
+  });
+
+  it('warns and continues when tag embedding is on but no tagger is wired (AC10)', async () => {
+    setupHappyPath();
+    const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+    const { service, log } = createService({ tagging: TAGGING_ON, taggingService: null, eventBroadcaster });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(log.warn).toHaveBeenCalled();
+    expect(vi.mocked(eventBroadcaster.emit)).toHaveBeenCalledWith('merge_complete', expect.objectContaining({
+      success: true,
+      message: 'Merged 2 files into The Way of Kings.m4b',
+    }));
+    expect(enrichBookFromAudio).toHaveBeenCalled();
+  });
+
+  /** Count the `stat()` reads taken against the committed merge output. */
+  function statsOnOutput(): number {
+    return vi.mocked(stat).mock.calls.filter((c) => c[0] === MERGED_OUTPUT).length;
+  }
+
+  it('takes the size stat only AFTER the tag rewrite resolves (AC11)', async () => {
+    setupHappyPath();
+    // tagFile rewrites the file through a temp + atomic rename, so commitMerge's stat is stale
+    // the moment a tag lands.
+    const sizes = [500_000_000, 500_004_096];
+    (stat as Mock).mockImplementation(async () => ({ size: sizes.shift() ?? 500_004_096 }));
+
+    // Gate `retagBook` rather than feeding two values and reading the second: a stat hoisted
+    // above `await retagBook` consumes that same second value and leaves a value-only
+    // assertion green. Holding the tag write open makes the ORDER the observable.
+    let release!: (r: RetagResult) => void;
+    const gate = new Promise<RetagResult>((res) => { release = res; });
+    const tagging = { retagBook: vi.fn().mockReturnValue(gate) };
+    const { service, db } = createService({ tagging: TAGGING_ON, taggingService: tagging });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(tagging.retagBook).toHaveBeenCalled();
+    // Only commitMerge's own stat so far — the post-tag one must not have been taken yet.
+    expect(statsOnOutput()).toBe(1);
+
+    release(retagResult());
+    await settle();
+
+    expect(statsOnOutput()).toBe(2);
+    const lastSet = (db.update as Mock).mock.results.at(-1)?.value?.set as Mock;
+    expect(lastSet).toHaveBeenCalledWith(expect.objectContaining({
+      size: 500_004_096, updatedAt: expect.any(Date),
+    }));
+  });
+
+  it('awaits the final size write before the merge moves on (AC11)', async () => {
+    setupHappyPath();
+    (stat as Mock).mockResolvedValue({ size: 500_004_096 });
+
+    // Gate the post-tag update's `where()` terminus. Inspecting the synchronous `set()` call
+    // cannot see a dropped `await` — the call trace is identical either way (the repo's
+    // issuance-vs-persistence trap). Only a pending terminus can.
+    let releasePersist!: () => void;
+    const persisted = new Promise<void>((res) => { releasePersist = res; });
+    const gatedWhere = vi.fn().mockImplementation(() => ({
+      // Thenable only: production awaits this terminus directly and never calls `.returning()`.
+      then: (onOk: unknown, onErr: unknown) =>
+        persisted.then(() => undefined).then(onOk as never, onErr as never),
+    }));
+
+    // Discriminate the post-tag update from commitMerge's by TAG STATE, not call index: the
+    // post-tag write is by definition the one issued after `retagBook` resolved, so this stays
+    // correct however many updates either step makes.
+    let tagWriteDone = false;
+    const tagging = {
+      retagBook: vi.fn().mockImplementation(async () => { tagWriteDone = true; return retagResult(); }),
+    };
+    const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+    const { service, db } = createService({ tagging: TAGGING_ON, taggingService: tagging, eventBroadcaster });
+    (db.update as Mock).mockImplementation(() =>
+      tagWriteDone ? { set: vi.fn().mockReturnValue({ where: gatedWhere }) } : mockDbChain());
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    // The write was ISSUED, but the merge must not have proceeded past it.
+    expect(gatedWhere).toHaveBeenCalledTimes(1);
+    expect(enrichBookFromAudio).not.toHaveBeenCalled();
+    expect(vi.mocked(eventBroadcaster.emit).mock.calls.some((c) => c[0] === 'merge_complete')).toBe(false);
+
+    releasePersist();
+    await settle();
+
+    expect(enrichBookFromAudio).toHaveBeenCalled();
+    expect(vi.mocked(eventBroadcaster.emit)).toHaveBeenCalledWith('merge_complete', expect.objectContaining({ success: true }));
+  });
+
+  it('scopes the final size write to exactly the merged book row (AC11)', async () => {
+    setupHappyPath();
+    (stat as Mock).mockResolvedValue({ size: 500_004_096 });
+
+    const capturedWhere: unknown[] = [];
+    let tagWriteDone = false;
+    const tagging = {
+      retagBook: vi.fn().mockImplementation(async () => { tagWriteDone = true; return retagResult(); }),
+    };
+    const { service, db } = createService({ tagging: TAGGING_ON, taggingService: tagging });
+    (db.update as Mock).mockImplementation(() => {
+      if (!tagWriteDone) return mockDbChain();
+      return {
+        set: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation((predicate: unknown) => {
+            capturedWhere.push(predicate);
+            return Promise.resolve(undefined);
+          }),
+        }),
+      };
+    });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    // A payload-only assertion passes with the WHERE deleted, widened, or pointed at another
+    // book — which would rewrite the wrong rows' size.
+    expect(capturedWhere).toHaveLength(1);
+    expect(capturedWhere[0]).toEqual(eq(books.id, 42));
+    expect(capturedWhere[0]).not.toEqual(eq(books.id, 43));
+  });
+
+  it('fires the post-tag metadata connector refresh only when a file was actually tagged (AC12)', async () => {
+    setupHappyPath();
+    const connector = { notifyRefresh: vi.fn().mockResolvedValue(undefined) };
+    const { service } = createService({ tagging: TAGGING_ON, taggingService: tagger(), connector });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    // commitMerge's own 'merge' refresh (the just-deleted originals) stays where it is; this
+    // second 'metadata' refresh points connectors at the finished, tagged file.
+    expect(connector.notifyRefresh).toHaveBeenCalledWith('merge', expect.any(Array));
+    expect(connector.notifyRefresh).toHaveBeenCalledWith('metadata', [
+      expect.objectContaining({ bookId: 42, libraryPath: BOOK_PATH }),
+    ]);
+  });
+
+  it('does not fire the metadata refresh when nothing was tagged (AC12)', async () => {
+    setupHappyPath();
+    const connector = { notifyRefresh: vi.fn().mockResolvedValue(undefined) };
+    const { service } = createService({
+      tagging: TAGGING_ON, connector,
+      taggingService: tagger(retagResult({ tagged: 0, skipped: 1 })),
+    });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(connector.notifyRefresh).toHaveBeenCalledWith('merge', expect.any(Array));
+    expect(connector.notifyRefresh).not.toHaveBeenCalledWith('metadata', expect.anything());
+  });
+
+  it('folds tag-step warnings into the merge_complete message beside the processing ones (AC13)', async () => {
+    setupHappyPath();
+    (processAudioFiles as Mock).mockResolvedValue({
+      success: true,
+      outputFiles: [STAGING_DIR + '/The Way of Kings.m4b'],
+      warnings: ['Requested bitrate capped from 320 kbps to 256 kbps'],
+    });
+    const eventBroadcaster = { emit: vi.fn() } as unknown as EventBroadcasterService;
+    const { service } = createService({
+      tagging: TAGGING_ON, eventBroadcaster,
+      taggingService: tagger(retagResult({ warnings: ['Cover art embedding enabled but no cover image found in book directory'] })),
+    });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    const emitted = vi.mocked(eventBroadcaster.emit).mock.calls.find((c) => c[0] === 'merge_complete')!;
+    const message = (emitted[1] as { message: string }).message;
+    expect(message).toContain('Requested bitrate capped from 320 kbps to 256 kbps');
+    expect(message).toContain('Cover art embedding enabled but no cover image found');
+  });
+
+  it('finishes the tag write BEFORE enrichment reads the file back', async () => {
+    setupHappyPath();
+    // Gate retagBook's resolution rather than comparing call order: a call-order assertion is
+    // satisfied by an un-awaited retagBook, which is exactly the bug this pins.
+    let release!: (r: RetagResult) => void;
+    const gate = new Promise<RetagResult>((res) => { release = res; });
+    const tagging = { retagBook: vi.fn().mockReturnValue(gate) };
+    const { service } = createService({ tagging: TAGGING_ON, taggingService: tagging });
+
+    await service.enqueueMerge(42);
+    await settle();
+
+    expect(tagging.retagBook).toHaveBeenCalled();
+    expect(enrichBookFromAudio).not.toHaveBeenCalled();
+
+    release(retagResult());
+    await settle();
+
+    expect(enrichBookFromAudio).toHaveBeenCalled();
   });
 });

--- a/src/server/services/merge.service.ts
+++ b/src/server/services/merge.service.ts
@@ -10,7 +10,9 @@ import type { AppSettings } from '@shared/schemas/settings/registry.js';
 import type { EventHistoryService } from './event-history.service.js';
 import type { EventBroadcasterService } from './event-broadcaster.service.js';
 import type { ConnectorService } from './connector.service.js';
+import type { TaggingService } from './tagging.service.js';
 import { enqueueBookRefresh } from '../utils/enqueue-book-refresh.js';
+import { retagMergedOutput } from './merge-post-tag.js';
 import { processAudioFiles, resolveFfmpegPath } from '@core/utils/audio-processor.js';
 import type { ProcessingResult } from '@core/utils/audio-processor.js';
 import { buildNamingContext, type RenameableBook } from '../utils/paths.js';
@@ -95,6 +97,10 @@ export class MergeService {
     private eventHistory?: EventHistoryService,
     private eventBroadcaster?: EventBroadcasterService,
     private connectorService?: ConnectorService,
+    // Optional and TRAILING (#2078) so every existing construction site keeps compiling. That
+    // also means dropping the argument in the composition root compiles and leaves this suite
+    // green — `routes/index.test.ts` carries the same-instance assertion that catches it.
+    private taggingService?: TaggingService,
   ) {}
 
   /** Resolve the recorded provenance for a book, defaulting to 'manual' on a lookup miss. */
@@ -363,6 +369,15 @@ export class MergeService {
       this.emitMergeProgress(bookId, book.title, 'committing');
       const outputPath = await this.commitMerge(stagingDir, stagedOutput, bookPath, topLevelAudioFiles, bookId, book);
 
+      // Layer 2 (#2078): re-tag the merged output from canonical DB state. It has to run AFTER
+      // commitMerge — `retagBook` resolves the directory from `book.path` itself, which holds
+      // the un-merged source parts until the commit lands (and the staging dir never receives
+      // `cover.jpg`, so it is not a candidate at all).
+      const taggingWarnings = await retagMergedOutput({
+        db: this.db, settingsService: this.settingsService, log: this.log,
+        taggingService: this.taggingService, connectorService: this.connectorService,
+      }, bookId, outputPath);
+
       const ffprobePath = resolveFfprobePathFromSettings(ffmpegPath);
       const enrichResult = await enrichBookFromAudio(bookId, bookPath, book, this.db, this.log, this.bookService, ffprobePath);
       let enrichmentWarning: string | undefined;
@@ -375,8 +390,9 @@ export class MergeService {
       // Fold the processing notices into the operator-visible completion message — the
       // existing `message` string, so the merge_complete event contract stays untouched.
       const mergedSummary = `Merged ${topLevelAudioFiles.length} files into ${basename(stagedOutput)}`;
-      const message = processingWarnings.length > 0
-        ? `${mergedSummary} (${processingWarnings.join('; ')})`
+      const allWarnings = [...processingWarnings, ...taggingWarnings];
+      const message = allWarnings.length > 0
+        ? `${mergedSummary} (${allWarnings.join('; ')})`
         : mergedSummary;
       this.emitMergeComplete(bookId, book.title, message, enrichmentWarning);
       return { bookId, outputFile: outputPath, filesReplaced: topLevelAudioFiles.length, message, ...(enrichmentWarning !== undefined && { enrichmentWarning }) };

--- a/src/server/services/merge.service.ts
+++ b/src/server/services/merge.service.ts
@@ -12,6 +12,7 @@ import type { EventBroadcasterService } from './event-broadcaster.service.js';
 import type { ConnectorService } from './connector.service.js';
 import { enqueueBookRefresh } from '../utils/enqueue-book-refresh.js';
 import { processAudioFiles, resolveFfmpegPath } from '@core/utils/audio-processor.js';
+import type { ProcessingResult } from '@core/utils/audio-processor.js';
 import { buildNamingContext, type RenameableBook } from '../utils/paths.js';
 import { toNamingOptions, type NamingOptions } from '@core/utils/naming.js';
 import { scanAudioDirectory } from '@core/utils/audio-scanner.js';
@@ -19,7 +20,7 @@ import { enrichBookFromAudio } from './enrichment-utils.js';
 import { AUDIO_EXTENSIONS, isHiddenName } from '@core/utils/audio-constants.js';
 import { dotPrefixBasename } from '@core/utils/hidden-staging.js';
 import { resolveFfprobePathFromSettings } from '@core/utils/ffprobe-path.js';
-import { toSourceBitrateKbps, logBitrateCapping } from '../utils/audio-bitrate.js';
+import { toSourceBitrateKbps } from '../utils/audio-bitrate.js';
 import { Semaphore, type SemaphoreRelease } from '../utils/semaphore.js';
 import type { MergePhase, MergeFailedReason } from '@shared/schemas/sse-events.js';
 import type { EventSource } from '@shared/schemas/event-history.js';
@@ -349,7 +350,7 @@ export class MergeService {
       }
 
       this.emitMergeProgress(bookId, book.title, 'staging');
-      const stagedOutput = await this.runStaging(
+      const { stagedOutput, warnings: processingWarnings } = await this.runStaging(
         stagingDir, { ...book, path: bookPath }, topLevelAudioFiles, { ...processingSettings, ffmpegPath },
         bookId, book.title, librarySettings.fileFormat, toNamingOptions(librarySettings), controller.signal,
       );
@@ -371,7 +372,12 @@ export class MergeService {
       }
 
       this.log.info({ bookId, outputPath, filesReplaced: topLevelAudioFiles.length }, 'Book merged');
-      const message = `Merged ${topLevelAudioFiles.length} files into ${basename(stagedOutput)}`;
+      // Fold the processing notices into the operator-visible completion message — the
+      // existing `message` string, so the merge_complete event contract stays untouched.
+      const mergedSummary = `Merged ${topLevelAudioFiles.length} files into ${basename(stagedOutput)}`;
+      const message = processingWarnings.length > 0
+        ? `${mergedSummary} (${processingWarnings.join('; ')})`
+        : mergedSummary;
       this.emitMergeComplete(bookId, book.title, message, enrichmentWarning);
       return { bookId, outputFile: outputPath, filesReplaced: topLevelAudioFiles.length, message, ...(enrichmentWarning !== undefined && { enrichmentWarning }) };
     } catch (error: unknown) {
@@ -386,7 +392,26 @@ export class MergeService {
     }
   }
 
-  /** Steps 1-5: copy to staging, process, verify. Returns the staged output filename (extension follows outputFormat). */
+  /**
+   * Surface the encode-strategy notices (and cover-art degradations) at warn on BOTH outcomes.
+   *
+   * The stderr deduplicator logs at debug, which the shipped default log level hides, and a run
+   * that adjusted a bitrate and then failed for an unrelated reason must still report the
+   * adjustment — which is why the failure variant carries `warnings` too.
+   */
+  private reportProcessingWarnings(bookId: number, result: ProcessingResult): string[] {
+    const warnings = result.warnings ?? [];
+    for (const warning of warnings) {
+      this.log.warn({ bookId }, warning);
+    }
+    return warnings;
+  }
+
+  /**
+   * Steps 1-5: copy to staging, process, verify. Returns the staged output filename (extension
+   * follows outputFormat) plus the processing warnings, which the caller folds into the
+   * operator-visible completion message.
+   */
   private async runStaging(
     stagingDir: string,
     book: RenameableBook & { path: string; authors?: Array<{ name: string }> | null; audioBitrate?: number | null },
@@ -397,7 +422,7 @@ export class MergeService {
     fileFormat: string,
     namingOptions: NamingOptions,
     signal?: AbortSignal,
-  ): Promise<string> {
+  ): Promise<{ stagedOutput: string; warnings: string[] }> {
     // Reset the deterministic staging dir to empty before copying (Change 4 / F25). A prior kill
     // can leave stale (non-dot) audio inside this exact path; the owning merge reopens it by
     // identity and would otherwise fold that residue into the result. A failure to empty it throws
@@ -413,7 +438,6 @@ export class MergeService {
     const authorName = book.authors?.[0]?.name ?? '';
     const sourceBitrateKbps = toSourceBitrateKbps(book.audioBitrate);
     const targetBitrateKbps = processingSettings.keepOriginalBitrate ? undefined : processingSettings.bitrate;
-    logBitrateCapping(sourceBitrateKbps, targetBitrateKbps, this.log);
 
     // Build stderr deduplicator for logging
     const stderrDedup = createStderrDeduplicator(this.log);
@@ -446,6 +470,8 @@ export class MergeService {
 
     stderrDedup.flush();
 
+    const warnings = this.reportProcessingWarnings(bookId, processingResult);
+
     if (!processingResult.success) {
       throw new Error(`Audio processing failed: ${processingResult.error}`);
     }
@@ -469,7 +495,7 @@ export class MergeService {
       throw new Error('Staged output not found after processing');
     }
 
-    return stagedOutput;
+    return { stagedOutput, warnings };
   }
 
   /** Step 7: move the staged output to book.path, update DB size, delete originals, clean staging. */

--- a/src/server/services/quality-gate.helpers.test.ts
+++ b/src/server/services/quality-gate.helpers.test.ts
@@ -15,7 +15,7 @@ const baseBook = {
   createdAt: new Date(), enrichmentStatus: 'pending' as const, productionType: 'unknown' as const, editionLabel: null, enrichmentAttempts: 0,
   audioBitrateMode: null, audioFileFormat: null, audioFileCount: null, topLevelAudioFileCount: null,
   seriesId: null, importListId: null,
-  lastGrabGuid: null, lastGrabInfoHash: null,
+  lastGrabGuid: null, lastGrabInfoHash: null, userClearedFields: null,
 };
 
 const baseScan = {

--- a/src/server/services/quality-gate.service.test.ts
+++ b/src/server/services/quality-gate.service.test.ts
@@ -43,7 +43,7 @@ const baseBook = {
   createdAt: new Date(), enrichmentStatus: 'pending' as const, productionType: 'unknown' as const, editionLabel: null, enrichmentAttempts: 0,
   audioBitrateMode: null, audioFileFormat: null, audioFileCount: null, topLevelAudioFileCount: null,
   seriesId: null, importListId: null,
-  lastGrabGuid: null, lastGrabInfoHash: null,
+  lastGrabGuid: null, lastGrabInfoHash: null, userClearedFields: null,
 };
 
 function makeScan(overrides?: Partial<{ totalSize: number; totalDuration: number; tagNarrator: string; channels: number; codec: string }>) {

--- a/src/server/services/refresh-scan.service.test.ts
+++ b/src/server/services/refresh-scan.service.test.ts
@@ -6,7 +6,7 @@ vi.mock('@core/utils/audio-processor.js', async (importOriginal) => {
 
 import { inject } from '../__tests__/helpers.js';
 import type { FastifyBaseLogger } from 'fastify';
-import type { BookService, BookWithAuthor } from './book.service.js';
+import type { BookService, BookDetail } from './book.service.js';
 import type { SettingsService } from './settings.service.js';
 
 vi.mock('@core/utils/audio-scanner.js', () => ({
@@ -62,8 +62,9 @@ function makeScanResult(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeBook(overrides: Partial<BookWithAuthor> = {}): BookWithAuthor {
-  return inject<BookWithAuthor>({
+function makeBook(overrides: Partial<BookDetail> = {}): BookDetail {
+  return inject<BookDetail>({
+    userClearedFields: [],
     id: 1,
     title: 'Test Book',
     path: '/library/author/book',

--- a/src/server/services/series-card.service.test.ts
+++ b/src/server/services/series-card.service.test.ts
@@ -861,4 +861,107 @@ describe('SeriesCardService — unit', () => {
       expect(book.seriesName).toBe('The Earthsea Cycle');
     });
   });
+  // ─── #2069 AC24: binding is an operator re-assertion of the SERIES ───
+  //
+  // It removes the initiating book's `seriesName` tombstone in the SAME transaction
+  // as the scalar write (otherwise a stored series would coexist with a live
+  // tombstone), and only that entry — binding asserts nothing about the other
+  // clearable fields.
+  describe('bindHardcoverSeries — user-cleared fields (#2069 AC24)', () => {
+    /** Set the tombstone column out of band, the way a prior PUT would have. */
+    async function setTombstones(bookId: number, raw: string | null): Promise<void> {
+      await db.update(books).set({ userClearedFields: raw }).where(eq(books.id, bookId));
+    }
+
+    async function readBook(bookId: number) {
+      return (await db.select().from(books).where(eq(books.id, bookId)))[0]!;
+    }
+
+    const earthseaPayload = (title: string) => hardcoverSeriesPayload({
+      id: 4242, name: 'The Earthsea Quartet', author: 'Ursula K. Le Guin',
+      members: [{ position: 1, id: 1, slug: 'wizard', title }],
+    });
+
+    it('removes the seriesName entry and leaves every other tombstone in place', async () => {
+      const bookId = await seedBookWithSeries(db, { title: 'A Wizard of Earthsea', seriesName: null, authorName: 'Ursula K. Le Guin' });
+      await setTombstones(bookId, '["genres","seriesName"]');
+      mockFetchOnce(earthseaPayload('A Wizard of Earthsea'));
+
+      await new SeriesCardService(db, log, settingsServiceWith('K')).bindHardcoverSeries(bookId, 4242);
+
+      // Both asserted from ONE read, so a write that lands the series without the
+      // removal (or vice versa) cannot pass.
+      const book = await readBook(bookId);
+      expect(book.seriesName).toBe('The Earthsea Quartet');
+      expect(book.userClearedFields).toBe('["genres"]');
+    });
+
+    it('persists the empty set as SQL NULL when seriesName was the only tombstone', async () => {
+      const bookId = await seedBookWithSeries(db, { title: 'A Wizard of Earthsea', seriesName: null, authorName: 'Ursula K. Le Guin' });
+      await setTombstones(bookId, '["seriesName"]');
+      mockFetchOnce(earthseaPayload('A Wizard of Earthsea'));
+
+      await new SeriesCardService(db, log, settingsServiceWith('K')).bindHardcoverSeries(bookId, 4242);
+
+      expect((await readBook(bookId)).userClearedFields).toBeNull();
+    });
+
+    it('F13: re-reads the set INSIDE the transaction, so a clear committed during the fetch survives', async () => {
+      const bookId = await seedBookWithSeries(db, { title: 'A Wizard of Earthsea', seriesName: null, authorName: 'Ursula K. Le Guin' });
+      await setTombstones(bookId, '["seriesName","subtitle"]');
+
+      // An unrelated `genres` clear commits while the Hardcover fetch is in flight.
+      globalThis.fetch = vi.fn().mockImplementation(async () => {
+        await setTombstones(bookId, '["genres","seriesName","subtitle"]');
+        return new Response(JSON.stringify(earthseaPayload('A Wizard of Earthsea')), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof globalThis.fetch;
+
+      await new SeriesCardService(db, log, settingsServiceWith('K')).bindHardcoverSeries(bookId, 4242);
+
+      // An implementation that drops `seriesName` from the PRE-fetch snapshot and
+      // writes that back yields '["subtitle"]', silently erasing the concurrent clear.
+      expect((await readBook(bookId)).userClearedFields).toBe('["genres","subtitle"]');
+    });
+
+    it('a seriesName-tombstoned sibling is structurally absent from the sibling pool and keeps its tombstone', async () => {
+      // The pool comes from `WHERE series_name IN (…)`, and a tombstoned book has
+      // `series_name = NULL` — SQL `IN` never matches NULL. Pinned here rather than
+      // defended by a guard branch.
+      const bookA = await seedBookWithSeries(db, { title: 'A Wizard of Earthsea', seriesName: 'Earthsea', authorName: 'Ursula K. Le Guin' });
+      const sibling = await seedBookWithSeries(db, { title: 'The Tombs of Atuan', seriesName: null, authorName: 'Ursula K. Le Guin' });
+      await setTombstones(sibling, '["seriesName"]');
+      mockFetchOnce(hardcoverSeriesPayload({
+        id: 4242, name: 'The Earthsea Quartet', author: 'Ursula K. Le Guin',
+        members: [
+          { position: 1, id: 1, slug: 'wizard', title: 'A Wizard of Earthsea' },
+          { position: 2, id: 2, slug: 'tombs', title: 'The Tombs of Atuan' },
+        ],
+      }));
+
+      await new SeriesCardService(db, log, settingsServiceWith('K')).bindHardcoverSeries(bookA, 4242);
+
+      const siblingRow = await readBook(sibling);
+      expect(siblingRow.seriesName).toBeNull();
+      expect(siblingRow.userClearedFields).toBe('["seriesName"]');
+    });
+
+    it('rolls the tombstone removal back with the scalar write when a later step in the transaction fails', async () => {
+      const bookId = await seedBookWithSeries(db, { title: 'A Wizard of Earthsea', seriesName: null, authorName: 'Ursula K. Le Guin' });
+      await setTombstones(bookId, '["seriesName"]');
+      mockFetchOnce(earthseaPayload('A Wizard of Earthsea'));
+
+      const link = await import('./book-series-link.js');
+      vi.spyOn(link, 'relinkBookToBoundSeries').mockRejectedValueOnce(new Error('relink boom'));
+
+      await expect(
+        new SeriesCardService(db, log, settingsServiceWith('K')).bindHardcoverSeries(bookId, 4242),
+      ).rejects.toThrow('relink boom');
+
+      const book = await readBook(bookId);
+      expect(book.seriesName).toBeNull();
+      expect(book.userClearedFields).toBe('["seriesName"]');
+    });
+  });
 });

--- a/src/server/services/series-card.service.ts
+++ b/src/server/services/series-card.service.ts
@@ -7,9 +7,9 @@ import type { SettingsService } from './settings.service.js';
 import { HardcoverClient, type HardcoverSearchCandidate, type HardcoverSeriesData } from '@core/metadata/hardcover.js';
 import { resolveSeriesViaHardcover } from './hardcover-series-resolver.js';
 import { findInLibraryMatch, normalizeMemberTitleForMatch, type LibraryBookSummary } from './series-title-match.js';
-import { relinkBookToBoundSeries } from './book-series-link.js';
+import { relinkBookToBoundSeries, removeSeriesNameTombstone } from './book-series-link.js';
+import { upsertHardcoverSeries } from './hardcover-series-upsert.js';
 import { normalizeSeriesName } from '../utils/series-normalize.js';
-import { generatePublicId } from '../utils/public-id.js';
 import { serializeError } from '../utils/serialize-error.js';
 
 /** Scheduled sweep threshold — rows older than this are re-fetched. */
@@ -389,6 +389,24 @@ export class SeriesCardService {
     const priorSeriesName = book.seriesName;
 
     const persistedRow = await this.db.transaction(async (tx) => {
+      // Binding is a deliberate operator assertion that THIS book belongs to that
+      // series, so it removes the initiating book's `seriesName` tombstone (#2069
+      // AC24) — otherwise a stored series would coexist with a live tombstone,
+      // the exact divergence AC7 exists to prevent. Only that one entry is
+      // removed: binding asserts nothing about subtitle/description/publisher/
+      // publishedDate/genres, so those tombstones survive.
+      //
+      // The set is re-read INSIDE this transaction, never carried from the
+      // pre-fetch `loadBook` above: `fetchById` is a network round-trip, so a PUT
+      // can add an unrelated tombstone while it is in flight, and writing back a
+      // pre-fetch snapshot would silently erase that concurrent clear
+      // (`src/db/serial-transactions.ts` — re-read preconditions inside the
+      // transaction). Matched SIBLINGS are never un-tombstoned, and need no guard:
+      // `loadLibraryBooksForSeriesNames` selects `WHERE series_name IN (…)` and a
+      // `seriesName`-tombstoned book has `series_name = NULL`, which SQL `IN` never
+      // matches — such a book is structurally absent from the sibling pool.
+      const boundClearedFields = await removeSeriesNameTombstone(tx, this.log, bookId);
+
       // Match the whole series at once, including books still on the pre-bind
       // name, so siblings are matched and synced alongside the initiating book.
       const extraNames = priorSeriesName ? [priorSeriesName] : [];
@@ -399,7 +417,12 @@ export class SeriesCardService {
         syncedIds.add(match.bookId);
         await tx
           .update(books)
-          .set({ seriesName: resolved.name, seriesPosition: match.position, updatedAt: new Date() })
+          .set({
+            seriesName: resolved.name,
+            seriesPosition: match.position,
+            ...(match.bookId === bookId ? { userClearedFields: boundClearedFields } : {}),
+            updatedAt: new Date(),
+          })
           .where(eq(books.id, match.bookId));
       }
 
@@ -409,7 +432,7 @@ export class SeriesCardService {
         syncedIds.add(bookId);
         await tx
           .update(books)
-          .set({ seriesName: resolved.name, seriesPosition: book.seriesPosition, updatedAt: new Date() })
+          .set({ seriesName: resolved.name, seriesPosition: book.seriesPosition, userClearedFields: boundClearedFields, updatedAt: new Date() })
           .where(eq(books.id, bookId));
       }
 
@@ -451,65 +474,6 @@ export class SeriesCardService {
       .where(inArray(books.seriesName, unique));
     return rows;
   }
-}
-
-async function upsertHardcoverSeries(
-  tx: DbOrTx,
-  resolved: HardcoverSeriesData,
-  normalized: string,
-): Promise<SeriesRow> {
-  const byHardcoverId = await tx
-    .select()
-    .from(series)
-    .where(eq(series.hardcoverSeriesId, resolved.id))
-    .limit(1);
-  if (byHardcoverId.length > 0) {
-    const existing = byHardcoverId[0]!;
-    const updated = await tx
-      .update(series)
-      .set({
-        name: resolved.name,
-        normalizedName: normalized,
-        authorName: resolved.authorName,
-        lastFetchedAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .where(eq(series.id, existing.id))
-      .returning();
-    return updated[0]!;
-  }
-  const byName = await tx
-    .select()
-    .from(series)
-    .where(eq(series.normalizedName, normalized))
-    .limit(1);
-  if (byName.length > 0) {
-    const existing = byName[0]!;
-    const updated = await tx
-      .update(series)
-      .set({
-        hardcoverSeriesId: resolved.id,
-        name: resolved.name,
-        authorName: resolved.authorName,
-        lastFetchedAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .where(eq(series.id, existing.id))
-      .returning();
-    return updated[0]!;
-  }
-  const inserted = await tx
-    .insert(series)
-    .values({
-      publicId: generatePublicId('sr'),
-      hardcoverSeriesId: resolved.id,
-      name: resolved.name,
-      normalizedName: normalized,
-      authorName: resolved.authorName,
-      lastFetchedAt: new Date(),
-    })
-    .returning();
-  return inserted[0]!;
 }
 
 /**

--- a/src/server/services/tagging.roundtrip.test.ts
+++ b/src/server/services/tagging.roundtrip.test.ts
@@ -14,12 +14,13 @@
  * survive. xHE-AAC / USAC decode depends on ffmpeg 8 (#1667), so the suite skips
  * when the runtime ffmpeg major is < 8 — but it MUST run in the ffmpeg-8 CI lane.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { buildFfmpegArgs, type TagMetadata } from './tagging.service.js';
+import { TaggingService, buildFfmpegArgs, type TagMetadata } from './tagging.service.js';
+import { resetFfmpegPathCache } from '@core/utils/audio-processor.js';
 import { extractFfmpegMajor } from '@core/utils/ffmpeg-version.js';
 
 const FFMPEG = 'ffmpeg';
@@ -183,5 +184,216 @@ describe.skipIf(!hasFfmpeg8)('tag-write round-trip (real ffmpeg ≥ 8)', () => {
     const tags = readTags(tagged);
     expect(tags.album).toBe('Words of Radiance');
     expect(tags.album_artist).toBe('Brandon Sanderson');
+  });
+});
+
+// ============================================================================
+// #2078 — a tag write must not destroy the cover art it was not asked to touch,
+// and a re-tag must be able to SELF-HEAL an already-merged, metadata-naked m4b.
+//
+// Gated on ffmpeg PRESENCE rather than the ≥8 floor above: nothing here decodes xHE-AAC, and
+// the M4B survival contract these assert against (album/album_artist/artist/composer/grouping/
+// date/genre/description survive; the freeform series/subtitle/asin/publisher atoms do not) is
+// the same one the ffmpeg-8 block documents.
+// ============================================================================
+
+const hasAnyFfmpeg = major !== null;
+
+/** True when the file carries a video stream flagged `attached_pic`. */
+function hasAttachedPic(file: string): boolean {
+  const out = execFileSync(FFPROBE, [
+    '-v', 'quiet', '-select_streams', 'v', '-show_entries', 'stream_disposition=attached_pic',
+    '-of', 'json', file,
+  ], { encoding: 'utf8' });
+  return ((JSON.parse(out).streams ?? []) as Array<{ disposition?: { attached_pic?: number } }>)
+    .some((s) => s.disposition?.attached_pic === 1);
+}
+
+describe.skipIf(!hasAnyFfmpeg)('#2078 cover art survives a re-tag (real ffmpeg)', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'narratorr-2078-tag-'));
+  });
+
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeCoverJpg(name: string): string {
+    const path = join(dir, name);
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-f', 'lavfi', '-i', 'color=c=blue:s=64x64:d=1', '-frames:v', '1', path], { stdio: 'ignore' });
+    return path;
+  }
+
+  /** An m4b with an embedded picture, and optionally its own chapter set. */
+  function makeArtM4b(name: string, opts: { chapters?: boolean } = {}): string {
+    const cover = makeCoverJpg(`${name}.src.jpg`);
+    const path = join(dir, name);
+    execFileSync(FFMPEG, [
+      '-y', '-v', 'quiet',
+      // Duration lives INSIDE the filter: a positional `-t` here would bind to the next
+      // input (the cover), leaving anullsrc unbounded and the command running forever.
+      '-f', 'lavfi', '-i', 'anullsrc=r=44100:cl=mono:d=6',
+      '-i', cover,
+      '-map', '0:a', '-map', '1:v', '-c:a', 'aac', '-c:v', 'copy', '-disposition:v', 'attached_pic',
+      path,
+    ], { stdio: 'ignore' });
+    if (!opts.chapters) return path;
+
+    const metaPath = join(dir, `${name}.ffmeta`);
+    writeFileSync(metaPath, [
+      ';FFMETADATA1',
+      '[CHAPTER]', 'TIMEBASE=1/1000', 'START=0', 'END=3000', 'title=Chapter 1',
+      '[CHAPTER]', 'TIMEBASE=1/1000', 'START=3000', 'END=6000', 'title=Chapter 2',
+      '',
+    ].join('\n'));
+    const out = join(dir, `chaptered-${name}`);
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-i', path, '-i', metaPath, '-map_metadata', '0', '-map_chapters', '1', '-c', 'copy', out], { stdio: 'ignore' });
+    return out;
+  }
+
+  it('a tag write with NO cover input keeps the file\'s existing picture (AC16)', () => {
+    const src = makeArtM4b('has-art.m4b');
+    expect(hasAttachedPic(src)).toBe(true);
+
+    // The exact `populate_missing` shape: `shouldEmbedCover` is false precisely BECAUSE the
+    // file already has art, so `tagFile` passes no coverPath. Pre-#2078 the args were
+    // `-map 0:a` alone and this remux silently dropped the picture.
+    const tagged = writeTags(src, join(dir, 'has-art.tagged.m4b'), { album: 'Retagged' });
+
+    expect(hasAttachedPic(tagged)).toBe(true);
+    expect(readTags(tagged).album).toBe('Retagged');
+  });
+
+  it('a tag write on a file with NO picture stream still succeeds (the `?` in -map 0:v?)', () => {
+    const src = join(dir, 'no-art.mp3');
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-f', 'lavfi', '-i', 'anullsrc=r=44100:cl=mono:d=1', '-c:a', 'libmp3lame', src], { stdio: 'ignore' });
+    const tagged = writeTags(src, join(dir, 'no-art.tagged.mp3'), { album: 'Retagged' });
+
+    expect(hasAttachedPic(tagged)).toBe(false);
+    expect(readTags(tagged).album).toBe('Retagged');
+  });
+
+  it('a re-tag preserves BOTH the existing picture and the chapter set (AC16 + AC17)', () => {
+    const src = makeArtM4b('art-and-chapters.m4b', { chapters: true });
+    const before = readChapterCount(src);
+    expect(before).toBe(2);
+    expect(hasAttachedPic(src)).toBe(true);
+
+    const tagged = writeTags(src, join(dir, 'art-and-chapters.tagged.m4b'), { album: 'Retagged' });
+
+    expect(hasAttachedPic(tagged)).toBe(true);
+    expect(readChapterCount(tagged)).toBe(before);
+  });
+});
+
+/**
+ * AC19 / F6 — the self-heal path for the 12 already-naked production files.
+ *
+ * An already-merged book has exactly ONE top-level audio file, and both merge admission gates
+ * reject a single-file book (`NO_TOP_LEVEL_FILES`), so a re-merge cannot recover it. The
+ * existing re-tag action is the recovery path — which is why AC16 matters: before this issue a
+ * `populate_missing` re-tag of a file that already had art DESTROYED that art.
+ *
+ * This drives the real `retagBook` end to end (canonical hydrated-book → tag projection, disk
+ * cover discovery, the temp + atomic-rename write) rather than `buildFfmpegArgs` alone, so it
+ * also pins AC15's multi-author/multi-narrator joins on a real read-back.
+ */
+describe.skipIf(!hasAnyFfmpeg)('#2078 re-tag self-heals a metadata-naked merged m4b (AC15, AC19)', () => {
+  let bookDir: string;
+
+  beforeAll(() => {
+    bookDir = mkdtempSync(join(tmpdir(), 'narratorr-2078-selfheal-'));
+  });
+
+  afterAll(() => {
+    if (bookDir) rmSync(bookDir, { recursive: true, force: true });
+    // Restore the AMBIENT value rather than deleting the key: a runner or dev machine may have
+    // its own FFMPEG_PATH configured, and unconditionally unsetting it makes every later suite
+    // order-dependent on this one. Reset the resolver cache AFTER restoring, so the next caller
+    // re-resolves against the restored environment rather than this suite's override.
+    vi.unstubAllEnvs();
+    resetFfmpegPathCache();
+  });
+
+  /** Exactly what auto-merge produced in production: chapters, no tags, no embedded art. */
+  function makeNakedMergedM4b(name: string): string {
+    const base = join(bookDir, `base-${name}`);
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-f', 'lavfi', '-i', 'anullsrc=r=44100:cl=mono:d=6', '-c:a', 'aac', base], { stdio: 'ignore' });
+
+    const metaPath = join(bookDir, `${name}.ffmeta`);
+    writeFileSync(metaPath, [
+      ';FFMETADATA1',
+      '[CHAPTER]', 'TIMEBASE=1/1000', 'START=0', 'END=3000', 'title=Chapter 1',
+      '[CHAPTER]', 'TIMEBASE=1/1000', 'START=3000', 'END=6000', 'title=Chapter 2',
+      '',
+    ].join('\n'));
+
+    const out = join(bookDir, name);
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-i', base, '-i', metaPath, '-map_metadata', '1', '-map_chapters', '1', '-c', 'copy', out], { stdio: 'ignore' });
+    rmSync(base);
+    rmSync(metaPath);
+    return out;
+  }
+
+  it('restores the canonical tag set, embeds the disk cover, and leaves chapters intact', async () => {
+    const merged = makeNakedMergedM4b('The Way of Kings.m4b');
+    // The disk cover `retagBook` will find via `findCoverFile(book.path)`.
+    execFileSync(FFMPEG, ['-y', '-v', 'quiet', '-f', 'lavfi', '-i', 'color=c=green:s=64x64:d=1', '-frames:v', '1', join(bookDir, 'cover.jpg')], { stdio: 'ignore' });
+
+    // Baseline: the reported production symptom — structural tags only, no art, chapters present.
+    const before = readTags(merged);
+    expect(before.artist).toBeUndefined();
+    expect(before.album).toBeUndefined();
+    expect(hasAttachedPic(merged)).toBe(false);
+    expect(readChapterCount(merged)).toBe(2);
+
+    // `resolveFfmpegPath` honors FFMPEG_PATH first, so the real resolver runs unmocked.
+    // `stubEnv` (not a raw assignment) so `vi.unstubAllEnvs()` in afterAll puts back whatever
+    // the ambient value was — including "not set at all".
+    vi.stubEnv('FFMPEG_PATH', FFMPEG);
+    resetFfmpegPathCache();
+
+    const bookService = {
+      getById: async () => ({
+        id: 1, title: 'The Way of Kings', path: bookDir,
+        authors: [{ name: 'Brandon Sanderson' }, { name: 'Co Author' }],
+        narrators: [{ name: 'Michael Kramer' }, { name: 'Kate Reading' }],
+        seriesName: 'The Stormlight Archive', seriesPosition: 1,
+        asin: 'B00ABCDEFG', subtitle: 'Book One', description: 'An epic fantasy.',
+        publisher: 'Tor Books', publishedDate: '2010-08-31', genres: ['Fantasy', 'Epic'],
+        coverUrl: null,
+      }),
+    };
+    const settingsService = { get: async () => ({ mode: 'overwrite' as const, embedCover: true }) };
+    const log = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} };
+
+    const service = new TaggingService(
+      null as never, settingsService as never, log as never, bookService as never,
+    );
+
+    const result = await service.retagBook(1);
+    expect(result.failed).toBe(0);
+    expect(result.tagged).toBe(1);
+
+    const after = readTags(merged);
+    // AC15 — the canonical projection joins ALL authors and ALL narrators with ', '. Asserted
+    // against the M4B-SURVIVING subset documented in this file's header, not the full shape.
+    expect(after.artist).toBe('Brandon Sanderson, Co Author');
+    expect(after.album_artist).toBe('Brandon Sanderson, Co Author');
+    expect(after.composer).toBe('Michael Kramer, Kate Reading');
+    expect(after.album).toBe('The Way of Kings');
+    expect(after.grouping).toBe('The Stormlight Archive');
+    expect(after.date).toBe('2010');
+    expect(after.genre).toBe('Fantasy');
+    expect(after.description).toBe('An epic fantasy.');
+    // Same container contract the ffmpeg-8 block pins: the freeform atoms do not survive M4B.
+    expect(after.series).toBeUndefined();
+    expect(after.asin).toBeUndefined();
+
+    // AC19 — the cover is newly embedded from disk, and the chapter set is untouched.
+    expect(hasAttachedPic(merged)).toBe(true);
+    expect(readChapterCount(merged)).toBe(2);
   });
 });

--- a/src/server/services/tagging.service.test.ts
+++ b/src/server/services/tagging.service.test.ts
@@ -150,14 +150,41 @@ describe('buildFfmpegArgs', () => {
     expect(args).toContain('attached_pic');
   });
 
-  it('omits cover art args when no coverPath', () => {
+  it('opens no cover input when no coverPath, but PRESERVES an existing picture (#2078 AC16)', () => {
     const tags: TagMetadata = { artist: 'Author' };
     const args = buildFfmpegArgs('/books/input.mp3', '/books/out.mp3', tags);
 
     // Should only have one -i (for the audio input)
     const iCount = args.filter(a => a === '-i').length;
     expect(iCount).toBe(1);
-    expect(args).not.toContain('-c:v');
+
+    // Pre-#2078 this mapped `0:a` alone, so EVERY tag write without a cover input silently
+    // stripped embedded art — including `populate_missing`, where shouldEmbedCover is false
+    // precisely BECAUSE the file already has art. `?` keeps files with no picture unaffected.
+    const mapIdx = args.indexOf('-map', args.indexOf('-map') + 1);
+    expect(args[mapIdx]).toBe('-map');
+    expect(args[mapIdx + 1]).toBe('0:v?');
+    expect(args[args.indexOf('-c:v') + 1]).toBe('copy');
+    expect(args[args.indexOf('-disposition:v') + 1]).toBe('attached_pic');
+  });
+
+  it('with a coverPath the NEW cover input wins and video is mapped exactly once (#2078 AC16)', () => {
+    const args = buildFfmpegArgs('/books/input.m4b', '/books/out.m4b', { artist: 'Author' }, '/books/cover.jpg');
+
+    const mapped = args.reduce<string[]>((acc, a, i) => (a === '-map' ? [...acc, args[i + 1]!] : acc), []);
+    // Exactly one video mapping, and it is the new cover input — never `0:v?` alongside it,
+    // which would emit two attached pictures.
+    expect(mapped).toEqual(['0:a', '1']);
+    expect(mapped).not.toContain('0:v?');
+  });
+
+  it('keeps -map_chapters 0 in both the cover and no-cover shapes (#2078 AC17)', () => {
+    for (const args of [
+      buildFfmpegArgs('/books/in.m4b', '/books/out.m4b', { album: 'Book' }),
+      buildFfmpegArgs('/books/in.m4b', '/books/out.m4b', { album: 'Book' }, '/books/cover.jpg'),
+    ]) {
+      expect(args[args.indexOf('-map_chapters') + 1]).toBe('0');
+    }
   });
 
   it('omits undefined tag fields', () => {
@@ -1752,7 +1779,11 @@ describe('TaggingService', () => {
 
       const args = (execFile as unknown as Mock).mock.calls[0]![1] as string[];
       expect(args.some(a => a.endsWith('cover.jpg'))).toBe(false);
-      expect(args).not.toContain('-disposition:v');
+      // Observation point moved by #2078: `-disposition:v` is now emitted unconditionally (it
+      // labels the file's OWN preserved picture), so it no longer distinguishes "cover embedded"
+      // from "cover suppressed". The input list does — a suppressed cover opens no second input.
+      expect(args.filter(a => a === '-i')).toHaveLength(1);
+      expect(args[args.indexOf('-map', args.indexOf('-map') + 1) + 1]).toBe('0:v?');
     });
 
     it('omitting overrides falls back to settings (regression — bare retagBook call)', async () => {

--- a/src/server/services/tagging.service.ts
+++ b/src/server/services/tagging.service.ts
@@ -101,13 +101,15 @@ export function buildFfmpegArgs(
     args.push('-i', coverPath);
   }
 
-  // Map inputs
+  // Map inputs. Exactly one video mapping either way: the new cover input when one was
+  // supplied, otherwise the source's OWN attached picture (#2078). Without that fallback the
+  // tag write is audio-only and silently strips embedded art — on every `populate_missing`
+  // re-tag (where shouldEmbedCover is false precisely BECAUSE the file already has a picture)
+  // and on every re-tag with Embed cover art off. The `?` makes the specifier optional, so a
+  // file with no video stream is unaffected.
   args.push('-map', '0:a');
-  if (coverPath) {
-    args.push('-map', '1');
-    args.push('-c:v', 'copy');
-    args.push('-disposition:v', 'attached_pic');
-  }
+  args.push('-map', coverPath ? '1' : '0:v?');
+  args.push('-c:v', 'copy', '-disposition:v', 'attached_pic');
 
   // Copy audio codec (no re-encode)
   args.push('-c:a', 'copy');

--- a/src/server/services/types.ts
+++ b/src/server/services/types.ts
@@ -42,6 +42,21 @@ export type BookRow = Omit<typeof books.$inferSelect, 'status' | 'enrichmentStat
   productionType: ProductionType;
 };
 
+/**
+ * A `books` row minus the RAW `user_cleared_fields` text (#2069 AC16).
+ *
+ * The column is plain text, so `BookRow` types it `string | null` — a shape that
+ * must never reach an HTTP response. **Any book row that gets serialized is a
+ * `BookRowPublic`**; `BookRow` is for consumers that only compare/score it
+ * internally (quality gate, discovery). One named type rather than a per-site
+ * omission is what makes that rule checkable. Strip with `stripClearedFields`.
+ *
+ * A caller that needs the tombstones as behavior takes the hydrated `BookDetail`
+ * (`book.service.ts`), whose `userClearedFields` is the `parseClearedFields`
+ * output — never the raw string.
+ */
+export type BookRowPublic = Omit<BookRow, 'userClearedFields'>;
+
 // Two-axis download state (#1445): narrow both axis columns to their Zod-derived
 // unions (Drizzle's $inferSelect widens text-enum columns to `string`). There is
 // no `status` column anymore — the display status is derived from the tuple.

--- a/src/server/services/unmatched-genres.ts
+++ b/src/server/services/unmatched-genres.ts
@@ -1,0 +1,34 @@
+import { sql } from 'drizzle-orm';
+import type { Db } from '@db/index.js';
+import type { FastifyBaseLogger } from 'fastify';
+import { unmatchedGenres } from '@db/schema.js';
+import { findUnmatchedGenres, normalizeGenres } from '@core/index.js';
+
+/**
+ * Fire-and-forget: track genres not in the synonym/known lists for future
+ * analysis. Extracted from `book.service.ts` (at its `max-lines` cap); the body
+ * is unchanged and `BookService.trackUnmatchedGenres` still delegates here, so
+ * every existing caller and test keeps its shape.
+ */
+export async function trackUnmatchedGenres(
+  db: Db,
+  log: FastifyBaseLogger,
+  genres: string[] | undefined,
+): Promise<void> {
+  const unmatched = findUnmatchedGenres(normalizeGenres(genres));
+  if (unmatched.length === 0) return;
+
+  for (const genre of unmatched) {
+    await db
+      .insert(unmatchedGenres)
+      .values({ genre, count: 1 })
+      .onConflictDoUpdate({
+        target: unmatchedGenres.genre,
+        set: {
+          count: sql`${unmatchedGenres.count} + 1`,
+          lastSeen: sql`(unixepoch())`,
+        },
+      });
+  }
+  log.debug({ genres: unmatched }, 'Tracked unmatched genres');
+}

--- a/src/server/utils/audio-bitrate.test.ts
+++ b/src/server/utils/audio-bitrate.test.ts
@@ -1,20 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { toSourceBitrateKbps, logBitrateCapping } from './audio-bitrate.js';
-import type { FastifyBaseLogger } from 'fastify';
-
-function createMockLogger(): FastifyBaseLogger {
-  return {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    fatal: vi.fn(),
-    trace: vi.fn(),
-    child: vi.fn(),
-    silent: vi.fn(),
-    level: 'debug',
-  } as unknown as FastifyBaseLogger;
-}
+import { describe, expect, it } from 'vitest';
+import { toSourceBitrateKbps } from './audio-bitrate.js';
 
 describe('toSourceBitrateKbps()', () => {
   it('returns undefined when input is null', () => {
@@ -36,45 +21,16 @@ describe('toSourceBitrateKbps()', () => {
   it('floors fractional kbps values (e.g., 128500 bps → 128 kbps)', () => {
     expect(toSourceBitrateKbps(128500)).toBe(128);
   });
-});
 
-describe('logBitrateCapping()', () => {
-  it('logs debug when sourceBitrateKbps < targetBitrateKbps', () => {
-    const log = createMockLogger();
-    logBitrateCapping(64, 128, log);
-    expect(log.debug).toHaveBeenCalledWith(
-      { sourceBitrateKbps: 64, targetBitrateKbps: 128, effectiveBitrateKbps: 64 },
-      'Capping target bitrate to source bitrate to prevent upsampling',
-    );
+  it('returns undefined for the documented 827 bps header lie rather than 0', () => {
+    expect(toSourceBitrateKbps(827)).toBeUndefined();
   });
 
-  it('does not log when sourceBitrateKbps >= targetBitrateKbps', () => {
-    const log = createMockLogger();
-    logBitrateCapping(128, 64, log);
-    expect(log.debug).not.toHaveBeenCalled();
+  it('returns undefined for any value that floors below 1 kbps', () => {
+    expect(toSourceBitrateKbps(999)).toBeUndefined();
   });
 
-  it('does not log when sourceBitrateKbps is undefined', () => {
-    const log = createMockLogger();
-    logBitrateCapping(undefined, 128, log);
-    expect(log.debug).not.toHaveBeenCalled();
-  });
-
-  it('does not log when targetBitrateKbps is undefined', () => {
-    const log = createMockLogger();
-    logBitrateCapping(64, undefined, log);
-    expect(log.debug).not.toHaveBeenCalled();
-  });
-
-  it('does not log when both are undefined', () => {
-    const log = createMockLogger();
-    logBitrateCapping(undefined, undefined, log);
-    expect(log.debug).not.toHaveBeenCalled();
-  });
-
-  it('returns sourceBitrateKbps and targetBitrateKbps unchanged', () => {
-    const log = createMockLogger();
-    const result = logBitrateCapping(64, 128, log);
-    expect(result).toEqual({ sourceBitrateKbps: 64, targetBitrateKbps: 128 });
+  it('returns 1 at the 1 kbps boundary', () => {
+    expect(toSourceBitrateKbps(1000)).toBe(1);
   });
 });

--- a/src/server/utils/audio-bitrate.ts
+++ b/src/server/utils/audio-bitrate.ts
@@ -1,21 +1,16 @@
-import type { FastifyBaseLogger } from 'fastify';
-
-/** Convert bps to kbps, returning undefined for null/0/undefined values. */
+/**
+ * Convert a stored bps bitrate to kbps, returning `undefined` for null/undefined and for any
+ * value that floors below 1 kbps.
+ *
+ * The sub-1-kbps arm is a *value-sanity* guarantee, not a policy threshold: "0 kbps" is not a
+ * bitrate at any layer, and the repository's known garbage class (an MP3 header reporting 827
+ * bps) would otherwise reach the core processor as a numeric `0`. Deciding what counts as
+ * *usable evidence* stays single-homed in the core encode-strategy resolver, which rejects
+ * anything below its own plausibility floor — a 1–7 kbps value that passes here is rejected
+ * there.
+ */
 export function toSourceBitrateKbps(bps: number | null | undefined): number | undefined {
-  return bps ? Math.floor(bps / 1000) : undefined;
-}
-
-/** Log a capping warning when source bitrate is below target. Returns both values unchanged. */
-export function logBitrateCapping(
-  sourceBitrateKbps: number | undefined,
-  targetBitrateKbps: number | undefined,
-  log: FastifyBaseLogger,
-): { sourceBitrateKbps: number | undefined; targetBitrateKbps: number | undefined } {
-  if (targetBitrateKbps != null && sourceBitrateKbps != null && sourceBitrateKbps < targetBitrateKbps) {
-    log.debug(
-      { sourceBitrateKbps, targetBitrateKbps, effectiveBitrateKbps: sourceBitrateKbps },
-      'Capping target bitrate to source bitrate to prevent upsampling',
-    );
-  }
-  return { sourceBitrateKbps, targetBitrateKbps };
+  if (typeof bps !== 'number' || !Number.isFinite(bps)) return undefined;
+  const kbps = Math.floor(bps / 1000);
+  return kbps >= 1 ? kbps : undefined;
 }

--- a/src/server/utils/cleared-fields.test.ts
+++ b/src/server/utils/cleared-fields.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { FastifyBaseLogger } from 'fastify';
+import {
+  parseClearedFields,
+  serializeClearedFields,
+  normalizeClearedFieldsColumn,
+  recomputeClearedFields,
+} from './cleared-fields.js';
+import { CLEARABLE_BOOK_FIELDS } from '@shared/schemas/book.js';
+
+function createMockLogger(): FastifyBaseLogger {
+  return {
+    info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    trace: vi.fn(), fatal: vi.fn(), child: vi.fn().mockReturnThis(),
+    level: 'info', silent: vi.fn(),
+  } as unknown as FastifyBaseLogger;
+}
+
+/**
+ * The longest run of `raw` that V8's `JSON.parse` SyntaxError message quotes back.
+ * The engine echoes a bounded window around the failure point (roughly ten
+ * characters, elided with `...`), so tests assert against the fragment it actually
+ * leaked instead of a hand-picked sentinel that may fall outside that window.
+ * Returns `''` when the message is purely positional.
+ */
+function longestEchoedFragment(raw: string): string {
+  let message = '';
+  try {
+    JSON.parse(raw);
+  } catch (error: unknown) {
+    message = (error as Error).message;
+  }
+  let longest = '';
+  for (let start = 0; start < raw.length; start++) {
+    for (let end = raw.length; end > start + longest.length; end--) {
+      const candidate = raw.slice(start, end);
+      if (message.includes(candidate)) {
+        longest = candidate;
+        break;
+      }
+    }
+  }
+  return longest;
+}
+
+describe('parseClearedFields', () => {
+  it('parses SQL NULL and a legacy "[]" to the empty set without warning', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields(null, log, 1)).toEqual([]);
+    expect(parseClearedFields('[]', log, 1)).toEqual([]);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns the recognized names for a valid array', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields('["genres","seriesName"]', log, 1)).toEqual(['genres', 'seriesName']);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('degrades unparseable JSON to the empty set with one warn and no raw value', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields('{oops', log, 42)).toEqual([]);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    const [payload] = vi.mocked(log.warn).mock.calls[0] as [Record<string, unknown>, string];
+    expect(payload).toEqual(expect.objectContaining({ bookId: 42 }));
+    expect(JSON.stringify(payload)).not.toContain('{oops');
+  });
+
+  // AC4's no-raw rule is ABSOLUTE, and `{oops` is the one shape that cannot catch a
+  // violation: V8 reports it positionally ("Expected property name or '}' in JSON at
+  // position 1") and never echoes the source. Most malformed input DOES echo a
+  // window of it — `JSON.parse('{"a": bad}')` yields
+  // `Unexpected token 'b', "{"a": bad}" is not valid JSON` — so a
+  // `serializeError(err)` payload reproduces persisted content verbatim in logs.
+  it.each([
+    ['object with a bare token', '{"seriesName": bad}'],
+    ['array with a bare token', '["seriesName", bad]'],
+    ['bare identifier', 'notjson-sentinel-abc123'],
+    ['single-quoted string', "'quoted-sentinel'"],
+    ['array with a dangling comma', '["seriesName",]'],
+    ['long value truncated to V8\'s echo window', '{"seriesName": operator-typed-secret-value-here}'],
+  ])('never reproduces the stored value in the warn payload (%s)', (_label, raw) => {
+    // Derive the fragment V8 ACTUALLY echoed rather than guessing one: the engine
+    // quotes a bounded window around the failure point, so a hard-coded sentinel
+    // longer than that window makes the test pass for the wrong reason.
+    const echoed = longestEchoedFragment(raw);
+    // Premise guard — if V8 ever stops echoing, this case proves nothing and should
+    // say so loudly rather than going quietly green.
+    expect(echoed.length).toBeGreaterThanOrEqual(4);
+
+    const log = createMockLogger();
+    expect(parseClearedFields(raw, log, 7)).toEqual([]);
+
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    const [payload, message] = vi.mocked(log.warn).mock.calls[0] as [Record<string, unknown>, string];
+    // Assert on the WHOLE serialized payload, not just known keys — a nested
+    // `error.message`/`error.stack` is exactly how the value used to escape.
+    expect(JSON.stringify(payload)).not.toContain(echoed);
+    expect(message).not.toContain(echoed);
+    expect(payload).toEqual({ bookId: 7 });
+  });
+
+  it('carries no error object at all on the unparseable arm', () => {
+    const log = createMockLogger();
+    parseClearedFields('{"a": bad}', log, 3);
+    const [payload] = vi.mocked(log.warn).mock.calls[0] as [Record<string, unknown>, string];
+    expect(payload).not.toHaveProperty('error');
+    expect(Object.keys(payload)).toEqual(['bookId']);
+  });
+
+  it('degrades a JSON object to the empty set with one warn carrying only bookId', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields('{"seriesName":true,"leaked":"SHAPE_SENTINEL"}', log, 7)).toEqual([]);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    const [payload] = vi.mocked(log.warn).mock.calls[0] as [Record<string, unknown>, string];
+    expect(payload).toEqual({ bookId: 7 });
+    expect(JSON.stringify(payload)).not.toContain('SHAPE_SENTINEL');
+  });
+
+  it('degrades an array of numbers to the empty set with one warn', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields('[1,2]', log, 7)).toEqual([]);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops unknown names, keeps the recognized ones, and warns naming the drops', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields('["genres","futureField"]', log, 9)).toEqual(['genres']);
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(log.warn).mock.calls[0]![0]).toEqual(
+      expect.objectContaining({ bookId: 9, dropped: ['futureField'] }),
+    );
+  });
+
+  it('sanitizes a non-canonical stored value (unsorted + duplicated)', () => {
+    const log = createMockLogger();
+    expect(parseClearedFields('["subtitle","genres","subtitle"]', log, 1)).toEqual(['genres', 'subtitle']);
+  });
+
+  it('never throws for any of the malformed shapes', () => {
+    const log = createMockLogger();
+    for (const raw of ['{oops', '"a string"', '3', 'null', '[null]', '[{"a":1}]']) {
+      expect(() => parseClearedFields(raw, log, 1)).not.toThrow();
+    }
+  });
+});
+
+describe('serializeClearedFields', () => {
+  it('emits the canonical sorted, deduplicated form', () => {
+    expect(serializeClearedFields(['subtitle', 'genres', 'subtitle'])).toBe('["genres","subtitle"]');
+  });
+
+  it('stores the empty set as SQL NULL, never "[]"', () => {
+    expect(serializeClearedFields([])).toBeNull();
+  });
+
+  it('accepts every canonical clearable name', () => {
+    expect(() => serializeClearedFields([...CLEARABLE_BOOK_FIELDS])).not.toThrow();
+    expect(serializeClearedFields([...CLEARABLE_BOOK_FIELDS])).toBe(
+      JSON.stringify([...CLEARABLE_BOOK_FIELDS].sort()),
+    );
+  });
+
+  it('throws on an unknown field name', () => {
+    expect(() => serializeClearedFields(['genres', 'futureField'])).toThrow();
+  });
+});
+
+describe('normalizeClearedFieldsColumn', () => {
+  it('canonicalizes a valid raw column value', () => {
+    expect(normalizeClearedFieldsColumn('["subtitle","genres"]')).toBe('["genres","subtitle"]');
+  });
+
+  it('maps null/undefined and the empty array to SQL NULL', () => {
+    expect(normalizeClearedFieldsColumn(null)).toBeNull();
+    expect(normalizeClearedFieldsColumn(undefined)).toBeNull();
+    expect(normalizeClearedFieldsColumn('[]')).toBeNull();
+  });
+
+  it('throws on unparseable JSON and on an unknown name', () => {
+    expect(() => normalizeClearedFieldsColumn('{oops')).toThrow();
+    expect(() => normalizeClearedFieldsColumn('["futureField"]')).toThrow();
+  });
+});
+
+describe('recomputeClearedFields — AC6 matrix, string fields', () => {
+  const STRING_FIELDS = ['seriesName', 'subtitle', 'description', 'publisher', 'publishedDate'] as const;
+
+  for (const field of STRING_FIELDS) {
+    it(`${field}: absent key leaves the set and the stored value untouched`, () => {
+      const r = recomputeClearedFields([], {});
+      expect(r.cleared).toEqual([]);
+      expect(r.normalized).toEqual({});
+      expect(r.blanked).toEqual([]);
+    });
+
+    it(`${field}: null adds the tombstone and normalizes the stored value to NULL`, () => {
+      const r = recomputeClearedFields([], { [field]: null });
+      expect(r.cleared).toEqual([field]);
+      expect(r.normalized[field]).toBeNull();
+      expect(r.blanked).toEqual([field]);
+    });
+
+    it(`${field}: '' adds the tombstone and normalizes the stored value to NULL`, () => {
+      const r = recomputeClearedFields([], { [field]: '' });
+      expect(r.cleared).toEqual([field]);
+      expect(r.normalized[field]).toBeNull();
+    });
+
+    it(`${field}: whitespace-only adds the tombstone and normalizes the stored value to NULL`, () => {
+      const r = recomputeClearedFields([], { [field]: '   ' });
+      expect(r.cleared).toEqual([field]);
+      expect(r.normalized[field]).toBeNull();
+    });
+
+    it(`${field}: a non-blank value removes the tombstone and stores verbatim`, () => {
+      const r = recomputeClearedFields([field], { [field]: '  Mistborn  ' });
+      expect(r.cleared).toEqual([]);
+      expect(r.normalized[field]).toBe('  Mistborn  ');
+      expect(r.blanked).toEqual([]);
+    });
+  }
+
+  it('preserves interior whitespace on description (matches diffDescription)', () => {
+    const r = recomputeClearedFields([], { description: 'one\n\n  two' });
+    expect(r.normalized.description).toBe('one\n\n  two');
+  });
+});
+
+describe('recomputeClearedFields — AC6 matrix, genres', () => {
+  it('absent key leaves the set untouched', () => {
+    expect(recomputeClearedFields(['genres'], {}).cleared).toEqual(['genres']);
+  });
+
+  it('null adds the tombstone and stores NULL', () => {
+    const r = recomputeClearedFields([], { genres: null });
+    expect(r.cleared).toEqual(['genres']);
+    expect(r.normalized.genres).toBeNull();
+    expect(r.blanked).toEqual(['genres']);
+  });
+
+  it('[] adds the tombstone and stores NULL', () => {
+    const r = recomputeClearedFields([], { genres: [] });
+    expect(r.cleared).toEqual(['genres']);
+    expect(r.normalized.genres).toBeNull();
+  });
+
+  it("['', '  '] adds the tombstone and stores NULL", () => {
+    const r = recomputeClearedFields([], { genres: ['', '  '] });
+    expect(r.cleared).toEqual(['genres']);
+    expect(r.normalized.genres).toBeNull();
+  });
+
+  it('a mixed array removes the tombstone and drops the blank elements', () => {
+    const r = recomputeClearedFields(['genres'], { genres: ['Fantasy', '  ', 'Epic'] });
+    expect(r.cleared).toEqual([]);
+    expect(r.normalized.genres).toEqual(['Fantasy', 'Epic']);
+  });
+});
+
+describe('recomputeClearedFields — pair rule and non-clearable keys', () => {
+  it('seriesPosition: null alone never adds a tombstone', () => {
+    const r = recomputeClearedFields([], { seriesPosition: null });
+    expect(r.cleared).toEqual([]);
+    expect(r.normalized).toEqual({});
+  });
+
+  it('seriesName: null covers the pair — only seriesName is tombstoned', () => {
+    const r = recomputeClearedFields([], { seriesName: null, seriesPosition: null });
+    expect(r.cleared).toEqual(['seriesName']);
+    expect(r.normalized).toEqual({ seriesName: null });
+  });
+
+  it('non-clearable keys never affect the set', () => {
+    const r = recomputeClearedFields([], {
+      coverUrl: null, status: 'wanted', title: 'x', narrators: [], authors: [{ name: 'a' }],
+    });
+    expect(r.cleared).toEqual([]);
+    expect(r.normalized).toEqual({});
+    expect(r.blanked).toEqual([]);
+  });
+});
+
+describe('recomputeClearedFields — idempotence and canonical form', () => {
+  it('applying the same clear twice yields a one-element set', () => {
+    const once = recomputeClearedFields([], { seriesName: null });
+    const twice = recomputeClearedFields(once.cleared, { seriesName: null });
+    expect(twice.cleared).toEqual(['seriesName']);
+  });
+
+  it('output is sorted and deduplicated, and the empty set serializes to NULL not "[]"', () => {
+    const r = recomputeClearedFields(['subtitle', 'subtitle', 'publisher'] as never, { genres: null });
+    expect(r.cleared).toEqual(['genres', 'publisher', 'subtitle']);
+    expect(serializeClearedFields(r.cleared)).toBe('["genres","publisher","subtitle"]');
+    expect(serializeClearedFields(recomputeClearedFields(['genres'], { genres: ['Fantasy'] }).cleared)).toBeNull();
+  });
+
+  it('mixed body: one field blanked while another is set in the same call', () => {
+    const r = recomputeClearedFields(['publisher'], { seriesName: null, publisher: 'Tor' });
+    expect(r.cleared).toEqual(['seriesName']);
+    expect(r.normalized).toEqual({ seriesName: null, publisher: 'Tor' });
+    expect(r.blanked).toEqual(['seriesName']);
+  });
+});

--- a/src/server/utils/cleared-fields.ts
+++ b/src/server/utils/cleared-fields.ts
@@ -1,0 +1,197 @@
+import type { FastifyBaseLogger } from 'fastify';
+import {
+  CLEARABLE_BOOK_FIELDS,
+  clearedFieldsSchema,
+  type ClearableBookField,
+} from '@shared/schemas/book.js';
+
+/**
+ * Operator-asserted absences ("tombstones") for `books.user_cleared_fields` (#2069).
+ *
+ * The column is PLAIN TEXT (see `src/db/schema.ts`), so nothing decodes it in the
+ * driver. This module is the only place that turns the stored bytes into behavior:
+ *
+ *  - {@link parseClearedFields} — the READ boundary. Warn-and-degrades, never throws.
+ *  - {@link serializeClearedFields} — the WRITE boundary. Validates through
+ *    `clearedFieldsSchema` and THROWS on an unknown name, and emits the canonical
+ *    form (sorted ascending, deduplicated, empty set as SQL NULL).
+ *  - {@link recomputeClearedFields} — the pure add/remove rules for a `PUT` body.
+ */
+
+const CLEARABLE_SET: ReadonlySet<string> = new Set<string>(CLEARABLE_BOOK_FIELDS);
+
+/**
+ * Parse a persisted `user_cleared_fields` column into its sanitized set.
+ *
+ * Takes the RAW column string (the `parsePhaseHistory` precedent) and degrades
+ * rather than throwing, matching the two existing persisted-JSON read boundaries
+ * in this repo (`parsePhaseHistory`, the quality-gate reason parser). Throwing
+ * here would turn one corrupt row into an unreadable book detail page and a
+ * permanently stuck enrichment candidate — strictly worse than losing a tombstone
+ * that can only become corrupt through an out-of-band DB edit, since every in-app
+ * write is validated by {@link serializeClearedFields}.
+ *
+ * Policy:
+ *  - unparseable JSON / non-array / non-string element → empty set + one `log.warn`;
+ *  - unknown names → dropped, recognized names kept, one `log.warn` naming the drops;
+ *  - SQL NULL and a legacy `'[]'` both parse to the empty set with no warning.
+ *
+ * **The raw column value is NEVER logged** — only `bookId`, and the dropped names
+ * once they are known to be recognized-shaped strings. In particular the
+ * unparseable arm logs NO error object: V8's `SyntaxError.message` embeds a
+ * snippet of the offending source (`JSON.parse('{"a": bad}')` →
+ * `Unexpected token 'b', "{"a": bad}" is not valid JSON`), and `serializeError`
+ * copies `message` and `stack` while redacting only URLs — so passing the parse
+ * exception through would reproduce persisted content in logs and break AC4's
+ * absolute no-raw rule. The `{oops` shape happens NOT to echo, which is exactly why
+ * a single-input test could not catch this. `bookId` is the whole diagnostic need:
+ * it identifies the row to inspect out of band.
+ *
+ * This mirrors the quality-gate reason parser, which logs Zod issue PATHS and never
+ * the field values (`quality-gate.service.ts`, #1404).
+ */
+export function parseClearedFields(
+  raw: string | null,
+  log: FastifyBaseLogger,
+  bookId: number,
+): ClearableBookField[] {
+  if (!raw) return [];
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    log.warn({ bookId }, 'Unparseable userClearedFields JSON; treating as no tombstones');
+    return [];
+  }
+
+  if (!Array.isArray(decoded) || decoded.some((entry) => typeof entry !== 'string')) {
+    log.warn({ bookId }, 'Malformed userClearedFields; treating as no tombstones');
+    return [];
+  }
+
+  const known: ClearableBookField[] = [];
+  const dropped: string[] = [];
+  for (const entry of decoded as string[]) {
+    if (CLEARABLE_SET.has(entry)) known.push(entry as ClearableBookField);
+    else dropped.push(entry);
+  }
+  if (dropped.length > 0) {
+    log.warn({ bookId, dropped }, 'Unknown userClearedFields entries dropped');
+  }
+  return [...new Set(known)].sort();
+}
+
+/**
+ * Canonical serialization for every in-app write (AC2/AC3).
+ *
+ * Validates through `clearedFieldsSchema` and THROWS on an unknown name — SQLite
+ * text columns emit no DB CHECK, so this is the only enforcement point. The output
+ * is sorted ascending and deduplicated, and the empty set is SQL `NULL` (never
+ * `'[]'`), so the stored text is a function of its set value: a no-op rewrite
+ * cannot change the bytes and tests have one form to assert against.
+ */
+export function serializeClearedFields(fields: readonly string[]): string | null {
+  const parsed = clearedFieldsSchema.parse(fields);
+  const canonical = [...new Set(parsed)].sort();
+  return canonical.length === 0 ? null : JSON.stringify(canonical);
+}
+
+/**
+ * Write-boundary normalization for a caller-supplied RAW column value (AC2).
+ * `BookService.update` runs this before opening its transaction, so a payload
+ * carrying an unknown field name rejects without issuing any write.
+ */
+export function normalizeClearedFieldsColumn(raw: string | null | undefined): string | null {
+  if (raw === null || raw === undefined) return null;
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    throw new Error('userClearedFields must be a JSON-encoded array of clearable field names');
+  }
+  return serializeClearedFields(clearedFieldsSchema.parse(decoded));
+}
+
+/** A `PUT /api/books/:id` body, as far as the recompute is concerned. */
+export type ClearableUpdateBody = Partial<Record<string, unknown>>;
+
+export interface ClearedFieldsRecompute {
+  /** The new tombstone set — canonical (sorted, deduplicated). */
+  cleared: ClearableBookField[];
+  /**
+   * Stored-value overrides to merge over the request body (AC7). A blank value
+   * for a clearable field normalizes to NULL and blank `genres` elements are
+   * dropped, so the stored value can never contradict the tombstone.
+   */
+  normalized: Partial<Record<ClearableBookField, string | string[] | null>>;
+  /** The clearable fields this body just blanked — drives AC14's membership reconcile. */
+  blanked: ClearableBookField[];
+}
+
+function isBlankString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim() === '';
+}
+
+/**
+ * Recompute the tombstone set from a `PUT` body (AC6/AC7). PURE — no I/O, no
+ * clock. The caller runs it inside the write transaction against a set it re-read
+ * there, so two concurrent edits cannot interleave into a stale set.
+ *
+ * Per clearable key:
+ *
+ * | body state                              | tombstone | stored          |
+ * |-----------------------------------------|-----------|-----------------|
+ * | key absent                              | unchanged | unchanged       |
+ * | `null`                                  | added     | NULL            |
+ * | `''` / whitespace-only string           | added     | NULL            |
+ * | `genres: []` or `['', '  ']`            | added     | NULL            |
+ * | non-blank string                        | removed   | verbatim        |
+ * | `genres` with ≥1 non-blank element      | removed   | blanks dropped  |
+ *
+ * A non-blank string is stored VERBATIM — no trimming — matching `diffDescription`,
+ * which deliberately preserves interior whitespace. Keys outside
+ * `CLEARABLE_BOOK_FIELDS` (`coverUrl`, `status`, `title`, `authors`, `narrators`,
+ * `seriesPosition`) never affect the set: `seriesPosition` is not tombstoned
+ * independently, the `seriesName` tombstone suppresses the pair (#1927 AC10).
+ */
+export function recomputeClearedFields(
+  current: readonly ClearableBookField[],
+  body: ClearableUpdateBody,
+): ClearedFieldsRecompute {
+  const next = new Set<ClearableBookField>(current);
+  const normalized: ClearedFieldsRecompute['normalized'] = {};
+  const blanked: ClearableBookField[] = [];
+
+  for (const field of CLEARABLE_BOOK_FIELDS) {
+    if (!(field in body)) continue;
+    const value = body[field];
+    // An explicit `undefined` is the same as an absent key everywhere else in
+    // `update()` ("omitted = unchanged"), so it must not read as a clear here.
+    if (value === undefined) continue;
+
+    if (field === 'genres') {
+      const kept = Array.isArray(value) ? value.filter((g): g is string => typeof g === 'string' && g.trim() !== '') : [];
+      if (kept.length === 0) {
+        next.add(field);
+        blanked.push(field);
+        normalized[field] = null;
+      } else {
+        next.delete(field);
+        normalized[field] = kept;
+      }
+      continue;
+    }
+
+    if (value === null || isBlankString(value)) {
+      next.add(field);
+      blanked.push(field);
+      normalized[field] = null;
+    } else {
+      next.delete(field);
+      normalized[field] = value as string;
+    }
+  }
+
+  return { cleared: [...next].sort(), normalized, blanked };
+}

--- a/src/server/utils/parse-phase-history.test.ts
+++ b/src/server/utils/parse-phase-history.test.ts
@@ -37,7 +37,7 @@ describe('parsePhaseHistory', () => {
     const result = parsePhaseHistory('not-json', log, 42);
     expect(result).toEqual([]);
     expect(log.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ jobId: 42, error: expect.any(Object) }),
+      { jobId: 42 },
       expect.stringContaining('Unparseable phaseHistory'),
     );
   });
@@ -47,8 +47,28 @@ describe('parsePhaseHistory', () => {
     const result = parsePhaseHistory('[{"foo":"bar"}]', log, 42);
     expect(result).toEqual([]);
     expect(log.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ jobId: 42, error: expect.any(Object) }),
+      expect.objectContaining({ jobId: 42, issuePaths: expect.any(Array) }),
       expect.stringContaining('Malformed phaseHistory'),
     );
+  });
+
+  // Sibling of #2069 F2: this parser had the identical `JSON.parse` catch →
+  // `serializeError` shape, and both of its warn payloads could reproduce the
+  // persisted column. V8's SyntaxError quotes a window of the offending source, and
+  // a ZodError message renders the `received` values.
+  it('reproduces neither the raw column nor persisted values in either warn payload', () => {
+    const log = createMockLogger();
+
+    parsePhaseHistory('{"phase": leaked-phase-token}', log, 1);
+    expect(JSON.stringify(vi.mocked(log.warn).mock.calls[0]![0])).not.toContain('leaked-phase');
+    expect(vi.mocked(log.warn).mock.calls[0]![0]).toEqual({ jobId: 1 });
+
+    vi.mocked(log.warn).mockClear();
+    parsePhaseHistory('[{"phase":"SENSITIVE_PHASE_VALUE","startedAt":"not-a-number"}]', log, 2);
+    const [payload] = vi.mocked(log.warn).mock.calls[0] as [Record<string, unknown>, string];
+    expect(JSON.stringify(payload)).not.toContain('SENSITIVE_PHASE_VALUE');
+    expect(JSON.stringify(payload)).not.toContain('not-a-number');
+    // Paths stay — they are the diagnostic, and they carry no values (#1404).
+    expect(payload.issuePaths).toEqual(expect.arrayContaining([expect.any(String)]));
   });
 });

--- a/src/server/utils/parse-phase-history.ts
+++ b/src/server/utils/parse-phase-history.ts
@@ -1,11 +1,21 @@
 import type { FastifyBaseLogger } from 'fastify';
 import { phaseHistorySchema, type PhaseHistoryEntry } from '@shared/schemas/import-job.js';
-import { serializeError } from './serialize-error.js';
 
 /**
  * Defensively parse a persisted `phaseHistory` JSON column.
  * On unparseable JSON or shape mismatch, logs a warn and returns `[]` so
  * listing/hydration paths cannot 500 on a malformed row.
+ *
+ * **Neither warn carries the persisted value.** Both arms used to pass the caught
+ * error through `serializeError`, which copies `message`/`stack` and redacts only
+ * URLs — and both of those messages can embed the stored content: V8's
+ * `SyntaxError` quotes a snippet of the offending source
+ * (`JSON.parse('{"a": bad}')` → `Unexpected token 'b', "{"a": bad}" is not valid
+ * JSON`), and a `ZodError` message renders the `received` values. `jobId` plus the
+ * failing issue PATHS are the whole diagnostic need; the row is inspected out of
+ * band. Same rule and same shape as `parseClearedFields` (#2069 AC4) and the
+ * quality-gate reason parser (#1404), which is the precedent for logging Zod paths
+ * without values.
  */
 export function parsePhaseHistory(
   raw: string | null,
@@ -16,13 +26,16 @@ export function parsePhaseHistory(
   let parsedJson: unknown;
   try {
     parsedJson = JSON.parse(raw);
-  } catch (error: unknown) {
-    log.warn({ jobId, error: serializeError(error) }, 'Unparseable phaseHistory JSON; treating as empty');
+  } catch {
+    log.warn({ jobId }, 'Unparseable phaseHistory JSON; treating as empty');
     return [];
   }
   const result = phaseHistorySchema.safeParse(parsedJson);
   if (!result.success) {
-    log.warn({ jobId, error: serializeError(result.error) }, 'Malformed phaseHistory; treating as empty');
+    log.warn(
+      { jobId, issuePaths: result.error.issues.map((i) => i.path.join('.')) },
+      'Malformed phaseHistory; treating as empty',
+    );
     return [];
   }
   return result.data;

--- a/src/shared/schemas/book.ts
+++ b/src/shared/schemas/book.ts
@@ -148,13 +148,39 @@ export const createBookBodySchema = z.object({
   searchImmediately: z.boolean().optional(),
 }).strict();
 
+/**
+ * The nullable scalar fields an operator can explicitly CLEAR through
+ * `PUT /api/books/:id`, and therefore the only names that may appear in
+ * `books.user_cleared_fields` (#2069).
+ *
+ * `seriesPosition` is deliberately absent: it is never tombstoned independently,
+ * the `seriesName` tombstone suppresses the pair (#1927 AC10's single-source pair
+ * rule). `coverUrl` (the #1634 Audnexus overwrite carve-out), `title`/`authors`
+ * (not clearable — `.min(1)` below), `narrators` (rewritten unconditionally by
+ * `refreshScanBook`), and `duration` (not clearable through the modal) are out of
+ * scope.
+ *
+ * SQLite text columns emit no DB CHECK, so `clearedFieldsSchema.parse` at the
+ * service write boundary is the ONLY enforcement — mirroring the
+ * `productionTypeSchema.parse` precedent in `BookService.update`.
+ */
+export const CLEARABLE_BOOK_FIELDS = ['seriesName', 'subtitle', 'description', 'publisher', 'publishedDate', 'genres'] as const;
+export const clearableBookFieldSchema = z.enum(CLEARABLE_BOOK_FIELDS);
+export type ClearableBookField = z.infer<typeof clearableBookFieldSchema>;
+export const clearedFieldsSchema = z.array(clearableBookFieldSchema);
+
 export const updateBookBodySchema = z.object({
   title: z.string().trim().min(1, 'Title cannot be empty').optional(),
   authors: z.array(bookAuthorInputSchema).min(1).optional(),
   narrators: z.array(z.string()).optional(),
-  // `.nullable()` so an emptied field can send `null` to CLEAR the stored column
-  // (the detail page then falls back to the merged provider value). `undefined`/
-  // omitted = unchanged, `null` = clear, value = set — matching `seriesName` below.
+  // `.nullable()` so an emptied field can send `null` to CLEAR the stored column.
+  // `undefined`/omitted = unchanged, `null` = clear, value = set — matching
+  // `seriesName` below. On the operator-facing route the clear is ALSO recorded as
+  // a tombstone in `books.user_cleared_fields` (#2069), so the detail header and
+  // fill-empty enrichment stop resurrecting the provider value; the field stays
+  // cleared until the operator sets a new one. Books that were never given a value
+  // keep the provider fallback. The request shape is unchanged — the tombstone is
+  // DERIVED from these values, there is no client-supplied key for it.
   subtitle: z.string().nullable().optional(),
   description: z.string().nullable().optional(),
   publisher: z.string().nullable().optional(),


### PR DESCRIPTION
7 commits since v0.12.0.

## Merge quality (the naked-m4b fixes)
- #2068 Stream-copy compatible sets; explicit `-b:a` on every encode — keepOriginalBitrate now means what it says, and ffmpeg's implicit default bitrate is unreachable
- #2078 Merges preserve source tags + cover art (Layer 1) and re-tag the merged output through TaggingService per the operator's Tag Embedding settings (Layer 2); post-merge `books.size` restat + connector refresh

## Metadata intent
- #2069 Explicit metadata clears persist as user intent (cleared-fields tombstones) — display fallbacks and fill-empty enrichment no longer resurrect deliberately removed values

## Test infra
- #2033 hydrate-clobber race closed: two-stage settingsHydrated barrier (fixture-distinct field observable in the DOM) + header contract rewrite
- Drift sentinel binding ci.yml's Playwright image tag to the installed @playwright/test version
- Windows-only argv test failures fixed (fixture-map POSIX re-keying, verbatim donor-path assertions)

Post-merge assessment of #2079 ran clean (19/19 ACs); its one surviving finding is filed as #2083 (mp3 donor-chapters, m4b path unaffected) and does not ship in this tag's default configuration.